### PR TITLE
Endless cycle in a sample stream after cancellation due to timeout

### DIFF
--- a/src/MTConnect.NET-HTTP/Clients/Rest/MTConnectHttpClientStream.cs
+++ b/src/MTConnect.NET-HTTP/Clients/Rest/MTConnectHttpClientStream.cs
@@ -177,7 +177,7 @@ namespace MTConnect.Clients.Rest
                             responseTimer.Start();
                         }
 
-                        while (b > -1)
+                        while (b > -1 && !stop.Token.IsCancellationRequested)
                         {
                             // Look for Start of Http Multipart boundary
                             if (b == Dash && prevByte == Dash) // 45 = UTF-8 '-'


### PR DESCRIPTION
Without that extra !stop.Token.IsCancellationRequested condition my client stream was in an endless loop after cancellation due to timeout.
After adding above mentioned condition cycle was successfully ended and we got into a new "probe -> current -> sample" procedure.