### PR TITLE
Sample stream handler continues to run ignoring http server stop.

### DIFF
--- a/libraries/MTConnect.NET-HTTP/Ceen/Common/Interfaces.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Common/Interfaces.cs
@@ -418,13 +418,14 @@ namespace Ceen
     /// Interface for implementing a routing provider
     /// </summary>
     internal interface IRouter
-	{
-		/// <summary>
-		/// Process the request for the specified context.
-		/// </summary>
-		/// <param name="context">The context to use.</param>
-		/// <returns>A value indicating if the request is now processed</returns>
-		Task<bool> Process(IHttpContext context);
+    {
+        /// <summary>
+        /// Process the request for the specified context.
+        /// </summary>
+        /// <param name="context">The context to use.</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        /// <returns>A value indicating if the request is now processed</returns>
+        Task<bool> Process(IHttpContext context, CancellationToken cancellationToken);
 	}
 
     /// <summary>
@@ -459,8 +460,9 @@ namespace Ceen
 		/// Process the request for the specified context.
 		/// </summary>
 		/// <param name="context">The context to use.</param>
+		/// <param name="cancellationToken">The token indicating to stop handling.</param>
 		/// <returns>A value indicating if the request is now processed</returns>
-		Task<bool> HandleAsync(IHttpContext context);
+		Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken);
 	}
 
     /// <summary>

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/CORSHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/CORSHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Ceen;
@@ -61,8 +62,9 @@ namespace Ceen.Httpd.Handler
         /// Handles OPTIONS requests
         /// </summary>
         /// <param name="context">The request context</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
         /// <returns>A value indicating if the request was handled</returns>
