### PR TITLE
Shdr events are not sent to agent from ShdrAdapter

### DIFF
--- a/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs
+++ b/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs
@@ -288,6 +288,8 @@ namespace MTConnect.Adapters
         {
             _stop = new CancellationTokenSource();
 
+            _adapter.Start();
+
             // Start Agent Connection Listener
             _connectionListener.Start(_stop.Token);
 
@@ -302,6 +304,7 @@ namespace MTConnect.Adapters
         {
             if (_stop != null) _stop.Cancel();
             _connectionListener.Stop();
+            _adapter.Stop();
 
             // Call Overridable Method
             OnStop();


### PR DESCRIPTION
Hi Patrick,

Long time since my last PR.
Amazing progress!

For some reason ShdrAdapter's Start method did not start its internal IMTConnectAdapter _adapter.
As a result elements fed through it, were not sent to the agent.

Best regards,
Sergii Gulyk.