### PR TITLE
Add Option to Skip CA Certificate Validation in MTConnect Agent Configuration

### DIFF
--- a/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
+++ b/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
@@ -133,7 +133,7 @@ namespace MTConnect
                                 var certificateAuthorityResults = _configuration.Tls.GetCertificateAuthority();
 
                                 var certificates = new List<X509Certificate2>();
-                                if (certificateAuthorityResults.Certificate != null)
+                                if (certificateAuthorityResults.Certificate != null && _configuration.Tls.OmitCAValidation == false)
                                 {
                                     certificates.Add(certificateAuthorityResults.Certificate);
                                 }

--- a/libraries/MTConnect.NET-MQTT/Clients/MTConnectMqttClient.cs
+++ b/libraries/MTConnect.NET-MQTT/Clients/MTConnectMqttClient.cs
@@ -252,7 +252,7 @@ namespace MTConnect.Clients
                                 var certificateAuthorityResults = _configuration.Tls.GetCertificateAuthority();
 
                                 var certificates = new List<X509Certificate2>();
-                                if (certificateAuthorityResults.Certificate != null)
+                                if (certificateAuthorityResults.Certificate != null && _configuration.Tls.OmitCAValidation == false)
                                 {
                                     certificates.Add(certificateAuthorityResults.Certificate);
                                 }

--- a/libraries/MTConnect.NET-TLS/TlsConfiguration.cs
+++ b/libraries/MTConnect.NET-TLS/TlsConfiguration.cs
@@ -18,6 +18,8 @@ namespace MTConnect.Tls
         [JsonPropertyName("verifyClientCertificate")]
         public bool VerifyClientCertificate { get; set; }
 
+        [JsonPropertyName("omitCAValidation")]
+        public bool OmitCAValidation { get; set; }
 
 
         public CertificateLoadResult GetCertificate()


### PR DESCRIPTION
In response to issues raised in [#66](https://github.com/TrakHound/MTConnect.NET/issues/66) and [#57](https://github.com/TrakHound/MTConnect.NET/issues/57), this change addresses scenarios where strict CA certificate validation may not be needed. Users interacting with non-public or self-signed brokers encountered problems due to the default requirement for CA validation. Allowing the option to skip this validation enhances flexibility for users who have controlled environments and do not need this level of security enforcement.