### PR TITLE
build(repo): bump Scriban + test-infra packages

### DIFF
--- a/build/MTConnect.NET-SysML-Import/MTConnect.NET-SysML-Import.csproj
+++ b/build/MTConnect.NET-SysML-Import/MTConnect.NET-SysML-Import.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Scriban" Version="5.9.0" />
+		<PackageReference Include="Scriban" Version="7.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/build/MTConnect.NET-SysML-Import/README.md
+++ b/build/MTConnect.NET-SysML-Import/README.md
@@ -184,7 +184,7 @@ When upgrading Scriban or editing templates, **always** run a v2.5 / v2.6 / v2.7
 | Importer prints "Done." but no `.g.cs` files change | Scriban template tree missing or case-mismatched. Build output should contain `CSharp/Templates/`, `Json-cppagent/Templates/`, `Xml/Templates/` — case-correct. The `EnsureTemplateTreesExist` startup check now catches this before XMI parse. |
 | `CS0246: type 'X' could not be found` after regen | A new XMI version introduced a cross-package parent that the resolver couldn't graft — typically because the parent lives in a sub-model whose `Classes` list isn't yet enumerated by `MTConnectModel.CollectClassLists`. Add it to that helper. |
 | `InvalidCastException` in `CSharpTemplateRenderer.Render` | A property's `Id` matches a suffix-based class selector. The `Result` selector now type-guards; new selectors should follow the same pattern (`typeof(MTConnectClassModel).IsAssignableFrom(type) && Id.EndsWith(...)`)|
