### PR TITLE
chore(repo): replace literal section sigil with the word `section`

### DIFF
--- a/libraries/MTConnect.NET-Common/Agents/MTConnectAgentBroker.cs
+++ b/libraries/MTConnect.NET-Common/Agents/MTConnectAgentBroker.cs
@@ -555,7 +555,7 @@ namespace MTConnect.Agents
         // `version` attribute on every response document Header.
         // Per <https://github.com/TrakHound/MTConnect.NET/issues/127>,
         // this attribute is the MTConnect release the agent serves
-        // (Part 1.0 §3 Header), not the library assembly version.
+        // (Part 1.0 section 3 Header), not the library assembly version.
         // Pads build + revision with zero so the emitted shape matches
         // the cppagent reference (e.g. "2.5.0.0") regardless of how
         // many segments the source `Version` carried.

--- a/tests/MTConnect.NET-Common-Tests/Headers/HeaderVersionRegressionTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Headers/HeaderVersionRegressionTests.cs
@@ -5,8 +5,8 @@
 // not the library assembly version.
 //
 // Spec sources:
-//   - https://docs.mtconnect.org/ Part 1.0 §3 (Header), Part 2.0 §7
-//     (Streams envelope), Part 3.0 §5 (Devices envelope), Part 4.0 §5
+//   - https://docs.mtconnect.org/ Part 1.0 section 3 (Header), Part 2.0 section 7
+//     (Streams envelope), Part 3.0 section 5 (Devices envelope), Part 4.0 section 5
 //     (Assets envelope) — Header.version is the MTConnect Standard
 //     release the agent serves.
 //   - XSD: MTConnectDevices_<vN.M>.xsd, MTConnectStreams_<vN.M>.xsd,

--- a/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/MTConnectVersionsTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/MTConnectVersionsTests.cs
@@ -14,7 +14,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
     //   - XSD:   https://schemas.mtconnect.org/schemas/MTConnectDevices_2.6.xsd
     //                                                  MTConnectDevices_2.7.xsd
     //            (each XSD's targetNamespace embeds the version it represents.)
-    //   - Prose: MTConnect Standard `Part_1.0_Overview_v2.7.pdf` §1 "Versioning"
+    //   - Prose: MTConnect Standard `Part_1.0_Overview_v2.7.pdf` section 1 "Versioning"
     //            (the document numbering scheme — v1.0 through v2.7 with v1.9
     //            intentionally skipped — is described here.)
     [TestFixture]
@@ -44,7 +44,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
         }
 
         // Pin that the version list contains no 1.9 entry.
-        // Source: MTConnect Standard Part_1.0_Overview prose §1 "Versioning";
+        // Source: MTConnect Standard Part_1.0_Overview prose section 1 "Versioning";
         // confirmed by the absence of an XMI tag `v1.9` in
         // `mtconnect/mtconnect_sysml_model` (tags: v2.5 b61907fb78,
         // v2.6 08185447bf, v2.7 25796ac591).

--- a/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_6ComponentAndEnumTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_6ComponentAndEnumTests.cs
@@ -15,8 +15,8 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
     //   - XSD: schemas.mtconnect.org/schemas/MTConnectDevices_2.6.xsd
     //          (Component element list + MediaType simpleType enumeration)
     //   - Prose: MTConnect Standard Part_3.0_Devices_v2.6
