### PR TITLE
fix(common): expose AssetBufferSize and AssetCount on Streams Header

### DIFF
--- a/libraries/MTConnect.NET-Common/Agents/MTConnectAgentBroker.cs
+++ b/libraries/MTConnect.NET-Common/Agents/MTConnectAgentBroker.cs
@@ -486,6 +486,8 @@ namespace MTConnect.Agents
             var header = new MTConnectStreamsHeader
             {
                 BufferSize = _observationBuffer.BufferSize,
+                AssetBufferSize = _assetBuffer != null ? _assetBuffer.BufferSize : 0,
+                AssetCount = _assetBuffer != null ? _assetBuffer.AssetCount : 0,
                 CreationTime = DateTime.UtcNow,
                 DeviceModelChangeTime = DeviceModelChangeTime.ToString("o"),
                 InstanceId = InstanceId,

--- a/libraries/MTConnect.NET-Common/Headers/IMTConnectStreamsHeader.cs
+++ b/libraries/MTConnect.NET-Common/Headers/IMTConnectStreamsHeader.cs
@@ -33,6 +33,16 @@ namespace MTConnect.Headers
         ulong BufferSize { get; }
 
         /// <summary>
+        /// A value representing the maximum number of Asset Documents that MAY be retained in the Agent that published the Response Document at any point in time.
+        /// </summary>
+        ulong AssetBufferSize { get; }
+
+        /// <summary>
+        /// A number representing the current number of Asset Documents that are currently stored in the Agent that published the Response Document.
+        /// </summary>
+        ulong AssetCount { get; }
+
+        /// <summary>
         /// A number representing the sequence number assigned to the oldest piece of Streaming Data stored
         /// in the buffer of the Agent immediately prior to the time that the Agent published the Response Document.
         /// </summary>

--- a/libraries/MTConnect.NET-Common/Headers/MTConnectStreamsHeader.cs
+++ b/libraries/MTConnect.NET-Common/Headers/MTConnectStreamsHeader.cs
@@ -33,6 +33,16 @@ namespace MTConnect.Headers
         public ulong BufferSize { get; set; }
 
         /// <summary>
+        /// A value representing the maximum number of Asset Documents that MAY be retained in the Agent that published the Response Document at any point in time.
+        /// </summary>
+        public ulong AssetBufferSize { get; set; }
+
+        /// <summary>
+        /// A number representing the current number of Asset Documents that are currently stored in the Agent that published the Response Document.
+        /// </summary>
+        public ulong AssetCount { get; set; }
+
+        /// <summary>
         /// A number representing the sequence number assigned to the oldest piece of Streaming Data stored
         /// in the buffer of the Agent immediately prior to the time that the Agent published the Response Document.
         /// </summary>

--- a/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonStreamsHeader.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonStreamsHeader.cs
@@ -21,6 +21,12 @@ namespace MTConnect.Streams.Json
         [JsonPropertyName("bufferSize")]
         public ulong BufferSize { get; set; }
 
+        [JsonPropertyName("assetBufferSize")]
+        public ulong AssetBufferSize { get; set; }
+
+        [JsonPropertyName("assetCount")]
+        public ulong AssetCount { get; set; }
+
         [JsonPropertyName("firstSequence")]
         public ulong FirstSequence { get; set; }
 
@@ -50,6 +56,8 @@ namespace MTConnect.Streams.Json
                 Version = header.Version;
                 Sender = header.Sender;
                 BufferSize = header.BufferSize;
+                AssetBufferSize = header.AssetBufferSize;
+                AssetCount = header.AssetCount;
                 FirstSequence = header.FirstSequence;
                 LastSequence = header.LastSequence;
                 NextSequence = header.NextSequence;
@@ -67,6 +75,8 @@ namespace MTConnect.Streams.Json
             header.Version = Version;
             header.Sender = Sender;
             header.BufferSize = BufferSize;
+            header.AssetBufferSize = AssetBufferSize;
+            header.AssetCount = AssetCount;
             header.FirstSequence = FirstSequence;
             header.LastSequence = LastSequence;
             header.NextSequence = NextSequence;

--- a/tests/MTConnect.NET-Common-Tests/Headers/MTConnectStreamsHeaderAssetFieldsTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Headers/MTConnectStreamsHeaderAssetFieldsTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using MTConnect.Headers;
+using NUnit.Framework;
+
+namespace MTConnect.Tests.Common.Headers
+{
+    /// <summary>
+    /// Pins the MTConnect Streams Header model-side support for the
+    /// `assetBufferSize` and `assetCount` attributes that the cppagent
+    /// JSON v2 reference printer emits on every Streams envelope's Header.
+    ///
+    /// The XSD `HeaderStreamsAttributesType` derives from
+    /// `HeaderAttributesType`, which carries `assetBufferSize` and
+    /// `assetCount` as inherited optional attributes. Both `IMTConnectDevicesHeader`
+    /// and `IMTConnectAssetsHeader` exposed these fields previously; the
+    /// Streams Header was the missing surface, surfacing as a wire-format
+    /// gap on Streams envelopes (operators monitoring multi-agent fleets
+    /// could not see asset-buffer utilisation on Current/Sample responses).
+    ///
+    /// Source authority:
+    /// - XSD: https://schemas.mtconnect.org/schemas/MTConnectStreams_2.7.xsd
+    ///   (HeaderStreamsAttributesType / HeaderAttributesType inheritance).
+    /// - Reference shape: cppagent v2.7.0.7 emits both fields on every
+    ///   Streams envelope Header (printer/json_printer.cpp).
+    /// </summary>
+    [TestFixture]
+    public class MTConnectStreamsHeaderAssetFieldsTests
+    {
+        [Test]
+        public void IMTConnectStreamsHeader_exposes_AssetBufferSize_getter()
+        {
+            var headerType = typeof(IMTConnectStreamsHeader);
+            var property = headerType.GetProperty(nameof(IMTConnectStreamsHeader.AssetBufferSize));
+            Assert.That(property, Is.Not.Null,
+                "IMTConnectStreamsHeader must declare an AssetBufferSize property to match the cppagent v2 wire shape.");
+            Assert.That(property!.PropertyType, Is.EqualTo(typeof(ulong)));
+        }
+
+        [Test]
+        public void IMTConnectStreamsHeader_exposes_AssetCount_getter()
+        {
+            var headerType = typeof(IMTConnectStreamsHeader);
+            var property = headerType.GetProperty(nameof(IMTConnectStreamsHeader.AssetCount));
+            Assert.That(property, Is.Not.Null,
+                "IMTConnectStreamsHeader must declare an AssetCount property to match the cppagent v2 wire shape.");
+            Assert.That(property!.PropertyType, Is.EqualTo(typeof(ulong)));
+        }
+
+        [Test]
+        public void MTConnectStreamsHeader_round_trips_AssetBufferSize_and_AssetCount()
+        {
+            var header = new MTConnectStreamsHeader
+            {
+                AssetBufferSize = 8192,
+                AssetCount = 42
+            };
+
+            Assert.That(header.AssetBufferSize, Is.EqualTo(8192UL));
+            Assert.That(header.AssetCount, Is.EqualTo(42UL));
+        }
+
+        [Test]
+        public void MTConnectStreamsHeader_AssetBufferSize_default_is_zero()
+        {
+            var header = new MTConnectStreamsHeader();
+            Assert.That(header.AssetBufferSize, Is.EqualTo(0UL),
+                "Default AssetBufferSize must be 0 (no asset buffer configured).");
+            Assert.That(header.AssetCount, Is.EqualTo(0UL),
+                "Default AssetCount must be 0 (no assets registered).");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`MTConnect.NET-JSON-cppagent` Streams envelope `Header` omits the `assetBufferSize` and `assetCount` attributes that the cppagent JSON v2 reference printer emits on every envelope's Header. Per the XSD's `HeaderStreamsAttributesType` (which derives from `HeaderAttributesType`), both attributes are inherited and optional — the cppagent reference always emits them.

`IMTConnectDevicesHeader` and `IMTConnectAssestsHeader` already exposed these fields. Only the Streams Header was missing the surface, surfacing as a wire-format omission on every Streams envelope.

## Reproduction

Boot a `JSON-cppagent-mqtt` agent with `assetBufferSize: 8192` configured. Capture a Current envelope:

```bash
mosquitto_sub -t 'MTConnect/Current/+' -h $BROKER -C 1 | jq '.MTConnectStreams.Header'
```

Pre-fix output:
```json
{
  "instanceId": 1776878246,
  "version": "6.9.0.0",
  "sender": "agent",
  "bufferSize": 131072,
  "firstSequence": 1,
  "lastSequence": 76,
  "nextSequence": 77,
  "deviceModelChangeTime": "...",
  "creationTime": "..."
}
```

cppagent v2.7.0.7 in an identical configuration emits both `assetBufferSize` and `assetCount`.

## Consumer impact

Downstream consumers monitoring multi-agent fleets cannot read asset-buffer utilisation from Current/Sample envelope Headers — only from less-frequent Asset envelopes. Strict cppagent JSON v2 parsers default the missing fields to `0` to keep parsing succeeding, but the resulting accounting rows under-report the agent's actual asset buffer state.

## Fix

- Add `AssetBufferSize` and `AssetCount` to `IMTConnectStreamsHeader` and `MTConnectStreamsHeader` (matches the existing properties on `IMTConnectDevicesHeader` / `IMTConnectAssestsHeader`).
- Add the matching JSON-cppagent serialisation (`assetBufferSize`, `assetCount`) on `JsonStreamsHeader`, including the `ToStreamsHeader()` round-trip path.
- Wire the producer-side population in `MTConnectAgentBroker.GetStreamsHeader`, sourcing values from the existing `_assetBuffer` field (matches the parallel `GetAssetsHeader` path).

## Tests

`tests/MTConnect.NET-Common-Tests/Headers/MTConnectStreamsHeaderAssetFieldsTests.cs` pins:

1. `IMTConnectStreamsHeader` declares `AssetBufferSize` getter (typed `ulong`).
2. `IMTConnectStreamsHeader` declares `AssetCount` getter (typed `ulong`).
3. `MTConnectStreamsHeader` round-trips both fields through get/set.
4. Default values are `0` (no buffer configured / no assets).

4/4 pass.

## Spec authority

- XSD: `https://schemas.mtconnect.org/schemas/MTConnectStreams_2.7.xsd` — `HeaderStreamsAttributesType` derives from `HeaderAttributesType` which carries both attributes.
- Reference: cppagent v2.7.0.7 `printer/json_printer.cpp` emits both fields on every envelope's Header.
- Prose: MTConnect Standard Part 2 §Header Attributes.

## Backward compatibility

The fields are added to a public interface (`IMTConnectStreamsHeader`). Any third-party consumer that implements this interface manually (rather than going through `MTConnectStreamsHeader`) needs to add the two new properties — but that's a small surface in practice. The default values (`0`) match the spec's `use="optional"` semantic.
