### PR TITLE
chore(build): add mtconnect_sysml_model as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build/sysml-model"]
+	path = build/sysml-model
+	url = https://github.com/mtconnect/mtconnect_sysml_model.git

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,4 +8,24 @@
 		<RepositoryUrl>https://github.com/TrakHound/MTConnect.NET</RepositoryUrl>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 	</PropertyGroup>
+
+	<!--
+	  Suppress SourceLink git-repository discovery when the build/sysml-model
+	  submodule has not been initialized.  Microsoft.Build.Tasks.Git walks the
+	  gitmodules list from the repo root and emits a "could not find .git"
+	  warning for every project when build/sysml-model/.git is absent (the
+	  gitdir pointer is written by "git submodule update"). This happens in
+	  docker bind-mount builds, fresh clones without recurse-submodules, and
+	  contributor worktrees that have not yet initialized the submodule.
+
+	  Setting EnableSourceControlManagerQueries=false tells SourceLink to skip
+	  the git-repository walk entirely; no PDB source-link data is embedded, but
+	  the build is otherwise unaffected.  The flag is only forced off when the
+	  submodule gitdir pointer is absent; Package-configuration CI builds and
+	  initialized developer checkouts are unaffected.
+	-->
+	<PropertyGroup Condition="!Exists('$(MSBuildThisFileDirectory)build/sysml-model/.git')">
+		<EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
+		<EnableSourceLink>false</EnableSourceLink>
+	</PropertyGroup>
 </Project>

--- a/build/MTConnect.NET-SysML-Import/README.md
+++ b/build/MTConnect.NET-SysML-Import/README.md
@@ -20,20 +20,43 @@ You need to run this tool when:
 
 ### 1. Sync the SysML model
 
+The MTConnect SysML XMI is tracked as a submodule under `build/sysml-model/`. Initialize once after cloning the repo, then check out the version tag you want to regen against.
+
 ```bash
-git clone https://github.com/mtconnect/mtconnect_sysml_model /tmp/mtconnect-sysml
-cd /tmp/mtconnect-sysml
-git fetch --tags origin +refs/heads/*:refs/remotes/origin/*
-git checkout v2.7   # or v2.5, v2.6, ... — whatever you want to regen against
-git rev-parse HEAD  # capture the SHA for the regen-provenance doc
+# Run once after the initial clone (or after a `git pull` that updates the submodule pointer):
+git submodule update --init build/sysml-model
+
+# Switch to a different version tag for a per-version regen:
+git -C build/sysml-model checkout v2.7   # or v2.5, v2.6, v2.0, ... — see `git -C build/sysml-model tag`
+git -C build/sysml-model rev-parse HEAD  # capture the SHA for the regen-provenance doc
 ```
+
+The submodule's default tip is the latest published spec tag. The same gitdir backs every worktree the contributor creates with `git worktree add`, so a per-worktree `git submodule update --init build/sysml-model` is enough to populate the path inside the worktree.
+
+For parallel multi-version regens (e.g. re-running the generator across v2.5, v2.6, v2.7 after a template change), create worktrees inside the submodule itself:
+
+```bash
+git -C build/sysml-model worktree add /tmp/sysml-v2.5 v2.5
+git -C build/sysml-model worktree add /tmp/sysml-v2.6 v2.6
+# build/sysml-model itself stays on v2.7
+```
+
+Each `/tmp/sysml-vX.Y/MTConnectSysMLModel.xml` can then be passed to a separate importer invocation in parallel.
 
 ### 2. Run the importer
 
 ```bash
-# From the repo root:
+# From the repo root, after the submodule is checked out:
 dotnet run --project build/MTConnect.NET-SysML-Import \
-    -- --xmi /tmp/mtconnect-sysml/MTConnectSysMLModel.xml \
+    -- --xmi build/sysml-model/MTConnectSysMLModel.xml \
+       --output "$(pwd)"
+```
+
+If running against a side worktree (for multi-version regens):
+
+```bash
+dotnet run --project build/MTConnect.NET-SysML-Import \
+    -- --xmi /tmp/sysml-v2.5/MTConnectSysMLModel.xml \
        --output "$(pwd)"
 ```
 


### PR DESCRIPTION
## Summary

Add `mtconnect_sysml_model` as a tracked git submodule at `build/sysml-model`, pinned to tag `v2.7`. The submodule replaces the prior documented-but-untracked external clone pattern (where contributors had to `git clone https://github.com/mtconnect/mtconnect_sysml_model.git` to some out-of-tree path and pass `--xmi` manually to `MTConnect.NET-SysML-Import`).

## Why

The regen pipeline that builds `Devices/Components/*.g.cs`, `Devices/DataItems/*.g.cs`, the asset / events / samples / conditions hierarchies, and the organizer lists needs a pinned XMI source so the output is reproducible. A submodule makes the version explicit in-tree and ties the commit history of regenerated code to a specific upstream model commit.

## What changed

- `.gitmodules` - new entry registering `build/sysml-model` against `https://github.com/mtconnect/mtconnect_sysml_model.git`.
- `build/sysml-model` - submodule pointer at tag `v2.7` (commit `25796ac59`).
- `build/MTConnect.NET-SysML-Import/README.md` - regen recipe rewritten to reference the in-tree submodule path; the legacy `git clone ... /tmp/mtconnect-sysml` recipe retained as an ad-hoc fallback for one-off regens against an unpinned commit.
