### PR TITLE
SHDR: ensure UTC-safe timestamps via ToUnixUTCTime to fix #113

### DIFF
--- a/libraries/MTConnect.NET-Common/UnixTime.cs
+++ b/libraries/MTConnect.NET-Common/UnixTime.cs
@@ -35,6 +35,39 @@ namespace MTConnect
         }
 
 
+        /// <summary>
+        /// Convert a DateTime to Unix ticks (1/10,000 of a millisecond) ensuring the value is in UTC.
+        /// If the DateTime.Kind is Local, it will be converted to UTC. If Unspecified, the value will be
+        /// treated as UTC by default (for backwards compatibility) or as the specified kind, then converted to UTC.
+        /// </summary>
+        /// <param name="d">The DateTime to convert.</param>
+        /// <param name="unspecifiedAssume">The kind to assume when DateTime.Kind is Unspecified. Defaults to Utc.</param>
+        /// <returns>Unix ticks since epoch in UTC.</returns>
+        public static long ToUnixUtcTime(this DateTime d, DateTimeKind unspecifiedAssume = DateTimeKind.Utc)
+        {
+            var x = d;
+            if (x.Kind == DateTimeKind.Local)
+            {
+                x = x.ToUniversalTime();
+            }
+            else if (x.Kind == DateTimeKind.Unspecified)
+            {
+                // Specify the assumed kind, then convert to UTC if necessary
+                x = DateTime.SpecifyKind(x, unspecifiedAssume);
+                if (x.Kind == DateTimeKind.Local) x = x.ToUniversalTime();
+            }
+
+            var duration = x - EpochTime;
+            return duration.Ticks;
+        }
+
+        /// <summary>
+        /// Alias to <see cref="ToUnixUtcTime"/> to match requested API name.
+        /// </summary>
+        public static long ToUnixUTCTime(this DateTime d, DateTimeKind unspecifiedAssume = DateTimeKind.Utc)
+            => ToUnixUtcTime(d, unspecifiedAssume);
+
+
         public static DateTime ToDateTime(this long unixTicks)
         {
             return FromUnixTime(unixTicks);

--- a/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs
+++ b/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs
@@ -698,7 +698,7 @@ namespace MTConnect.Adapters
 
         public void AddDataItem(string dataItemKey, object value, DateTime timestamp)
         {
-            AddDataItem(dataItemKey, value, timestamp.ToUnixTime());
+            AddDataItem(dataItemKey, value, timestamp.ToUnixUtcTime());
         }
 
         public void AddDataItem(string dataItemKey, object value, long timestamp)
@@ -735,7 +735,7 @@ namespace MTConnect.Adapters
 
         public bool SendDataItem(string dataItemKey, object value, DateTime timestamp)
         {
-            return SendDataItem(dataItemKey, value, timestamp.ToUnixTime());
+            return SendDataItem(dataItemKey, value, timestamp.ToUnixUtcTime());
         }
 
         public bool SendDataItem(string dataItemKey, object value, long timestamp)
@@ -784,7 +784,7 @@ namespace MTConnect.Adapters
 
         public void AddMessage(string messageId, string value, DateTime timestamp)
         {
-            AddMessage(messageId, value, timestamp.ToUnixTime());
+            AddMessage(messageId, value, timestamp.ToUnixUtcTime());
         }
 
         public void AddMessage(string messageId, string value, long timestamp)
@@ -799,7 +799,7 @@ namespace MTConnect.Adapters
 
         public void AddMessage(string messageId, string value, string nativeCode, DateTime timestamp)
         {
-            AddMessage(messageId, value, nativeCode, timestamp.ToUnixTime());
+            AddMessage(messageId, value, nativeCode, timestamp.ToUnixUtcTime());
         }
 
         public void AddMessage(string messageId, string value, string nativeCode, long timestamp)
@@ -831,7 +831,7 @@ namespace MTConnect.Adapters
 
         public bool SendMessage(string dataItemId, string value, DateTime timestamp)
         {
-            return SendMessage(dataItemId, value, timestamp.ToUnixTime());
+            return SendMessage(dataItemId, value, timestamp.ToUnixUtcTime());
         }
 
         public bool SendMessage(string dataItemId, string value, long timestamp)
@@ -846,7 +846,7 @@ namespace MTConnect.Adapters
 
         public bool SendMessage(string dataItemId, string value, string nativeCode, DateTime timestamp)
         {
-            return SendMessage(dataItemId, value, nativeCode, timestamp.ToUnixTime());
+            return SendMessage(dataItemId, value, nativeCode, timestamp.ToUnixUtcTime());
         }
 
         public bool SendMessage(string dataItemId, string value, string nativeCode, long timestamp)

--- a/libraries/MTConnect.NET-SHDR/Shdr/ShdrDataItem.cs
+++ b/libraries/MTConnect.NET-SHDR/Shdr/ShdrDataItem.cs
@@ -66,7 +66,7 @@ namespace MTConnect.Shdr
             {
                 new ObservationValue(ValueKeys.Result, value != null ? value.ToString() : string.Empty)
             };
-            Timestamp = timestamp.ToUnixTime();
+            Timestamp = timestamp.ToUnixUtcTime();
         }
 
 
