### PR TITLE
fix(tools): chown bind-mounted build outputs back to host user

### DIFF
--- a/tools/dotnet.sh
+++ b/tools/dotnet.sh
@@ -94,6 +94,14 @@ if [[ "${USE_DOCKER}" == "1" ]]; then
 		done
 	fi
 
+	# The SDK image runs `dotnet` as root by default. Files written to the
+	# bind-mounted repo (bin/, obj/, TestResults/, coverage report dirs)
+	# end up root-owned on the host, blocking the user's subsequent
+	# native dotnet build, rm -rf, or git clean. Run dotnet under a thin
+	# bash wrapper that chowns those output directories back to the host
+	# user's UID:GID on container exit. Named volumes (.nuget/packages,
+	# .dotnet/tools) stay root-owned inside the container; only the
+	# bind-mounted /src tree gets the post-run chown.
 	exec docker run --rm \
 		-v "${REPO_ROOT}:/src" \
 		-v "${NUGET_VOL}:/root/.nuget/packages" \
@@ -104,7 +112,18 @@ if [[ "${USE_DOCKER}" == "1" ]]; then
 		-e PATH=/root/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
 		-e DOTNET_NOLOGO=1 \
 		-e DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+		-e HOST_UID="$(id -u)" \
+		-e HOST_GID="$(id -g)" \
+		--entrypoint /bin/bash \
 		"${IMAGE}" \
+		-c '
+			dotnet "$@"
+			rc=$?
+			if [ -n "${HOST_UID:-}" ] && [ -n "${HOST_GID:-}" ]; then
+				find /src -type d \( -name bin -o -name obj -o -name TestResults -o -name CoverageReport \) -prune -exec chown -R "${HOST_UID}:${HOST_GID}" {} + 2>/dev/null || true
+			fi
+			exit ${rc}
+		' \
 		dotnet "$@"
 fi
 


### PR DESCRIPTION
## Summary

When `tools/dotnet.sh --docker` (and transitively `tools/test.sh --docker`) is used, `bin/`, `obj/`, `TestResults/`, and `CoverageReport/` directories under the bind-mounted repo end up root-owned on the host because the SDK image runs `dotnet` as root. This blocks subsequent native `dotnet` invocations, `rm -rf` cleanups, and `git clean` from removing those outputs without `sudo`.

- Wrap the in-container `dotnet` call in a thin bash entrypoint that, on exit, walks the bind-mounted `/src` tree and chowns the build-output directories back to the host user's UID:GID (passed in via `HOST_UID` / `HOST_GID` environment variables).
- The chown runs unconditionally on exit so a failing `dotnet` call still hands the build outputs back to the user; the original `dotnet` exit code is preserved.
- Named volumes that back the NuGet package cache and the dotnet-tools store stay root-owned inside the container; they are not visible to the host and do not interfere with host-side workflows.