### PR TITLE
Parsing two consecutive conditions failed in streams

### DIFF
--- a/src/MTConnect.NET-XML/Streams/XmlStreamsResponseDocument.cs
+++ b/src/MTConnect.NET-XML/Streams/XmlStreamsResponseDocument.cs
@@ -171,6 +171,8 @@ namespace MTConnect.Streams.Xml
 
                 if (reader.LocalName != container && reader.NodeType == XmlNodeType.Element)
                 {
+                    // Check if node is empty before moving position
+                    bool isEmptyElement = reader.IsEmptyElement;
                     // Read Observation Properties
                     var observation = ReadObservationProperties(reader, category, dataItemType, representation);
 
@@ -181,7 +183,7 @@ namespace MTConnect.Streams.Xml
                     }
 
                     // Read Content
-                    if (reader.NodeType != XmlNodeType.None)
+                    if (!isEmptyElement && reader.NodeType != XmlNodeType.None)
                     {
                         while (reader.NodeType != XmlNodeType.EndElement &&
                             ((category == DataItemCategory.CONDITION && reader.NodeType == XmlNodeType.Whitespace) ||

--- a/src/MTConnect.NET.sln
+++ b/src/MTConnect.NET.sln
@@ -71,6 +71,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTests", "..\test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MTConnect.NET-SHDR-Tests", "..\tests\MTConnect.NET-SHDR-Tests\MTConnect.NET-SHDR-Tests.csproj", "{83ABB6E9-7931-4C94-B1D8-2EECDA3FAA8F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MTConnect.NET-XML-Tests", "..\tests\MTConnect.NET-XML-Tests\MTConnect.NET-XML-Tests.csproj", "{E93A7C94-0959-4250-B58F-CD9742AA4B66}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -234,6 +236,12 @@ Global
 		{83ABB6E9-7931-4C94-B1D8-2EECDA3FAA8F}.Package|Any CPU.Build.0 = Debug|Any CPU
 		{83ABB6E9-7931-4C94-B1D8-2EECDA3FAA8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{83ABB6E9-7931-4C94-B1D8-2EECDA3FAA8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E93A7C94-0959-4250-B58F-CD9742AA4B66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E93A7C94-0959-4250-B58F-CD9742AA4B66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E93A7C94-0959-4250-B58F-CD9742AA4B66}.Package|Any CPU.ActiveCfg = Debug|Any CPU
+		{E93A7C94-0959-4250-B58F-CD9742AA4B66}.Package|Any CPU.Build.0 = Debug|Any CPU
+		{E93A7C94-0959-4250-B58F-CD9742AA4B66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E93A7C94-0959-4250-B58F-CD9742AA4B66}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -264,6 +272,7 @@ Global
 		{88F4AC84-2CF6-4FB5-81E8-39C8376C7590} = {F3BC3895-4155-4C8D-BAB2-437741AC9B5D}
 		{B566E826-3A52-47FD-BB6D-E4E04C099E39} = {14375E03-6BF8-45E6-B868-D2399368992B}
 		{83ABB6E9-7931-4C94-B1D8-2EECDA3FAA8F} = {14375E03-6BF8-45E6-B868-D2399368992B}
+		{E93A7C94-0959-4250-B58F-CD9742AA4B66} = {14375E03-6BF8-45E6-B868-D2399368992B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CC13D3AD-18BF-4695-AB2A-087EF0885B20}

--- a/tests/MTConnect.NET-XML-Tests/Devices/DeviceLoad.cs
+++ b/tests/MTConnect.NET-XML-Tests/Devices/DeviceLoad.cs
@@ -1,7 +1,7 @@
-using MTConnect.Devices;
-using NUnit.Framework;
 using System;
 using System.IO;
+using MTConnect.Configurations;
+using NUnit.Framework;
 
 namespace MTConnect.Tests.XML.Devices
 {
@@ -21,7 +21,7 @@ namespace MTConnect.Tests.XML.Devices
             var path = Path.Combine(dir, DevicesFilename);
 
             // Read 'devices.xml' file
-            var devices = Device.FromFile(path, DocumentFormat.XML);
+            var devices = DeviceConfiguration.FromFile(path, DocumentFormat.XML);
             if (!devices.IsNullOrEmpty())
             {
                 foreach (var device in devices)
@@ -43,7 +43,7 @@ namespace MTConnect.Tests.XML.Devices
             var dir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, DevicesDirectory);
 
             // Read 'devices.xml' file
-            var devices = Device.FromFiles(dir, DocumentFormat.XML);
+            var devices = DeviceConfiguration.FromFiles(dir, DocumentFormat.XML);
             if (!devices.IsNullOrEmpty())
             {
                 foreach (var device in devices)

--- a/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
+++ b/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DeepEqual" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
@@ -14,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\MTConnect.NET-XML\MTConnect.NET-XML.csproj" />
+    <ProjectReference Include="..\..\src\MTConnect.NET-XML\MTConnect.NET-XML.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MTConnect.NET-XML-Tests/XmlStreamsResponseDocumentTests.cs
+++ b/tests/MTConnect.NET-XML-Tests/XmlStreamsResponseDocumentTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using DeepEqual.Syntax;
+using MTConnect.Observations;
+using MTConnect.Streams.Xml;
+using NUnit.Framework;
+
+namespace MTConnect.Tests.XML
+{
+    public sealed class XmlStreamsResponseDocumentTests
+    {
+        [Test]
+        public void TwoConditionsShouldBeParsed()
+        {
+            var text = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<MTConnectStreams xmlns=""urn:mtconnect.org:MTConnectStreams:2.0"" xmlns:m=""urn:mtconnect.org:MTConnectStreams:2.0"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""urn:mtconnect.org:MTConnectStreams:2.0 /schemas/MTConnectStreams_2.0.xsd"">
+  <Header instanceId=""1663078056"" version=""1.0.0.0"" sender=""ADSKPF3FBP2T"" bufferSize=""131072"" firstSequence=""1"" lastSequence=""222"" nextSequence=""223"" deviceModelChangeTime=""2022-09-13T14:07:36.2828516Z"" creationTime=""2022-09-13T14:07:47.2901070Z"" />
+  <Streams>
+    <DeviceStream name=""Machine"" uuid=""cc17e6f8-61c2-427b-a45f-11a2189ae3a4"">
+      <ComponentStream component=""Controller"" componentId=""cont"" name=""controller"">
+        <Condition>
+          <Fault dataItemId=""comms_cond"" type=""COMMUNICATIONS"" sequence=""221"" timestamp=""2022-09-13T14:07:36.444Z"" />
+          <Normal dataItemId=""comms_cond"" type=""COMMUNICATIONS"" sequence=""222"" timestamp=""2022-09-13T14:07:36.570Z"" />
+        </Condition>
+      </ComponentStream>
+    </DeviceStream>
+  </Streams>
+</MTConnectStreams>";
+
+            var doc = XmlStreamsResponseDocument.FromXml(Encoding.UTF8.GetBytes(text));
+
+            Assert.AreEqual(1, doc.Streams.Count());
+            var stream = doc.Streams.Single();
+            var conditions = stream.Conditions.ToArray();
+            Assert.AreEqual(2, conditions.Length);
+
+            var cond1 = new ConditionObservation()
+            {
+                DataItemId = "comms_cond",
+                Type = "COMMUNICATIONS",
+                Level = ConditionLevel.FAULT,
+                Sequence = 221,
+                Timestamp = new DateTime(2022, 09, 13, 16, 7, 36, DateTimeKind.Local)
+                    .Add(TimeSpan.FromMilliseconds(444))
+            };
+
+            // Overriding default value to pass the test.
+            // Is it a bug, that level not capitalized?
+            cond1.AddValue(ValueKeys.Level, "Fault");
+
+            conditions[0].ShouldDeepEqual(cond1);
+
+            var cond2 = new ConditionObservation()
+            {
+                DataItemId = "comms_cond",
+                Type = "COMMUNICATIONS",
+                Level = ConditionLevel.NORMAL,
+                Sequence = 222,
+                Timestamp = new DateTime(2022, 09, 13, 16, 7, 36, DateTimeKind.Local)
+                    .Add(TimeSpan.FromMilliseconds(570))
+            };
+
+            // Overriding default value to pass the test.
+            // Is it a bug, that level not capitalized?
+            cond2.AddValue(ValueKeys.Level, "Normal");
+
+            conditions[1].ShouldDeepEqual(cond2);
+        }
+    }
+}


### PR DESCRIPTION
Hi Patrick,
Found a problem with two consecutive conditions arriving as part of the stream document. Only the first was successfully parsed.
Conditions as I see them now are by default empty nodes and thus no content parsing should be done.
Could please pay attention to the test I've added? There is a value override that seems strange for me, maybe it is an earlier introduced bug.