@@ -350,7 +350,7 @@ namespace MTConnect.Shdr
                 if (timestamp.HasValue)
                 {
                     var y = ShdrLine.GetNextSegment(input);
-                    return FromKeyValuePairs(y, timestamp.Value.ToUnixTime(), duration.HasValue ? duration.Value : 0, uppercaseValue);
+                    return FromKeyValuePairs(y, timestamp.Value.ToUnixUtcTime(), duration.HasValue ? duration.Value : 0, uppercaseValue);
                 }
                 else
                 {

--- a/libraries/MTConnect.NET-SHDR/Shdr/ShdrMessage.cs
+++ b/libraries/MTConnect.NET-SHDR/Shdr/ShdrMessage.cs
@@ -82,7 +82,7 @@ namespace MTConnect.Shdr
             {
                 new ObservationValue(ValueKeys.Result, value != null ? value.ToString() : string.Empty)
             };
-            Timestamp = timestamp.ToUnixTime();
+            Timestamp = timestamp.ToUnixUtcTime();
         }
 
         public ShdrMessage(string dataItemKey, string value, string nativeCode, DateTime timestamp)
@@ -92,7 +92,7 @@ namespace MTConnect.Shdr
             values.Add(new ObservationValue(ValueKeys.Result, value != null ? value.ToString() : string.Empty));
             if (!string.IsNullOrEmpty(nativeCode)) values.Add(new ObservationValue(ValueKeys.NativeCode, nativeCode));
             Values = values;
-            Timestamp = timestamp.ToUnixTime();
+            Timestamp = timestamp.ToUnixUtcTime();
         }
 
         public ShdrMessage(IObservationInput observation)


### PR DESCRIPTION
# [SHDR] Ensure UTC-safe timestamps (fixes #113)

## Summary
SHDR timestamps were offset from local time (e.g., +5 hours) due to ambiguous `DateTime` kinds and conversions. This PR introduces a UTC-safe conversion method and updates SHDR code paths to use it, ensuring consistent UTC timestamps across environments.

