### PR TITLE
Added exception unwinding and logging on MqttRelay module when connec…

### DIFF
--- a/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
+++ b/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
@@ -219,7 +219,7 @@ namespace MTConnect
                         
                         Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error : {ex.Message}");
 
-                        var current = current.InnerException;
+                        var current = ex.InnerException;
 
                         while( current != null )
                         {

--- a/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
+++ b/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
@@ -216,7 +216,20 @@ namespace MTConnect
                     }
                     catch (Exception ex)
                     {
+                        
                         Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error : {ex.Message}");
+
+                        var current = current.InnerException;
+
+                        while( current != null )
+                        {
+                            Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error (InnerException) : {current.Message}");
+                            current = current.InnerException;
+                        }
+
+                        Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error (BaseException) : {ex.GetBaseException().ToString()}");
+
+
                     }
                     finally
                     {

--- a/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
+++ b/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
@@ -214,22 +214,19 @@ namespace MTConnect
                             await Task.Delay(100);
                         }
                     }
-                    catch (Exception ex)
+                    catch (Exception exception)
                     {
-                        
-                        Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error : {ex.Message}");
+                        Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error : {exception.Message}");
 
-                        var current = ex.InnerException;
+                        var innerException = exception.InnerException;
 
-                        while( current != null )
+                        while (innerException != null)
                         {
-                            Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error (InnerException) : {current.Message}");
-                            current = current.InnerException;
+                            Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error (InnerException) : {innerException.Message}");
+                            innerException = innerException.InnerException;
                         }
 
-                        Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error (BaseException) : {ex.GetBaseException().ToString()}");
-
-
+                        Log(MTConnectLogLevel.Warning, $"MQTT Relay Connection Error (BaseException) : {exception.GetBaseException().ToString()}");
                     }
                     finally
                     {


### PR DESCRIPTION
As discussed on #66, I have added unwinding of the exceptions and logging the inner exceptions and the base exception when the connection attempt of MqttRelay throws. Below an example of the output, which corresponds to the problem described in the issue 

```
2024-06-21 03:18:35.4669|WARN|modules.mqtt-relay|MQTT Relay Connection Error : Authentication failed, see inner exception.
2024-06-21 03:18:35.4669|WARN|modules.mqtt-relay|MQTT Relay Connection Error (InnerException) : Authentication failed, see inner exception.
2024-06-21 03:18:35.4669|WARN|modules.mqtt-relay|MQTT Relay Connection Error (InnerException) : SSL Handshake failed with OpenSSL error - SSL_ERROR_SSL.
2024-06-21 03:18:35.4669|WARN|modules.mqtt-relay|MQTT Relay Connection Error (InnerException) : error:14094412:SSL routines:ssl3_read_bytes:sslv3 alert bad certificate
2024-06-21 03:18:35.4669|WARN|modules.mqtt-relay|MQTT Relay Connection Error (BaseException) : Interop+Crypto+OpenSslCryptographicException: error:14094412:SSL routines:ssl3_read_bytes:sslv3 alert bad certificate
```

Maybe this can be converted to a utility function that can be used all around the code, if you find it useful.