-    //          §3.4.18 "CuttingTorch" / §3.4.21 "Electrode"
-    //          §4.7.2.5 MediaType (introduces QIF_MBD)
+    //          section 3.4.18 "CuttingTorch" / section 3.4.21 "Electrode"
+    //          section 4.7.2.5 MediaType (introduces QIF_MBD)
     [TestFixture]
     public class V2_6ComponentAndEnumTests
     {
@@ -46,7 +46,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
 
         // Source: XMI v2.6 enum `MediaTypeEnum` member `QIF_MBD`. XSD v2.6 lists
         // QIF_MBD inside the MediaType simpleType enumeration. Prose
-        // Part_3.0_Devices_v2.6 §4.7.2.5 introduces "ISO 10303 QIF model-based
+        // Part_3.0_Devices_v2.6 section 4.7.2.5 introduces "ISO 10303 QIF model-based
         // design" as the rationale.
         [Test]
         public void MediaType_QIF_MBD_value_present_in_v2_6()

--- a/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_6DataItemTypeTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_6DataItemTypeTests.cs
@@ -15,7 +15,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
     //   - XSD: schemas.mtconnect.org/schemas/MTConnectStreams_2.6.xsd
     //          (the EVENT category for both new types is encoded in the
     //          MTConnectStreams XSD's enumerations.)
-    //   - Prose: MTConnect Standard Part_2.0_Streams_v2.6 §11.5 "Asset events"
+    //   - Prose: MTConnect Standard Part_2.0_Streams_v2.6 section 11.5 "Asset events"
     //          (clarifies the v2.5 → v2.6 split — `AssetChanged` narrowed to
     //          changes only; `AssetAdded` introduced for additions.)
     [TestFixture]
@@ -74,7 +74,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
 
         // Source: XMI v2.6 description on `AssetChangedDataItem` (was "added or
         // changed" in v2.5; now "changed" only). Prose confirms in
-        // Part_2.0_Streams_v2.6 §11.5.
+        // Part_2.0_Streams_v2.6 section 11.5.
         [Test]
         public void AssetChangedDataItem_description_narrowed_in_v2_6()
         {

--- a/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7ComponentTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7ComponentTests.cs
@@ -11,7 +11,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
     //            * ToolHolder   — tool-holder component
     //   - XSD: https://schemas.mtconnect.org/schemas/MTConnectDevices_2.7.xsd
     //          (each TypeId appears in the ComponentType enumeration).
-    //   - Prose: MTConnect Standard Part_2.0_Devices_v2.7 §7 "Component
+    //   - Prose: MTConnect Standard Part_2.0_Devices_v2.7 section 7 "Component
     //          types" — describes intended use of each Component subclass.
     [TestFixture]
     public class V2_7ComponentTests

--- a/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7ConfigurationDataSetTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7ConfigurationDataSetTests.cs
@@ -20,7 +20,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
     //   - XSD: https://schemas.mtconnect.org/schemas/MTConnectDevices_2.7.xsd
     //          (the geometric-primitive complexTypes encode the same shape
     //          on the wire under <Configuration>).
-    //   - Prose: MTConnect Standard Part_2.0_Devices_v2.7 §10 "Configuration"
+    //   - Prose: MTConnect Standard Part_2.0_Devices_v2.7 section 10 "Configuration"
     //          — describes how Component-level Configuration carries the
     //          geometric primitives that locate a Component in space.
     [TestFixture]

--- a/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7DataItemTypeTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7DataItemTypeTests.cs
@@ -20,7 +20,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
     //   - XSD: schemas.mtconnect.org/schemas/MTConnectStreams_2.7.xsd
     //          (each TypeId is encoded in the EventEnum / SampleEnum
     //          enumerations.)
-    //   - Prose: MTConnect Standard Part_2.0_Streams_v2.7 §11/§13 "Event/Sample
+    //   - Prose: MTConnect Standard Part_2.0_Streams_v2.7 section 11/section 13 "Event/Sample
     //          types" — describes intended use of each type.
     [TestFixture]
     public class V2_7DataItemTypeTests

--- a/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7SampleObservationTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7SampleObservationTests.cs
@@ -16,7 +16,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
     //   - XSD: schemas.mtconnect.org/schemas/MTConnectStreams_2.7.xsd
     //          enum `SampleEnum` value `WATER_HARDNESS` is the sample-category
     //          element name on the wire.
-    //   - Prose: MTConnect Standard Part_2.0_Streams_v2.7 §11 "Sample observation
+    //   - Prose: MTConnect Standard Part_2.0_Streams_v2.7 section 11 "Sample observation
     //          types" — describes how SAMPLE-category observations carry
     //          continuous-numeric values reported at agent-defined intervals.
     //

--- a/tests/MTConnect.NET-XML-Tests/Headers/HeaderVersionXmlRoundTripTests.cs
+++ b/tests/MTConnect.NET-XML-Tests/Headers/HeaderVersionXmlRoundTripTests.cs
@@ -8,7 +8,7 @@
 // of the agent's DefaultVersion.
 //
 // Spec sources:
-//   - https://docs.mtconnect.org/ Part 1.0 §3 (Header) — defines the
+//   - https://docs.mtconnect.org/ Part 1.0 section 3 (Header) — defines the
 //     `version` attribute on the Header element as the MTConnect
 //     release the agent serves.
 //   - https://schemas.mtconnect.org/schemas/MTConnectDevices_2.5.xsd


### PR DESCRIPTION
## Summary

Replace the literal section sigil (`§`) with the word `section ` across ten committed source files. The `§` character is non-ASCII and renders inconsistently across editors and tooling; replacing it with the ASCII word `section ` keeps committed prose portable. Every replacement is verbatim `section ` (single trailing space) in place of `§`; the cited section numbers and titles are unchanged. No behavioural or test-code changes.

Affected files:

- `libraries/MTConnect.NET-Common/Agents/MTConnectAgentBroker.cs`
- `tests/MTConnect.NET-Common-Tests/Headers/HeaderVersionRegressionTests.cs`
- `tests/MTConnect.NET-Common-Tests/V2_6_V2_7/MTConnectVersionsTests.cs`
- `tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_6ComponentAndEnumTests.cs`
- `tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_6DataItemTypeTests.cs`
- `tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7ComponentTests.cs`
- `tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7ConfigurationDataSetTests.cs`
- `tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7DataItemTypeTests.cs`
- `tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7SampleObservationTests.cs`
- `tests/MTConnect.NET-XML-Tests/Headers/HeaderVersionXmlRoundTripTests.cs`
