### PR TITLE
Added Accept header to all requests

### DIFF
--- a/src/Clients/Asset.cs
+++ b/src/Clients/Asset.cs
@@ -102,7 +102,7 @@ namespace MTConnect.Clients
         {
             // Create HTTP Client and Request Data
             var client = new RestClient(CreateUri());
-            var request = new RestRequest(Method.GET);
+            var request = CreateRequest(); //new RestRequest(Method.GET);
             IRestResponse response = client.Execute(request);
             return ProcessResponse(response);
         }
@@ -114,7 +114,7 @@ namespace MTConnect.Clients
         {
             // Create HTTP Client and Request Data
             var client = new RestClient(CreateUri());
-            var request = new RestRequest(Method.GET);
+            var request = CreateRequest(); //new RestRequest(Method.GET);
             client.ExecuteAsync(request, AsyncCallback);
         }
 
@@ -133,6 +133,9 @@ namespace MTConnect.Clients
         private RestRequest CreateRequest()
         {
             var request = new RestRequest(Method.GET);
+
+            //add header to accept xml response (v1.5 beta agent will return json if not specified)
+            request.AddHeader("Accept", "application/xml");
 
             // Add 'Type' parameter
             if (!string.IsNullOrEmpty(Type)) request.AddQueryParameter("type", Type);

--- a/src/Clients/Current.cs
+++ b/src/Clients/Current.cs
@@ -186,6 +186,9 @@ namespace MTConnect.Clients
         {
             var request = new RestRequest(Method.GET);
 
+            //add header to accept xml response (v1.5 beta agent will return json if not specified)
+            request.AddHeader("Accept", "application/xml");
+
             // Add 'At' parameter
             if (At > -1) request.AddQueryParameter("at", At.ToString());
 

--- a/src/Clients/Probe.cs
+++ b/src/Clients/Probe.cs
@@ -83,6 +83,9 @@ namespace MTConnect.Clients
             client.Timeout = Timeout;
             client.ReadWriteTimeout = Timeout;
             var request = new RestRequest(Method.GET);
+            //add header to accept xml response (v1.5 beta agent will return json if not specified)
+            request.AddHeader("Accept", "application/xml");
+
             IRestResponse response = client.Execute(request);
             return ProcessResponse(response);
         }
@@ -95,6 +98,10 @@ namespace MTConnect.Clients
             // Create HTTP Client and Request Data
             var client = new RestClient(CreateUri());
             var request = new RestRequest(Method.GET);
+
+            //add header to accept xml response (v1.5 beta agent will return json if not specified)
+            request.AddHeader("Accept", "application/xml");
+
             client.ExecuteAsync(request, AsyncCallback);
         }
 

--- a/src/Clients/Sample.cs
+++ b/src/Clients/Sample.cs
@@ -226,6 +226,9 @@ namespace MTConnect.Clients
         {
             var request = new RestRequest(Method.GET);
 
+            //add header to accept xml response (v1.5 beta agent will return json if not specified)
+            request.AddHeader("Accept", "application/xml");
+
             // Add 'From' parameter
             if (From > 0) request.AddQueryParameter("from", From.ToString());
 

--- a/src/Clients/Stream.cs
+++ b/src/Clients/Stream.cs
@@ -76,6 +76,7 @@ namespace MTConnect.Clients
                 if (!stop.WaitOne(0, true))
                 {
                     var request = (HttpWebRequest)WebRequest.Create(Url);
+                    request.Headers.Add(HttpRequestHeader.Accept, "application/xml");
                     request.Timeout = ConnectionTimeout;
                     request.ReadWriteTimeout = IOTimeout;
                     using (response = (HttpWebResponse)request.GetResponse())


### PR DESCRIPTION
While I was testing the library on address http://mtconnect.mazakcorp.com:5612, I received a null document.
Upon debugging, I found the response was in json format instead xml.

Adding the accept header to receive a xml response resolved the issue.