-        public Task<bool> HandleAsync(IHttpContext context)
+        public Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
         {
             var preflight = context.Request.Method == "OPTIONS";
             var origin = context.Request.Headers["Origin"];

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/ClearRequestStateHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/ClearRequestStateHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ceen.Httpd.Handler
@@ -8,12 +9,13 @@ namespace Ceen.Httpd.Handler
     /// </summary>
     internal class ClearRequestStateHandler : IHttpModule
 	{
-		/// <summary>
-		/// Handles the request.
-		/// </summary>
-		/// <returns>The awaitable task.</returns>
-		/// <param name="context">The http context.</param>
-		public Task<bool> HandleAsync(IHttpContext context)
+        /// <summary>
+        /// Handles the request.
+        /// </summary>
+        /// <returns>The awaitable task.</returns>
+        /// <param name="context">The http context.</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        public Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
 		{
 			context.Request.RequestState.Clear();
 			return Task.FromResult(false);

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/FileHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/FileHandler.cs
@@ -692,7 +692,8 @@ namespace Ceen.Httpd.Handler
         /// </summary>
         /// <returns>The awaitable task.</returns>
         /// <param name="context">The http context.</param>
-        public virtual async Task<bool> HandleAsync(IHttpContext context)
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        public virtual async Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
         {
             if (!string.Equals(context.Request.Method, "GET", StringComparison.Ordinal) && !string.Equals(context.Request.Method, "HEAD", StringComparison.Ordinal))
             {

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/FileMirrorHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/FileMirrorHandler.cs
@@ -113,7 +113,8 @@ namespace Ceen.Httpd.Handler
         /// </summary>
         /// <returns>An awaitable task.</returns>
         /// <param name="context">The request context.</param>
-        public override async Task<bool> HandleAsync(IHttpContext context)
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        public override async Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
         {
             if (!string.Equals(context.Request.Method, "GET", StringComparison.Ordinal) && !string.Equals(context.Request.Method, "HEAD", StringComparison.Ordinal))
             {
@@ -183,7 +184,7 @@ namespace Ceen.Httpd.Handler
                     // We hit a race here where the file is downloaded and exists,
                     // but the active tables have been cleared just after we checked the filecache
                     if (m_filecache.TryGetValue(localpath, out var v))
-                        return await base.HandleAsync(context);
+                        return await base.HandleAsync(context, cancellationToken);
                 }
 
                 // Download if we are the first process requesting it
@@ -195,7 +196,7 @@ namespace Ceen.Httpd.Handler
 
             }
 
-            return await base.HandleAsync(context);
+            return await base.HandleAsync(context, cancellationToken);
         }
         /// <summary>
         /// The predicate method for expiring a 404 entry

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/FunctionHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/FunctionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ceen.Httpd.Handler
@@ -22,14 +23,15 @@ namespace Ceen.Httpd.Handler
 			m_handler = handler;			
 		}
 
-		#region IHttpModule implementation
+        #region IHttpModule implementation
 
-		/// <summary>
-		/// Handles the operation asynchronously.
-		/// </summary>
-		/// <returns>The awaitable task.</returns>
-		/// <param name="context">The request context.</param>
-		public Task<bool> HandleAsync(IHttpContext context)
+        /// <summary>
+        /// Handles the operation asynchronously.
+        /// </summary>
+        /// <returns>The awaitable task.</returns>
+        /// <param name="context">The request context.</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        public Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
 		{
 			return m_handler(context);
 		}

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/RedirectHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/RedirectHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ceen.Httpd.Handler
@@ -39,12 +40,13 @@ namespace Ceen.Httpd.Handler
 		/// <param name="target">The redirect target url.</param>
 		public RedirectHandler(string target) { RedirectTarget = target; }
 
-		/// <summary>
-		/// Handles the request by sending a redirect
-		/// </summary>
-		/// <returns>The awaitable task.</returns>
-		/// <param name="context">The http context.</param>
-		public Task<bool> HandleAsync(IHttpContext context)
+        /// <summary>
+        /// Handles the request by sending a redirect
+        /// </summary>
+        /// <returns>The awaitable task.</returns>
+        /// <param name="context">The http context.</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        public Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
 		{
 			if (InternalRedirect)
 			{

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/SessionHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/SessionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ceen.Httpd.Handler
@@ -32,12 +33,13 @@ namespace Ceen.Httpd.Handler
         /// </summary>
         public string SessionCookieSameSite { get; set; } = "Strict";
 
-		/// <summary>
-		/// Handles the request
-		/// </summary>
-		/// <returns>The awaitable task.</returns>
-		/// <param name="context">The requests context.</param>
-		public async Task<bool> HandleAsync(IHttpContext context)
+        /// <summary>
+        /// Handles the request
+        /// </summary>
+        /// <returns>The awaitable task.</returns>
+        /// <param name="context">The requests context.</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        public async Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
 		{
 			if (context.Session != null)
 				return false;

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/SimpleProxyHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/SimpleProxyHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Ceen;
 
@@ -47,8 +48,9 @@ namespace Ceen.Httpd.Handler
         /// Handles a proxy request
         /// </summary>
         /// <param name="context">The request content</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
         /// <returns><c>true</c> if the request was handled; <c>false</c> otherwise</returns>
-        public async Task<bool> HandleAsync(IHttpContext context)
+        public async Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
         {
             var targeturl = RewriteUrl(context);
             if (targeturl == null)

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/StaticHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/StaticHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ceen.Httpd.Handler
@@ -28,7 +29,8 @@ namespace Ceen.Httpd.Handler
         /// </summary>
         /// <returns>The awaitable task.</returns>
         /// <param name="context">The http context.</param>
-        public Task<bool> HandleAsync(IHttpContext context)
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        public Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
         {
             context.Response.StatusCode = StatusCode;
             context.Response.StatusMessage = StatusMessage;

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/HttpServer.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/HttpServer.cs
@@ -540,7 +540,12 @@ namespace Ceen.Httpd
 		/// <param name="spawner">The method handling the new connection.</param>
 		public static Task ListenToSocketAsync(EndPoint addr, bool usessl, CancellationToken stoptoken, ServerConfig config, Action<Socket, EndPoint, string> spawner)
 		{
-			return ListenToSocketInternalAsync(addr, usessl, stoptoken, config, (client, remoteendpoint, logid, controller) => spawner(client, remoteendpoint, logid));
+			return ListenToSocketInternalAsync(
+                addr, 
+                usessl, 
+                stoptoken, 
+                config, 
+                (client, remoteendpoint, logid, controller) => spawner(client, remoteendpoint, logid));
 		}
 
         /// <summary>
@@ -626,7 +631,12 @@ namespace Ceen.Httpd
         /// <param name="stoptoken">The stoptoken.</param>
         /// <param name="config">The server configuration</param>
         /// <param name="spawner">The method handling the new connection.</param>
-		private static async Task ListenToSocketInternalAsync(EndPoint addr, bool usessl, CancellationToken stoptoken, ServerConfig config, Action<Socket, EndPoint, string, RunnerControl> spawner)
+		private static async Task ListenToSocketInternalAsync(
+            EndPoint addr, 
+            bool usessl, 
+            CancellationToken stoptoken, 
+            ServerConfig config, 
+            Action<Socket, EndPoint, string, RunnerControl> spawner)
         {
             var rc = new RunnerControl(stoptoken, usessl, config);
             var socket = SocketUtil.CreateAndBindSocket(addr, config.SocketBacklog);
@@ -825,7 +835,11 @@ namespace Ceen.Httpd
 		/// <param name="usessl">A flag indicating if this instance should use SSL</param>
 		/// <param name="config">The server configuration</param>
 		/// <param name="stoptoken">The stoptoken.</param>
-		public static Task ListenAsync(EndPoint addr, bool usessl, ServerConfig config, CancellationToken stoptoken = default(CancellationToken))
+		public static Task ListenAsync(
+            EndPoint addr, 
+            bool usessl, 
+            ServerConfig config,
+            CancellationToken stoptoken = default(CancellationToken))
 		{
 			if (usessl && (config.SSLCertificate as X509Certificate2 == null || !(config.SSLCertificate as X509Certificate2).HasPrivateKey))
 				throw new Exception("Certificate does not have a private key and cannot be used for signing");
@@ -833,7 +847,12 @@ namespace Ceen.Httpd
 			if (config.Storage == null)
 				config.Storage = new MemoryStorageCreator();
 
-			return ListenToSocketInternalAsync(addr, usessl, stoptoken, config, RunClient);
+			return ListenToSocketInternalAsync(
+                addr, 
+                usessl, 
+                stoptoken, 
+                config, 
+                RunClient);
 		}
 
 		/// <summary>
@@ -1052,7 +1071,7 @@ namespace Ceen.Httpd
                                     if (target != null)
                                         cur.Path = target;
 
-                                    if (!await config.Router.Process(context))
+                                    if (!await config.Router.Process(context, controller.StopToken))
                                         throw new HttpException(Ceen.HttpStatusCode.NotFound);
                                 }
                                 while (resp.IsRedirectingInternally);

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Router.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Router.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Threading;
 
 namespace Ceen.Httpd
 {
@@ -100,12 +101,13 @@ namespace Ceen.Httpd
 			Rules.Add(new KeyValuePair<Regex, IHttpModule>(route, handler));
 		}
 
-		/// <summary>
-		/// Process the specified request.
-		/// </summary>
-		/// <param name="context">The http context.</param>
-		/// <returns><c>True</c> if the processing was handled, false otherwise</returns>
-		public async Task<bool> Process(IHttpContext context)
+        /// <summary>
+        /// Process the specified request.
+        /// </summary>
+        /// <param name="context">The http context.</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        /// <returns><c>True</c> if the processing was handled, false otherwise</returns>
+        public async Task<bool> Process(IHttpContext context, CancellationToken cancellationToken)
 		{
 			foreach (var rule in Rules)
 			{
@@ -118,7 +120,7 @@ namespace Ceen.Httpd
 
 				context.Request.RequireHandler(rule.Value.GetType().GetCustomAttributes(typeof(RequireHandlerAttribute), true).OfType<RequireHandlerAttribute>());
 
-				if (await rule.Value.HandleAsync(context))
+				if (await rule.Value.HandleAsync(context, cancellationToken))
 					return true;
 
 				context.Request.PushHandlerOnStack(rule.Value);

--- a/libraries/MTConnect.NET-HTTP/Ceen/Mvc/ControllerRouter.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Mvc/ControllerRouter.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Text.Json;
+using System.Threading;
 
 namespace Ceen
 {
@@ -718,21 +719,23 @@ namespace Ceen.Mvc
 			return merged;
 		}
 
-		/// <summary>
-		/// Handles a request
-		/// </summary>
-		/// <returns>The awaitable task.</returns>
-		/// <param name="context">The exexcution context.</param>
-		public Task<bool> HandleAsync(IHttpContext context)
+        /// <summary>
+        /// Handles a request
+        /// </summary>
+        /// <returns>The awaitable task.</returns>
+        /// <param name="context">The exexcution context.</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        public Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
 		{
-			return Process(context);
+			return Process(context, cancellationToken);
 		}
 
-		/// <summary>
-		/// Attempts to route the request to a controller instance.
-		/// </summary>
-		/// <param name="context">The exexcution context.</param>
-		public async Task<bool> Process(IHttpContext context)
+        /// <summary>
+        /// Attempts to route the request to a controller instance.
+        /// </summary>
+        /// <param name="context">The exexcution context.</param>
+        /// <param name="cancellationToken">The token indicating to stop handling.</param>
+        public async Task<bool> Process(IHttpContext context, CancellationToken cancellationToken)
 		{
 			var anymatches = false;
 			var test = m_routeparser

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectAssetResponseHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectAssetResponseHandler.cs
@@ -8,6 +8,7 @@ using MTConnect.Http;
 using MTConnect.Servers.Http;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MTConnect.Servers
@@ -17,7 +18,7 @@ namespace MTConnect.Servers
         public MTConnectAssetResponseHandler(IHttpServerConfiguration serverConfiguration, IMTConnectAgentBroker mtconnectAgent) : base(serverConfiguration, mtconnectAgent) { }
 
 
-        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context)
+        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context, CancellationToken cancellationToken)
         {
             var httpRequest = context.Request;
             var httpResponse = context.Response;

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectAssetsResponseHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectAssetsResponseHandler.cs
@@ -8,6 +8,7 @@ using MTConnect.Http;
 using MTConnect.Servers.Http;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MTConnect.Servers
@@ -17,7 +18,7 @@ namespace MTConnect.Servers
         public MTConnectAssetsResponseHandler(IHttpServerConfiguration serverConfiguration, IMTConnectAgentBroker mtconnectAgent) : base(serverConfiguration, mtconnectAgent) { }
 
 
-        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context)
+        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context, CancellationToken cancellationToken)
         {
             var httpRequest = context.Request;
             var httpResponse = context.Response;

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectCurrentResponseHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectCurrentResponseHandler.cs
@@ -7,6 +7,7 @@ using MTConnect.Configurations;
 using MTConnect.Http;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MTConnect.Servers.Http
@@ -20,7 +21,7 @@ namespace MTConnect.Servers.Http
         public MTConnectCurrentResponseHandler(IHttpServerConfiguration serverConfiguration, IMTConnectAgentBroker mtconnectAgent) : base(serverConfiguration, mtconnectAgent) { }
 
 
-        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context)
+        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context, CancellationToken cancellationToken)
         {
             var httpRequest = context.Request;
             var httpResponse = context.Response;

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpResponseHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpResponseHandler.cs
@@ -12,6 +12,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MTConnect.Servers.Http
@@ -52,7 +53,7 @@ namespace MTConnect.Servers.Http
         }
 
 
-        public async Task<bool> HandleAsync(IHttpContext context)
+        public async Task<bool> HandleAsync(IHttpContext context, CancellationToken cancellationToken)
         {
             try
             {
@@ -62,7 +63,7 @@ namespace MTConnect.Servers.Http
                 var acceptEncodings = GetRequestHeaderValues(context.Request, HttpHeaders.AcceptEncoding);
                 acceptEncodings = ProcessAcceptEncodings(acceptEncodings);
 
-                var mtconnectResponse = await OnRequestReceived(context);
+                var mtconnectResponse = await OnRequestReceived(context, cancellationToken);
                 mtconnectResponse.WriteDuration = await WriteResponse(mtconnectResponse, context.Response, acceptEncodings);
 
                 ResponseSent?.Invoke(this, mtconnectResponse);
@@ -88,7 +89,7 @@ namespace MTConnect.Servers.Http
             return false;
         }
 
-        protected async virtual Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context) { return new MTConnectHttpResponse(); }
+        protected async virtual Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context, CancellationToken cancellationToken) { return new MTConnectHttpResponse(); }
 
 
 

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs
@@ -178,7 +178,11 @@ namespace MTConnect.Servers.Http
 
                             if (ServerStarted != null) ServerStarted.Invoke(this, endpointId);
 
-                            await HttpServer.ListenAsync(endpoint, useSsl, config, cancellationToken);
+                            await HttpServer.ListenAsync(
+                                endpoint, 
+                                useSsl, 
+                                config, 
+                                cancellationToken);
                         }
                         catch (Exception ex)
                         {
@@ -318,7 +322,7 @@ namespace MTConnect.Servers.Http
                         var device = _mtconnectAgent.GetDevice(deviceKey);
                         if (device != null)
                         {
-                            await handler.HandleAsync(context);
+                            await handler.HandleAsync(context, CancellationToken.None);
 
                             return true;
                         }
@@ -338,7 +342,7 @@ namespace MTConnect.Servers.Http
             {
                 if (httpRequest.Method == HttpMethod.Put.Method)
                 {
-                    await handler.HandleAsync(context);
+                    await handler.HandleAsync(context, CancellationToken.None);
 
                     return true;
                 }
@@ -356,7 +360,7 @@ namespace MTConnect.Servers.Http
             {
                 if (httpRequest.Method == HttpMethod.Post.Method)
                 {
-                    await handler.HandleAsync(context);
+                    await handler.HandleAsync(context, CancellationToken.None);
 
                     return true;
                 }

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServerStream.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServerStream.cs
@@ -119,9 +119,10 @@ namespace MTConnect.Servers.Http
             _isConnected = false;
         }
 
-        public void RunSample()
+        public void RunSample(CancellationToken cancellationToken)
         {
             _stop = new CancellationTokenSource();
+            cancellationToken.Register(() => { Stop(); });
             _currentOnly = false;
 
             Worker();

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectPostResponseHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectPostResponseHandler.cs
@@ -8,6 +8,7 @@ using MTConnect.Errors;
 using MTConnect.Servers.Http;
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MTConnect.Servers
@@ -20,7 +21,7 @@ namespace MTConnect.Servers
         public MTConnectPostResponseHandler(IHttpServerConfiguration serverConfiguration, IMTConnectAgentBroker mtconnectAgent) : base(serverConfiguration, mtconnectAgent) { }
 
 
-        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context)
+        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context, CancellationToken cancellationToken)
         {
             var response = new MTConnectHttpResponse();
 

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectProbeResponseHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectProbeResponseHandler.cs
@@ -7,6 +7,7 @@ using MTConnect.Configurations;
 using MTConnect.Http;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MTConnect.Servers.Http
@@ -16,7 +17,7 @@ namespace MTConnect.Servers.Http
         public MTConnectProbeResponseHandler(IHttpServerConfiguration serverConfiguration, IMTConnectAgentBroker mtconnectAgent) : base(serverConfiguration, mtconnectAgent) { }
 
 
-        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context)
+        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context, CancellationToken cancellationToken)
         {
             var httpRequest = context.Request;
             var httpResponse = context.Response;

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectPutResponseHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectPutResponseHandler.cs
@@ -9,6 +9,7 @@ using MTConnect.Servers.Http;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MTConnect.Servers
@@ -21,7 +22,7 @@ namespace MTConnect.Servers
         public MTConnectPutResponseHandler(IHttpServerConfiguration serverConfiguration, IMTConnectAgentBroker mtconnectAgent) : base(serverConfiguration, mtconnectAgent) { }
 
 
-        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context)
+        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context, CancellationToken cancellationToken)
         {
             var response = new MTConnectHttpResponse();
 

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectSampleResponseHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectSampleResponseHandler.cs
@@ -8,6 +8,7 @@ using MTConnect.Http;
 using MTConnect.Servers.Http;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MTConnect.Servers
@@ -21,7 +22,7 @@ namespace MTConnect.Servers
         public MTConnectSampleResponseHandler(IHttpServerConfiguration serverConfiguration, IMTConnectAgentBroker mtconnectAgent) : base(serverConfiguration, mtconnectAgent) { }
 
 
-        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context)
+        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context, CancellationToken cancellationToken)
         {
             var httpRequest = context.Request;
             var httpResponse = context.Response;
@@ -127,7 +128,7 @@ namespace MTConnect.Servers
                             sampleStream.DocumentReceived += async (s, args) => await WriteFromStream(sampleStream, responseStream, args);
 
                             // Run the MTConnectHttpStream
-                            sampleStream.RunSample();
+                            sampleStream.RunSample(cancellationToken);
                         }
                     }
                     catch { }

--- a/libraries/MTConnect.NET-HTTP/Servers/MTConnectStaticResponseHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Servers/MTConnectStaticResponseHandler.cs
@@ -9,6 +9,7 @@ using MTConnect.Servers.Http;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MTConnect.Servers
@@ -21,7 +22,7 @@ namespace MTConnect.Servers
         public MTConnectStaticResponseHandler(IHttpServerConfiguration serverConfiguration, IMTConnectAgentBroker mtconnectAgent) : base(serverConfiguration, mtconnectAgent) { }
 
 
-        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context)
+        protected async override Task<MTConnectHttpResponse> OnRequestReceived(IHttpContext context, CancellationToken cancellationToken)
         {
             var response = new MTConnectHttpResponse();
 


### PR DESCRIPTION
Hi Patrick 

Sample stream handler continues to run ignoring http server stop.
From now, the stopping of the http server will break long running sample stream handler.

I have added a cancellation token to RunSample and if it is cancelled, internal _stop token is cancelled. Have stolen idea from CreateSample :)