### PR TITLE
Improve MQTT Relay Module Buffer Path Handling

### DIFF
--- a/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
+++ b/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
@@ -345,6 +345,7 @@ namespace MTConnect
             {
                 baseDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, baseDir);
             }
+            Directory.CreateDirectory(baseDir);
             return Path.Combine(baseDir, LastSentSequenceFileName);
         }
 

--- a/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
+++ b/agent/Modules/MTConnect.NET-AgentModule-MqttRelay/Module.cs
@@ -38,7 +38,8 @@ namespace MTConnect
         private static readonly object _lastSentSequenceLock = new object();
         private long _totalIncomingObservations = 0;
         private long _lastSentSequence = 0;
-
+        private const string DirectoryBuffer = "buffer";
+        private const string LastSentSequenceFileName = "mqttrelay_last_sent.seq";
 
         public Module(IMTConnectAgentBroker mtconnectAgent, object configuration) : base(mtconnectAgent)
         {
@@ -334,17 +335,24 @@ namespace MTConnect
             }
         }
 
-        private static string GetLastSentSequenceFilePath()
+        private static string GetLastSentSequenceFilePath(IAgentApplicationConfiguration agentConfig = null)
         {
-            var bufferDir = Path.Combine(AppContext.BaseDirectory, "buffer");
-            Directory.CreateDirectory(bufferDir);
-            return Path.Combine(bufferDir, "mqttrelay_last_sent.seq");
+            string baseDir = !string.IsNullOrEmpty(agentConfig?.DurableBufferPath)
+                ? agentConfig.DurableBufferPath
+                : DirectoryBuffer;
+
+            if (!Path.IsPathRooted(baseDir))
+            {
+                baseDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, baseDir);
+            }
+            return Path.Combine(baseDir, LastSentSequenceFileName);
         }
 
         private ulong GetLastSentSequence()
         {
-            if (!_configuration.DurableRelay) return 0; // Default
-            var path = GetLastSentSequenceFilePath();
+            if (!_configuration.DurableRelay) return 0;
+            var agentConfig = Agent?.Configuration as IAgentApplicationConfiguration;
+            var path = GetLastSentSequenceFilePath(agentConfig);
             lock (_lastSentSequenceLock)
             {
                 if (File.Exists(path))
@@ -359,7 +367,8 @@ namespace MTConnect
         private void SetLastSentSequence(ulong seq)
         {
             if (!_configuration.DurableRelay) return; // Default
-            var path = GetLastSentSequenceFilePath();
+            var agentConfig = Agent?.Configuration as IAgentApplicationConfiguration;
+            var path = GetLastSentSequenceFilePath(agentConfig);
             lock (_lastSentSequenceLock)
             {
                 File.WriteAllText(path, seq.ToString());


### PR DESCRIPTION
1. This change takes care of the feature introduced in https://github.com/TrakHound/MTConnect.NET/commit/b558d204862c27c087ad345f399c8a8cb3032778 (durable buffer path) for the durable relay feature.
2. The changes ensure that the .seq file used for durable relay is always written to the correct buffer directory as specified by the global agent configuration. If not specified, will write the file to the default 'buffer' directory.
3. The changes ensure the durableRelay: true logic does not create a new directory if custom buffer path is mentioned.


@PatrickRitchie 