### PR TITLE
TaskCompletionSource may hang an application when used with async/await.

### DIFF
--- a/libraries/MTConnect.NET-HTTP/Ceen/Common/AppDomainTask.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Common/AppDomainTask.cs
@@ -11,7 +11,7 @@ namespace Ceen
 		/// <summary>
 		/// A task completion source
 		/// </summary>
-		private TaskCompletionSource<object> m_tcs = new TaskCompletionSource<object>();
+		private TaskCompletionSource<object> m_tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		/// <summary>
 		/// Marks the operation complete

--- a/libraries/MTConnect.NET-HTTP/Ceen/Common/AsyncLock.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Common/AsyncLock.cs
@@ -48,9 +48,7 @@ namespace Ceen
 		{
 			if (token.IsCancellationRequested)
 			{
-				var tcs = new TaskCompletionSource<bool>();
-				tcs.SetCanceled();
-				return tcs.Task;
+				return Task.FromCanceled(token);
 			}
 
 			lock (m_waiters)
@@ -62,7 +60,7 @@ namespace Ceen
 				}
 				else
 				{
-					var waiter = new TaskCompletionSource<bool>();
+					var waiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 					// Make sure the waiter returns asap on cancellation
 					var registrar =

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/FileMirrorHandler.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/Handler/FileMirrorHandler.cs
@@ -175,7 +175,7 @@ namespace Ceen.Httpd.Handler
                     if (!m_activeTransfers.TryGetValue(localpath, out task))
                     {
                         m_activeTransferSizes[localpath] = -1;
-                        m_activeTransfers[localpath] = task = (tcs = new TaskCompletionSource<long>()).Task;
+                        m_activeTransfers[localpath] = task = (tcs = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
                     }
                 }
 
@@ -518,7 +518,7 @@ namespace Ceen.Httpd.Handler
                             // Swap around and notify of the progress
                             var oldsignal = signal;
                             lock (m_statuslock)
-                                m_activeTransfers[localpath] = (signal = new TaskCompletionSource<long>()).Task;
+                                m_activeTransfers[localpath] = (signal = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously)).Task;
                             oldsignal.TrySetResult(pg);
                         }
                     }

--- a/libraries/MTConnect.NET-HTTP/Ceen/Httpd/HttpServer.cs
+++ b/libraries/MTConnect.NET-HTTP/Ceen/Httpd/HttpServer.cs
@@ -280,15 +280,15 @@ namespace Ceen.Httpd
 			/// <summary>
 			/// The task used to signal all requests are stopped
 			/// </summary>
-			private readonly TaskCompletionSource<bool> m_finishedtask = new TaskCompletionSource<bool>();
+			private readonly TaskCompletionSource<bool> m_finishedtask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 			/// <summary>
 			/// The task used to signal all handlers to stop
 			/// </summary>
-			private readonly TaskCompletionSource<bool> m_stoptask = new TaskCompletionSource<bool>();
+			private readonly TaskCompletionSource<bool> m_stoptask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 			/// <summary>
 			/// The task used to signal waiting for handlers to complete before starting new handlers
 			/// </summary>
-			private TaskCompletionSource<bool> m_throttletask = new TaskCompletionSource<bool>();
+			private TaskCompletionSource<bool> m_throttletask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			/// <summary>
 			/// A logger for reporting the internal log state
@@ -338,7 +338,7 @@ namespace Ceen.Httpd
 					if (m_debuglogger != null) m_debuglogger("Blocking throttle", logtaskid, null);
 					lock (m_lock)
 						if (m_throttletask.Task.IsCompleted)
-							m_throttletask = new TaskCompletionSource<bool>();
+							m_throttletask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 				}
 
 				return true;
@@ -986,7 +986,7 @@ namespace Ceen.Httpd
                         // Set up call context access to this instance
                         Context.SetCurrentContext(context);
 
-                        var timeoutcontroltask = new TaskCompletionSource<bool>();
+                        var timeoutcontroltask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                         var idletime = TimeSpan.FromSeconds(config.RequestHeaderReadTimeoutSeconds);
 
                         // Set up timeout for processing


### PR DESCRIPTION
Please start with this article https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/ 
It had bitten us several times in the past, so I analyzed the code and for all TCS-s that are used with async/await, added the TaskCreationOptions.RunContinuationsAsynchronously option.
No, I have not got into the problem yet with MTConnect.NET. But from the experience it will happen sooner or later.