### PR TITLE
Assembly.GetTypes can throw ReflectionTypeLoadException

### DIFF
--- a/src/MTConnect.NET-Common/AssemblyExtensions.cs
+++ b/src/MTConnect.NET-Common/AssemblyExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace MTConnect
+{
+    public static class AssemblyExtensions
+    {
+        /// <summary>
+        /// Get the types within the assembly that match the predicate.
+        /// <para>for example, to get all types within a namespace</para>
+        /// <para>    typeof(SomeClassInAssemblyYouWant).Assembly.GetMatchingTypesInAssembly(item => "MyNamespace".Equals(item.Namespace))</para>
+        /// </summary>
+        /// <param name="assembly">The assembly to search</param>
+        /// <param name="predicate">The predicate query to match against</param>
+        /// <returns>The collection of types within the assembly that match the predicate</returns>
+        /// <remarks>
+        /// Code taken from https://stackoverflow.com/questions/7889228/how-to-prevent-reflectiontypeloadexception-when-calling-assembly-gettypes
+        /// </remarks>
+        public static IReadOnlyCollection<Type> GetMatchingTypesInAssembly(
+            this Assembly assembly, 
+            Predicate<Type> predicate)
+        {
+            var types = new List<Type>();
+            try
+            {
+                types = assembly.GetTypes().Where(i => predicate(i) && i.Assembly == assembly).ToList();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                foreach (var theType in ex.Types)
+                {
+                    try
+                    {
+                        if (theType != null && predicate(theType) && theType.Assembly == assembly)
+                            types.Add(theType);
+                    }
+                    // This exception list is not exhaustive, modify to suit any reasons
+                    // you find for failure to parse a single assembly
+                    catch (BadImageFormatException)
+                    {
+                        // Type not in this assembly - reference to elsewhere ignored
+                    }
+                }
+            }
+            return types;
+        }
+    }
+}

--- a/src/MTConnect.NET-Common/Assets/Asset.cs
+++ b/src/MTConnect.NET-Common/Assets/Asset.cs
@@ -112,9 +112,11 @@ namespace MTConnect.Assets
             var assemblies = Assemblies.Get();
             if (!assemblies.IsNullOrEmpty())
             {
-                var allTypes = assemblies.SelectMany(x => x.GetTypes());
+                var types = assemblies
+                    .SelectMany(
+                        x => x.GetMatchingTypesInAssembly(
+                            t => typeof(IAsset).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract));
 
-                var types = allTypes.Where(x => typeof(IAsset).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract);
                 if (!types.IsNullOrEmpty())
                 {
                     var objs = new Dictionary<string, Type>();

--- a/src/MTConnect.NET-Common/Devices/Component.cs
+++ b/src/MTConnect.NET-Common/Devices/Component.cs
@@ -350,9 +350,11 @@ namespace MTConnect.Devices
             var assemblies = Assemblies.Get();
             if (!assemblies.IsNullOrEmpty())
             {
-                var allTypes = assemblies.SelectMany(x => x.GetTypes());
+                var types = assemblies
+                    .SelectMany(
+                        x => x.GetMatchingTypesInAssembly(
+                            t => typeof(Component).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract));
 
-                var types = allTypes.Where(x => typeof(Component).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract);
                 if (!types.IsNullOrEmpty())
                 {
                     var objs = new Dictionary<string, Type>();

--- a/src/MTConnect.NET-Common/Devices/Composition.cs
+++ b/src/MTConnect.NET-Common/Devices/Composition.cs
@@ -209,9 +209,11 @@ namespace MTConnect.Devices
             var assemblies = Assemblies.Get();
             if (!assemblies.IsNullOrEmpty())
             {
-                var allTypes = assemblies.SelectMany(x => x.GetTypes());
+                var types = assemblies
+                    .SelectMany(
+                        x => x.GetMatchingTypesInAssembly(
+                            t => typeof(Composition).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract));
 
-                var types = allTypes.Where(x => typeof(Composition).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract);
                 if (!types.IsNullOrEmpty())
                 {
                     var objs = new Dictionary<string, Type>();

--- a/src/MTConnect.NET-Common/Devices/DataItem.cs
+++ b/src/MTConnect.NET-Common/Devices/DataItem.cs
@@ -388,9 +388,11 @@ namespace MTConnect.Devices
             var assemblies = Assemblies.Get();
             if (!assemblies.IsNullOrEmpty())
             {
-                var allTypes = assemblies.SelectMany(x => x.GetTypes());
+                var types = assemblies
+                    .SelectMany(
+                        x => x.GetMatchingTypesInAssembly(
+                            t => typeof(DataItem).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract));
 
-                var types = allTypes.Where(x => typeof(DataItem).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract);
                 if (!types.IsNullOrEmpty())
                 {
                     var objs = new Dictionary<string, Type>();

--- a/src/MTConnect.NET-Common/Formatters/ResponseDocumentFormatter.cs
+++ b/src/MTConnect.NET-Common/Formatters/ResponseDocumentFormatter.cs
@@ -191,10 +191,12 @@ namespace MTConnect.Formatters
             var assemblies = Assemblies.Get();
             if (!assemblies.IsNullOrEmpty())
             {
-                var allTypes = assemblies.SelectMany(x => x.GetTypes());
-
                 // Get IResponseDocumentFormatter Types
-                var types = allTypes.Where(x => typeof(IResponseDocumentFormatter).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract);
+                var types = assemblies
+                    .SelectMany(
+                        x => x.GetMatchingTypesInAssembly(
+                            t => typeof(IResponseDocumentFormatter).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract));
+
                 if (!types.IsNullOrEmpty())
                 {
                     foreach (var type in types)

--- a/src/MTConnect.NET-Common/Observations/Observation.cs
+++ b/src/MTConnect.NET-Common/Observations/Observation.cs
@@ -793,9 +793,11 @@ namespace MTConnect.Observations
             var assemblies = Assemblies.Get();
             if (!assemblies.IsNullOrEmpty())
             {
-                var allTypes = assemblies.SelectMany(x => x.GetTypes());
+                var types = assemblies
+                    .SelectMany(
+                        x => x.GetMatchingTypesInAssembly(
+                            t => typeof(IObservation).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract));
 
-                var types = allTypes.Where(x => typeof(IObservation).IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract);
                 if (!types.IsNullOrEmpty())
                 {
                     var objs = new Dictionary<string, Type>();


### PR DESCRIPTION
Assembly.GetTypes can throw ReflectionTypeLoadException when the assembly references types from other currently missing assemblies.
In my case it led to Probe failure.
Suggested wrapping extension method handles ReflectionTypeLoadException gracefully.