-| 11 NuGet vulnerability warnings on Scriban | Known — Scriban 5.x has open advisories. Upgrade to 7.x is tracked as a follow-up dep-update PR, not here. |
+| Older NuGet vulnerability warnings on Scriban | Scriban now pinned at 7.2.0 — the 5.x advisories no longer apply. If a warning resurfaces on a fresh dependency, audit the resolved version with `dotnet list package --vulnerable --include-transitive`. |
 
 ## Reproducibility
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/HeightMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/HeightMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class HeightMeasurement : Measurement, IHeightMeasurement
     {
-        public new const string DescriptionText = "Height of the PhysicalAsset";
         public const string TypeId = "Height";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/LengthMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/LengthMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class LengthMeasurement : Measurement, ILengthMeasurement
     {
-        public new const string DescriptionText = "Length of the PhysicalAsset";
         public const string TypeId = "Length";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedHeightMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedHeightMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class LoadedHeightMeasurement : Measurement, ILoadedHeightMeasurement
     {
-        public new const string DescriptionText = "Loaded height of the PhysicalAsset";
         public const string TypeId = "LoadedHeight";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedLengthMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedLengthMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class LoadedLengthMeasurement : Measurement, ILoadedLengthMeasurement
     {
-        public new const string DescriptionText = "Loaded length of the PhysicalAsset";
         public const string TypeId = "LoadedLength";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedSwingMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedSwingMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class LoadedSwingMeasurement : Measurement, ILoadedSwingMeasurement
     {
-        public new const string DescriptionText = "Loaded swing of the PhysicalAsset";
         public const string TypeId = "LoadedSwing";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedWeightMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedWeightMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class LoadedWeightMeasurement : Measurement, ILoadedWeightMeasurement
     {
-        public new const string DescriptionText = "Loaded weight of the PhysicalAsset";
         public const string TypeId = "LoadedWeight";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedWidthMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/LoadedWidthMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class LoadedWidthMeasurement : Measurement, ILoadedWidthMeasurement
     {
-        public new const string DescriptionText = "Loaded width of the PhysicalAsset";
         public const string TypeId = "LoadedWidth";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/SwingMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/SwingMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class SwingMeasurement : Measurement, ISwingMeasurement
     {
-        public new const string DescriptionText = "Swing of the PhysicalAsset";
         public const string TypeId = "Swing";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/WeightMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/WeightMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class WeightMeasurement : Measurement, IWeightMeasurement
     {
-        public new const string DescriptionText = "Weight of the PhysicalAsset";
         public const string TypeId = "Weight";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Assets/Pallet/WidthMeasurement.g.cs
+++ b/libraries/MTConnect.NET-Common/Assets/Pallet/WidthMeasurement.g.cs
@@ -8,7 +8,6 @@ namespace MTConnect.Assets.Pallet
     /// </summary>
     public class WidthMeasurement : Measurement, IWidthMeasurement
     {
-        public new const string DescriptionText = "Width of the PhysicalAsset";
         public const string TypeId = "Width";
         public const string CodeId = "";
 

--- a/libraries/MTConnect.NET-Common/Devices/Components/PinToolComponent.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/Components/PinToolComponent.g.cs
@@ -16,7 +16,7 @@ namespace MTConnect.Devices.Components
 
         public override string TypeDescription => DescriptionText;
         
-         
+        public override System.Version MinimumVersion => MTConnectVersions.Version27; 
 
 
         public PinToolComponent()

--- a/libraries/MTConnect.NET-Common/Devices/Components/ToolHolderComponent.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/Components/ToolHolderComponent.g.cs
@@ -16,7 +16,7 @@ namespace MTConnect.Devices.Components
 
         public override string TypeDescription => DescriptionText;
         
-         
+        public override System.Version MinimumVersion => MTConnectVersions.Version27; 
 
 
         public ToolHolderComponent()

--- a/libraries/MTConnect.NET-Common/Devices/DataItems/AssetCountDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/DataItems/AssetCountDataItem.g.cs
@@ -13,7 +13,7 @@ namespace MTConnect.Devices.DataItems
         public const DataItemCategory CategoryId = DataItemCategory.EVENT;
         public const string TypeId = "ASSET_COUNT";
         public const string NameId = "assetCount";
-        public const DataItemRepresentation DefaultRepresentation = DataItemRepresentation.DATA_SET;
+        public const DataItemRepresentation DefaultRepresentation = DataItemRepresentation.DATA_SET;     
              
         public new const string DescriptionText = "Data set of the number of Asset of a given type for a Device.";
         

--- a/libraries/MTConnect.NET-Common/Devices/DataItems/BindingStateDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/DataItems/BindingStateDataItem.g.cs
@@ -24,7 +24,7 @@ namespace MTConnect.Devices.DataItems
         
         public override string TypeDescription => DescriptionText;
         
-               
+        public override System.Version MinimumVersion => MTConnectVersions.Version27;       
 
 
         public BindingStateDataItem()

--- a/libraries/MTConnect.NET-Common/Devices/DataItems/DepthDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/DataItems/DepthDataItem.g.cs
@@ -19,7 +19,7 @@ namespace MTConnect.Devices.DataItems
         
         public override string TypeDescription => DescriptionText;
         
-               
+        public override System.Version MinimumVersion => MTConnectVersions.Version27;       
 
 
         public enum SubTypes

--- a/libraries/MTConnect.NET-Common/Devices/DataItems/FixtureAssetIdDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/DataItems/FixtureAssetIdDataItem.g.cs
@@ -19,7 +19,7 @@ namespace MTConnect.Devices.DataItems
         
         public override string TypeDescription => DescriptionText;
         
-               
+        public override System.Version MinimumVersion => MTConnectVersions.Version27;       
 
 
         public FixtureAssetIdDataItem()

--- a/libraries/MTConnect.NET-Common/Devices/DataItems/SwingAngleDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/DataItems/SwingAngleDataItem.g.cs
@@ -19,7 +19,7 @@ namespace MTConnect.Devices.DataItems
         
         public override string TypeDescription => DescriptionText;
         
-               
+        public override System.Version MinimumVersion => MTConnectVersions.Version27;       
 
 
         public SwingAngleDataItem()

--- a/libraries/MTConnect.NET-Common/Devices/DataItems/SwingDiameterDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/DataItems/SwingDiameterDataItem.g.cs
@@ -19,7 +19,7 @@ namespace MTConnect.Devices.DataItems
         
         public override string TypeDescription => DescriptionText;
         
-               
+        public override System.Version MinimumVersion => MTConnectVersions.Version27;       
 
 
         public SwingDiameterDataItem()

--- a/libraries/MTConnect.NET-Common/Devices/DataItems/SwingRadiusDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/DataItems/SwingRadiusDataItem.g.cs
@@ -19,7 +19,7 @@ namespace MTConnect.Devices.DataItems
         
         public override string TypeDescription => DescriptionText;
         
-               
+        public override System.Version MinimumVersion => MTConnectVersions.Version27;       
 
 
         public SwingRadiusDataItem()

--- a/libraries/MTConnect.NET-Common/Devices/DataItems/TaskAssetIdDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/DataItems/TaskAssetIdDataItem.g.cs
@@ -19,7 +19,7 @@ namespace MTConnect.Devices.DataItems
         
         public override string TypeDescription => DescriptionText;
         
-               
+        public override System.Version MinimumVersion => MTConnectVersions.Version27;       
 
 
         public TaskAssetIdDataItem()

--- a/libraries/MTConnect.NET-Common/Devices/DataItems/WaterHardnessDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Devices/DataItems/WaterHardnessDataItem.g.cs
@@ -19,7 +19,7 @@ namespace MTConnect.Devices.DataItems
         
         public override string TypeDescription => DescriptionText;
         
-               
+        public override System.Version MinimumVersion => MTConnectVersions.Version27;       
 
 
         public WaterHardnessDataItem()

--- a/libraries/MTConnect.NET-Common/Interfaces/InterfaceStateDataItem.g.cs
+++ b/libraries/MTConnect.NET-Common/Interfaces/InterfaceStateDataItem.g.cs
@@ -13,12 +13,12 @@ namespace MTConnect.Interfaces
         public const DataItemCategory CategoryId = DataItemCategory.EVENT;
         public const string TypeId = "INTERFACE_STATE";
         public const string NameId = "interfaceState";
-             
-        public new const string DescriptionText = "Operational state of an Interface.";
         
+        public new const string DescriptionText = "Operational state of an Interface.";
+
         public override string TypeDescription => DescriptionText;
         
-        public override System.Version MinimumVersion => MTConnectVersions.Version13;       
+        public override System.Version MinimumVersion => MTConnectVersions.Version13;
 
 
         public InterfaceStateDataItem()

--- a/libraries/MTConnect.NET-MQTT/MTConnect.NET-MQTT.csproj
+++ b/libraries/MTConnect.NET-MQTT/MTConnect.NET-MQTT.csproj
@@ -52,6 +52,19 @@
 		<PackageReference Include="MQTTnet" Version="4.3.7.1207" />
 	</ItemGroup>
 
+	<!-- Pin System.Text.Json 8.0.5 on TFMs without an in-the-runtime
+		 System.Text.Json. Microsoft.Extensions.Hosting 7.0.0
+		 transitively brings System.Text.Json 7.0.0 which is flagged
+		 by GHSA-hh2w-p6rv-4g7w. On netstandard2.0 and net48 the
+		 package is the only thing on the wire, so the override here
+		 closes the actual exposure surface. -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<None Include="Configurations\IMTConnectMqttExpanderConfiguration.cs" />
 		<None Include="Configurations\MTConnectMqttExpanderConfiguration.cs" />

--- a/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
+++ b/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>

--- a/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
+++ b/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 

--- a/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
+++ b/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
+++ b/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />

--- a/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
+++ b/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>

--- a/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
+++ b/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
+++ b/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />

--- a/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
+++ b/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 

--- a/tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj
+++ b/tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj
@@ -63,7 +63,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj
+++ b/tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj
@@ -54,11 +54,12 @@
 
   <ItemGroup>
     <PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Testcontainers" Version="3.10.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj
+++ b/tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj
@@ -55,7 +55,7 @@
   <ItemGroup>
     <PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="Testcontainers" Version="3.10.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
+++ b/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
+++ b/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
+++ b/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
+++ b/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
+++ b/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
+++ b/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
+++ b/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="DeepEqual" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
+++ b/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Closes #163.

## Summary

Bumps Scriban (the SysML importer's templating engine) from 5.9.0 to 7.2.0 and supersedes Dependabot's mechanical follow-up 7.2.0 bump in #163 (which already superseded #126), sweeping the test-infrastructure packages that Dependabot left out at the same time.

- `build(sysml-import)`: bump Scriban 5.9.0 -> 7.2.0. Closes 1 critical + 7 high + 3 moderate advisories on the 5.x line. Dependabot can only edit the `<PackageReference Version="...">` value; this PR also carries the matching SysML re-import against 7.2.0's template engine so the generated `.g.cs` outputs stay in lock-step with the bump (commits `9243a75f` + `f3b4ce05`).
- `build(repo)`: bump `Microsoft.NET.Test.Sdk` to 17.14.1 across the five test projects (latest stable 17.x; 18.x intentionally skipped pending a separate evaluation).
- `build(repo)`: bump `coverlet.collector` to 6.0.4 across the five test projects (latest stable 6.x).
- `build(repo)`: bump `NUnit` to 3.14.0 across the four NUnit test projects. NUnit stays on the 3.x line; the 4.x major rewrite (Assert.That syntax overhaul) is deferred to a dedicated migration PR.
- `build(repo)`: bump `NUnit3TestAdapter` to 4.6.0 across the four NUnit test projects (latest stable 4.x).
- `build(repo)`: pin `System.Text.Json` 8.0.5 on `netstandard2.0` / `net48` in the MQTT projects to clear the F-S-H2 transitive High advisory chain.
- `build(integration-tests)`: pin transitive package versions to clear remaining High advisories on the integration-tests project (F-S-H4, F-Si-L14).