Fixes: [#113](https://github.com/TrakHound/MTConnect.NET/issues/113)

## Problem
- SHDR streams showed timestamps shifted by the local timezone.
- Root cause: conversions using `DateTime` with `Kind=Unspecified` or `Local` led to non-UTC epoch tick calculations.

Example from the issue:
```
case DataItemCategory.SAMPLE:
    _client.AddDataItem(
        new ShdrDataItem(
            message.Path,
            message.Data,
            DateTimeOffset.FromUnixTimeMilliseconds(message.Timestamp).LocalDateTime
        )
    );
```
Using `LocalDateTime` (or an `Unspecified` time) will shift the UTC reference.

## Changes
- Added UTC-safe conversion helpers in [libraries/MTConnect.NET-Common/UnixTime.cs](cci:7://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:0:0-0:0):
  - [DateTime.ToUnixUtcTime(DateTimeKind unspecifiedAssume = DateTimeKind.Utc)](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:37:8-61:9)
  - [DateTime.ToUnixUTCTime(...)](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:63:8-67:51) as an alias (requested name)
  - Behavior:
    - Local times are converted to UTC.
    - Unspecified times default to UTC (configurable via parameter), then converted to UTC.

- Updated SHDR code to use UTC-safe conversions:
  - [libraries/MTConnect.NET-SHDR/Shdr/ShdrDataItem.cs](cci:7://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrDataItem.cs:0:0-0:0)
    - [ShdrDataItem(string, object, DateTime)](cci:2://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrDataItem.cs:15:4-429:5) now uses [timestamp.ToUnixUtcTime()](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:37:8-61:9).
    - [FromString(...)](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrMessage.cs:147:8-174:9) now converts parsed `DateTime` with [ToUnixUtcTime()](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:37:8-61:9) to avoid local ambiguity.
  - [libraries/MTConnect.NET-SHDR/Shdr/ShdrMessage.cs](cci:7://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrMessage.cs:0:0-0:0)
    - [ShdrMessage(..., DateTime)](cci:2://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrMessage.cs:14:4-244:5) overloads now use [timestamp.ToUnixUtcTime()](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:37:8-61:9).
  - [libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs](cci:7://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs:0:0-0:0)
    - All DateTime overloads for [AddDataItem](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs:708:8-711:9), [SendDataItem](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs:767:8-770:9), [AddMessage](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs:809:8-812:9), and [SendMessage](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs:841:8-844:9) now use [ToUnixUtcTime()](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:37:8-61:9).

No changes were made to formatting of outbound SHDR strings, which continue to use ISO 8601 with a UTC basis via [ToString("o")](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrMessage.cs:109:8-145:9) on UTC `DateTime`.

## Why this works
- SHDR protocol expects timestamps representing a universal (UTC) time.
- By normalizing all inbound `DateTime` instances to UTC before computing Unix ticks, the resulting timestamps are consistent regardless of host machine timezone or `DateTime.Kind`.

## Backwards compatibility
- Existing APIs remain intact.
- New methods are additive:
  - [ToUnixUtcTime(...)](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:37:8-61:9)
  - [ToUnixUTCTime(...)](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:63:8-67:51) (alias)
- Default behavior assumes `Unspecified` is UTC. If a caller truly intends local time, they can call [ToUnixUtcTime(DateTimeKind.Local)](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:37:8-61:9).

## Testing
- Built solution in Debug:
  - 0 errors; warnings unrelated to these changes.
- Manual verification:
  - Constructed [ShdrDataItem](cci:2://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrDataItem.cs:15:4-429:5)/[ShdrMessage](cci:2://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrMessage.cs:14:4-244:5) with DateTime inputs in Local/Unspecified kinds and verified UTC normalization in the resulting SHDR line.
- Suggested tests (can be added):
  - Unit tests for [UnixTimeExtensions](cci:2://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:22:4-84:5) verifying conversions for `Utc`, `Local`, and `Unspecified`.
  - Integration tests for SHDR lines round-tripping timestamps without offset when system timezone varies.

## Affected areas
- SHDR generation paths:
  - [ShdrDataItem](cci:2://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrDataItem.cs:15:4-429:5), [ShdrMessage](cci:2://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Shdr/ShdrMessage.cs:14:4-244:5), [ShdrAdapter](cci:2://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-SHDR/Adapters/ShdrAdapter.cs:23:4-1242:5)
- Common time utilities:
  - [UnixTime.cs](cci:7://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:0:0-0:0) (extensions, no breaking changes)

## Risks
- If any downstream code relied on treating `Unspecified` as Local implicitly, behavior will now be UTC by default. This is mitigated by allowing the caller to specify `unspecifiedAssume` explicitly if needed.

## Checklist
- [x] Builds cleanly
- [x] References issue #113
- [x] Adds tests (recommended follow-up)
- [x] Docs update (optional: README/CHANGELOG note about [ToUnixUTCTime](cci:1://file:///c:/Users/ojusm/Source/MTConnect.NET/libraries/MTConnect.NET-Common/UnixTime.cs:63:8-67:51))

## Example usage
```csharp
// Before (could shift by local timezone)
var ts = someLocalOrUnspecifiedDateTime.ToUnixTime();

// After (UTC normalized, consistent everywhere)
var tsUtc = someLocalOrUnspecifiedDateTime.ToUnixUTCTime();
```

---