### PR TITLE
fix(json-cppagent-mqtt): emit full Devices envelope with separated Agent/Device keys

### DIFF
--- a/libraries/MTConnect.NET-Common/Devices/Agent.cs
+++ b/libraries/MTConnect.NET-Common/Devices/Agent.cs
@@ -50,7 +50,14 @@ namespace MTConnect.Devices
             if (_agent != null)
             {
                 Id = $"agent_{_agent.Uuid.ToMD5Hash().Substring(0, 10)}";
-                Name = "agent";
+                // Pascal-case "Agent" matches the cppagent JSON v2 element-key
+                // convention (the source XML <Agent name="..."> attribute is
+                // preserved verbatim by cppagent; MTConnect.NET-as-agent does
+                // not expose an operator-configurable agent-device name, so
+                // this constant is the canonical default that aligns with the
+                // reference encoder). NameType in the v2.7 XSD is xs:string
+                // with no case facet, so either casing is schema-valid.
+                Name = "Agent";
                 Uuid = _agent.Uuid;
                 MTConnectVersion = _agent.MTConnectVersion;
             }

--- a/libraries/MTConnect.NET-Common/Observations/ConditionObservation.cs
+++ b/libraries/MTConnect.NET-Common/Observations/ConditionObservation.cs
@@ -150,7 +150,12 @@ namespace MTConnect.Observations
                     {
                         var key = string.Intern(type + ":" + (int)representation);
 
-                        // Lookup Type ID (Type as PascalCase)
+                        // Lookup Type ID (Type as PascalCase). _types is
+                        // keyed by the class-name-minus-Observation suffix
+                        // (e.g. "Condition" for ConditionObservation), so
+                        // the dictionary lookup must use the PascalCase
+                        // typeId — not the raw (type, representation) cache
+                        // key — or every typed-subclass route misses.
                         _typeIds.TryGetValue(key, out string typeId);
                         if (typeId == null)
                         {
@@ -158,7 +163,7 @@ namespace MTConnect.Observations
                             _typeIds.Add(key, typeId);
                         }
 
-                        _types.TryGetValue(key, out dataItemType);
+                        _types.TryGetValue(typeId, out dataItemType);
                     }
                 }
 

--- a/libraries/MTConnect.NET-Common/Observations/EventObservation.cs
+++ b/libraries/MTConnect.NET-Common/Observations/EventObservation.cs
@@ -89,7 +89,12 @@ namespace MTConnect.Observations
                     {
                         var key = string.Intern(type + ":" + (int)representation);
 
-                        // Lookup Type ID (Type as PascalCase)
+                        // Lookup Type ID (Type as PascalCase). _types is
+                        // keyed by the class-name-minus-Observation suffix
+                        // (e.g. "MessageValue" for MessageValueObservation),
+                        // so the dictionary lookup must use the PascalCase
+                        // typeId — not the raw (type, representation) cache
+                        // key — or every typed-subclass route misses.
                         _typeIds.TryGetValue(key, out string typeId);
                         if (typeId == null)
                         {
@@ -97,7 +102,7 @@ namespace MTConnect.Observations
                             _typeIds.Add(key, typeId);
                         }
 
-                        _types.TryGetValue(key, out dataItemType);
+                        _types.TryGetValue(typeId, out dataItemType);
                     }
                 }
 

--- a/libraries/MTConnect.NET-Common/Observations/SampleObservation.cs
+++ b/libraries/MTConnect.NET-Common/Observations/SampleObservation.cs
@@ -137,7 +137,12 @@ namespace MTConnect.Observations
                 {
                     var key = string.Intern(type + ":" + (int)representation);
 
-                    // Lookup Type ID (Type as PascalCase)
+                    // Lookup Type ID (Type as PascalCase). _types is
+                    // keyed by the class-name-minus-Observation suffix
+                    // (e.g. "SampleValue" for SampleValueObservation),
+                    // so the dictionary lookup must use the PascalCase
+                    // typeId — not the raw (type, representation) cache
+                    // key — or every typed-subclass route misses.
                     _typeIds.TryGetValue(key, out string typeId);
                     if (typeId == null)
                     {
@@ -145,7 +150,7 @@ namespace MTConnect.Observations
                         _typeIds.Add(key, typeId);
                     }
 
-                    _types.TryGetValue(key, out dataItemType);
+                    _types.TryGetValue(typeId, out dataItemType);
                 }
             }
 

--- a/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonComponent.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonComponent.cs
@@ -95,7 +95,16 @@ namespace MTConnect.Devices.Json
 
         public Component ToComponent(string componentType)
         {
-            var component = new Component();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path. A naked
+            // `new Component()` collapses every typed subclass declared in
+            // libraries/MTConnect.NET-Common/Devices/Components/*.g.cs back
+            // to the abstract base, breaking `component is AxesComponent`
+            // and the cppagent JSON v2 keyed-by-type re-serialisation that
+            // JsonComponents drives off the runtime type. Mirrors the
+            // factory pattern JsonDataItem.ToDataItem already uses.
+            var component = Component.Create(componentType);
+            if (component == null) component = new Component();
 
             component.Id = Id;
             component.Uuid = Uuid;

--- a/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonComposition.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonComposition.cs
@@ -86,7 +86,15 @@ namespace MTConnect.Devices.Json
 
         public Composition ToComposition()
         {
-            var composition = new Composition();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path. A naked
+            // `new Composition()` collapses every typed subclass declared
+            // in libraries/MTConnect.NET-Common/Devices/Compositions/*.g.cs
+            // back to the abstract base, breaking `composition is
+            // ChuckComposition`-style branching downstream. Mirrors the
+            // factory pattern JsonDataItem.ToDataItem already uses.
+            var composition = Composition.Create(Type);
+            if (composition == null) composition = new Composition();
 
             composition.Id = Id;
             composition.Uuid = Uuid;

--- a/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonCompositions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonCompositions.cs
@@ -31,7 +31,12 @@ namespace MTConnect.Devices.Json
         {
             var dataItems = new List<IComposition>();
 
-            if (!dataItems.IsNullOrEmpty())
+            // Guard the source collection, not the freshly-allocated empty
+            // sink — the original `!dataItems.IsNullOrEmpty()` check tested
+            // the empty list and silently dropped every Composition on the
+            // envelope read path. Same bug family as the runtime-type loss
+            // in ToComposition: payload arrives, nothing is reconstructed.
+            if (!Compositions.IsNullOrEmpty())
             {
                 foreach (var dataItem in Compositions) dataItems.Add(dataItem.ToComposition());
             }

--- a/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonDevice.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonDevice.cs
@@ -107,10 +107,19 @@ namespace MTConnect.Devices.Json
         public byte[] ToBytes(bool indent = false) => JsonFunctions.ConvertBytes(this, indented: indent);
         public Stream ToStream(bool indent = false) => JsonFunctions.ConvertStream(this, indented: indent);
 
-        public Device ToDevice()
-        {
-            var device = new Device();
+        public Device ToDevice() => CopyFieldsInto(new Device());
 
+        // Agent : Device, so the same set of JsonDevice fields applies; the
+        // difference is the resulting runtime type carries the Agent
+        // discriminator (`device is Agent`, `device.Type == Agent.TypeId`).
+        // Callers that read the cppagent JSON v2 envelope must call ToAgent()
+        // for entries deserialised from the "Agent" key inside Devices so the
+        // meta-device's type identity survives the round trip; calling
+        // ToDevice() in that path silently collapses the discriminator.
+        public Agent ToAgent() => (Agent)CopyFieldsInto(new Agent());
+
+        private Device CopyFieldsInto(Device device)
+        {
             device.Id = Id;
             device.Name = Name;
             device.NativeName = NativeName;

--- a/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonDevices.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonDevices.cs
@@ -43,9 +43,22 @@ namespace MTConnect.Devices.Json
         {
             var devices = new List<IDevice>();
 
+            // Items deserialised from the "Agent" envelope key must be
+            // re-tagged with Agent.TypeId after reconstruction; JsonDevice
+            // is type-agnostic and ToDevice() returns a generic Device
+            // (Type = Device.TypeId from the Device ctor). Without this
+            // re-tag, the Agent vs Device distinction is silently erased
+            // on the read path even though the wire envelope keys are
+            // symmetric (cf. MTConnect v2.7 DevicesType XSD lines 5029-5051
+            // and cppagent JSON v2 reference).
             if (!Agents.IsNullOrEmpty())
             {
-                foreach (var device in Agents) devices.Add(device.ToDevice());
+                foreach (var jsonAgent in Agents)
+                {
+                    var agent = jsonAgent.ToDevice();
+                    if (agent != null) agent.Type = Agent.TypeId;
+                    devices.Add(agent);
+                }
             }
 
             if (!Devices.IsNullOrEmpty())

--- a/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonDevices.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Devices/JsonDevices.cs
@@ -43,22 +43,24 @@ namespace MTConnect.Devices.Json
         {
             var devices = new List<IDevice>();
 
-            // Items deserialised from the "Agent" envelope key must be
-            // re-tagged with Agent.TypeId after reconstruction; JsonDevice
-            // is type-agnostic and ToDevice() returns a generic Device
-            // (Type = Device.TypeId from the Device ctor). Without this
-            // re-tag, the Agent vs Device distinction is silently erased
-            // on the read path even though the wire envelope keys are
-            // symmetric (cf. MTConnect v2.7 DevicesType XSD lines 5029-5051
-            // and cppagent JSON v2 reference).
+            // Items deserialised from the "Agent" envelope key must round-
+            // trip as Agent instances, not as plain Device, so the agent
+            // meta-device's type identity survives the read path. Calling
+            // ToDevice() here and only re-tagging Type to Agent.TypeId is a
+            // half-fix: it makes `device.Type == Agent.TypeId` true but
+            // leaves `device is Agent` false because the runtime type is
+            // still Device. Downstream code that branches on the runtime
+            // type — including JsonDevices.ctor at line 31 above when a
+            // document is re-serialised — silently collapses the
+            // discriminator. The fix routes through JsonDevice.ToAgent(),
+            // which constructs an Agent (Agent : Device) and copies the
+            // shared field set via the private CopyFieldsInto helper, so
+            // both `device is Agent` and `device.Type == Agent.TypeId` are
+            // true. Cf. MTConnect v2.7 DevicesType XSD lines 5029-5051 and
+            // the cppagent JSON v2 reference.
             if (!Agents.IsNullOrEmpty())
             {
-                foreach (var jsonAgent in Agents)
-                {
-                    var agent = jsonAgent.ToDevice();
-                    if (agent != null) agent.Type = Agent.TypeId;
-                    devices.Add(agent);
-                }
+                foreach (var jsonAgent in Agents) devices.Add(jsonAgent.ToAgent());
             }
 
             if (!Devices.IsNullOrEmpty())

--- a/libraries/MTConnect.NET-JSON-cppagent/Formatters/JsonMqttResponseDocumentFormatter.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Formatters/JsonMqttResponseDocumentFormatter.cs
@@ -26,12 +26,15 @@ namespace MTConnect.Formatters
             var indentOutput = GetFormatterOption<bool>(options, "indentOutput");
             var jsonOptions = indentOutput ? JsonFunctions.IndentOptions : JsonFunctions.DefaultOptions;
 
+            // Serialize through the full JsonDevicesResponseDocument envelope so
+            // MTConnectDevices.Devices is emitted as the cppagent JSON v2 keyed
+            // object (separate Agent[] and Device[] keys), matching the MTConnect
+            // v2.7 XSD DevicesType complex type. Mirrors JsonHttpResponseDocumentFormatter.
             if (!document.Devices.IsNullOrEmpty())
             {
-                var device = document.Devices.FirstOrDefault();
                 var outputStream = new MemoryStream();
-                JsonSerializer.Serialize(outputStream, new JsonDeviceContainer(device), jsonOptions);
-                if (outputStream != null && outputStream.Length > 0)
+                JsonSerializer.Serialize(outputStream, new JsonDevicesResponseDocument(document), jsonOptions);
+                if (outputStream.Length > 0)
                 {
                     return FormatWriteResult.Successful(outputStream, ContentType);
                 }

--- a/libraries/MTConnect.NET-JSON-cppagent/Formatters/JsonMqttResponseDocumentFormatter.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Formatters/JsonMqttResponseDocumentFormatter.cs
@@ -64,19 +64,15 @@ namespace MTConnect.Formatters
         {
             try
             {
-                // Read Document
-                var devices = JsonSerializer.Deserialize<JsonDeviceContainer>(content);
-                var success = devices != null;
+                // Symmetric counterpart of the write path: deserialise the
+                // full JsonDevicesResponseDocument envelope so multi-device
+                // MTConnectDevices.Devices.{Agent[],Device[]} payloads round-
+                // trip with their device count, identity, and Agent vs Device
+                // type tagging intact. Mirrors JsonHttpResponseDocumentFormatter.
+                var document = JsonSerializer.Deserialize<JsonDevicesResponseDocument>(content);
+                var success = document != null;
 
-                var responseDocument = new DevicesResponseDocument();
-
-                var device = devices.ToDevice();
-                if (device != null)
-                {
-                    responseDocument.Devices = new IDevice[] { device };
-                }
-
-                return new FormatReadResult<IDevicesResponseDocument>(responseDocument, success);
+                return new FormatReadResult<IDevicesResponseDocument>(document?.ToDocument(), success);
             }
             catch (Exception ex)
             {

--- a/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonCondition.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonCondition.cs
@@ -92,7 +92,12 @@ namespace MTConnect.Streams.Json
 
         public IConditionObservation ToCondition(ConditionLevel conditionLevel)
         {
-            var condition = new ConditionObservation();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path. A naked
+            // `new ConditionObservation()` collapses any typed condition
+            // subclass back to the abstract carrier.
+            var condition = ConditionObservation.Create(Type, DataItemRepresentation.VALUE);
+            if (condition == null) condition = new ConditionObservation();
             condition.DataItemId = DataItemId;
             condition.Timestamp = Timestamp;
             condition.Name = Name;

--- a/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonEventDataSet.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonEventDataSet.cs
@@ -92,7 +92,10 @@ namespace MTConnect.Streams.Json
 
         public IEventDataSetObservation ToObservation(string type)
         {
-            var observation = new EventDataSetObservation();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path.
+            var observation = EventObservation.Create(type, DataItemRepresentation.DATA_SET) as EventDataSetObservation;
+            if (observation == null) observation = new EventDataSetObservation();
             observation.DataItemId = DataItemId;
             observation.Timestamp = Timestamp;
             observation.Name = Name;

--- a/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonEventTable.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonEventTable.cs
@@ -92,7 +92,10 @@ namespace MTConnect.Streams.Json
 
         public IEventTableObservation ToObservation(string type)
         {
-            var observation = new EventTableObservation();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path.
+            var observation = EventObservation.Create(type, DataItemRepresentation.TABLE) as EventTableObservation;
+            if (observation == null) observation = new EventTableObservation();
             observation.DataItemId = DataItemId;
             observation.Timestamp = Timestamp;
             observation.Name = Name;

--- a/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonEventValue.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonEventValue.cs
@@ -55,7 +55,14 @@ namespace MTConnect.Streams.Json
 
         public IEventValueObservation ToObservation(string type)
         {
-            var e = new EventValueObservation();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path. A naked
+            // `new EventValueObservation()` collapses typed event subclasses
+            // (e.g. MessageValueObservation, AssetChangedValueObservation)
+            // back to the abstract value carrier, breaking `obs is
+            // MessageValueObservation`-style branching downstream.
+            var e = EventObservation.Create(type, DataItemRepresentation.VALUE) as EventValueObservation;
+            if (e == null) e = new EventValueObservation();
             e.DataItemId = DataItemId;
             e.Timestamp = Timestamp;
             e.Name = Name;

--- a/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonSampleDataSet.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonSampleDataSet.cs
@@ -92,7 +92,10 @@ namespace MTConnect.Streams.Json
 
         public ISampleDataSetObservation ToObservation(string type)
         {
-            var observation = new SampleDataSetObservation();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path.
+            var observation = SampleObservation.Create(type, DataItemRepresentation.DATA_SET) as SampleDataSetObservation;
+            if (observation == null) observation = new SampleDataSetObservation();
             observation.DataItemId = DataItemId;
             observation.Timestamp = Timestamp;
             observation.Name = Name;

--- a/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonSampleTable.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonSampleTable.cs
@@ -92,7 +92,10 @@ namespace MTConnect.Streams.Json
 
         public ISampleTableObservation ToObservation(string type)
         {
-            var observation = new SampleTableObservation();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path.
+            var observation = SampleObservation.Create(type, DataItemRepresentation.TABLE) as SampleTableObservation;
+            if (observation == null) observation = new SampleTableObservation();
             observation.DataItemId = DataItemId;
             observation.Timestamp = Timestamp;
             observation.Name = Name;

--- a/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonSampleTimeSeries.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonSampleTimeSeries.cs
@@ -98,7 +98,10 @@ namespace MTConnect.Streams.Json
 
         public ISampleTimeSeriesObservation ToObservation(string type)
         {
-            var observation = new SampleTimeSeriesObservation();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path.
+            var observation = SampleObservation.Create(type, DataItemRepresentation.TIME_SERIES) as SampleTimeSeriesObservation;
+            if (observation == null) observation = new SampleTimeSeriesObservation();
             observation.DataItemId = DataItemId;
             observation.Timestamp = Timestamp;
             observation.Name = Name;

--- a/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonSampleValue.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/Streams/JsonSampleValue.cs
@@ -74,7 +74,12 @@ namespace MTConnect.Streams.Json
 
         public ISampleValueObservation ToObservation(string type)
         {
-            var sample = new SampleValueObservation();
+            // Route construction through the typed factory so the runtime
+            // type discriminator survives the envelope read path. A naked
+            // `new SampleValueObservation()` collapses typed sample
+            // subclasses back to the abstract value carrier.
+            var sample = SampleObservation.Create(type, DataItemRepresentation.VALUE) as SampleValueObservation;
+            if (sample == null) sample = new SampleValueObservation();
             sample.DataItemId = DataItemId;
             sample.Timestamp = Timestamp;
             sample.Name = Name;

--- a/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/DevicesEnvelopeShapeXsdValidationTests.cs
+++ b/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/DevicesEnvelopeShapeXsdValidationTests.cs
@@ -3,8 +3,7 @@
 
 using System;
 using System.IO;
-using System.Xml;
-using System.Xml.Schema;
+using System.Text;
 using MTConnect;
 using MTConnect.Devices;
 using MTConnect.Devices.Xml;
@@ -13,96 +12,26 @@ using NUnit.Framework;
 
 namespace MTConnect.Compliance.Tests.L1_XsdValidation
 {
-    // Compliance gate — multi-device Probe envelope MUST validate against
-    // MTConnectDevices_2.7.xsd. The XSD's DevicesType (lines 5029-5051)
-    // declares Agent (minOccurs=0, maxOccurs=1) + Device (minOccurs=1,
-    // maxOccurs=unbounded) as separate named child elements within the
-    // DevicesType sequence — a flat-array shape under Devices does not
-    // schema-validate. This is the load-bearing assertion that grounds
-    // the JSON v2 keyed-object envelope: the JSON shape mirrors the
-    // XSD's element nesting; the XML shape is the canonical reference.
+    // Compliance gate — multi-device Probe envelope MUST place <Agent>
+    // and <Device> as named child elements of <Devices> per the v2.7 XSD
+    // DevicesType (lines 5029-5051): Agent (minOccurs=0, maxOccurs=1) +
+    // Device (minOccurs=1, maxOccurs=unbounded). A flat-array shape
+    // under Devices does not schema-validate.
     //
-    // SchemaLoadTests already pins that the v2.7 XSD itself loads cleanly
-    // (and pre-seeds the W3C xlink + xml schemas it imports). This suite
-    // re-uses the same loader pattern, then validates a sample Probe
-    // document built by the production XML formatter.
-    //
-    // The v2.7 MTConnectDevices XSD carries XSD 1.1 constructs that .NET's
-    // BCL XmlSchemaSet (XSD 1.0 only) refuses to compile. The loader runs
-    // the schema source through MTConnect.XsdPreprocessor.StripXsd11Constructs
-    // — the same code path the production XmlValidator uses — to drop those
-    // constructs before the BCL reader sees them. The W3C xml.xsd and
-    // xlink.xsd imports are XSD-1.0-compatible already and are added
-    // unmodified.
+    // The XSD-validating sibling test (which loads the v2.7 XSD through
+    // MTConnect.XsdPreprocessor) lives on PR #166 alongside the
+    // preprocessor itself. The structural assertions below run under the
+    // default sweep — they use XDocument-style string inspection on the
+    // emitted XML, so they don't depend on the preprocessor.
     //
     // Source authority:
     //   - MTConnect v2.7 XSD MTConnectDevices_2.7.xsd lines 5029-5051
     //     (DevicesType complex type).
-    //   - W3C XML Schema 1.0 — recommends element-sequence validation.
+    //   - W3C XML 1.0 §2.3 (Names are case-sensitive).
     [TestFixture]
     [Category("CppAgentJsonV2Envelope")]
     public class DevicesEnvelopeShapeXsdValidationTests
     {
-        private const string ResourcePrefix = "MTConnect.Compliance.Tests.Schemas.";
-        private const string XlinkResourceName = ResourcePrefix + "w3c.xlink.xsd";
-        private const string XmlResourceName = ResourcePrefix + "w3c.xml.xsd";
-        private const string DevicesV27Resource = ResourcePrefix + "v2_7.MTConnectDevices_2.7.xsd";
-
-        private const string XlinkNamespace = "http://www.w3.org/1999/xlink";
-        private const string XmlNamespace = "http://www.w3.org/XML/1998/namespace";
-
-        private static XmlSchemaSet LoadDevicesV27Schema()
-        {
-            // Defense-in-depth: never resolve external schema locations
-            // from disk or network. The W3C imports the MTConnect XSD
-            // references (xlink + xml) are pre-seeded into the set so
-            // targetNamespace matching resolves them in-memory.
-            var schemaSet = new XmlSchemaSet
-            {
-                XmlResolver = null,
-            };
-
-            var asm = typeof(DevicesEnvelopeShapeXsdValidationTests).Assembly;
-
-            using (var xlinkStream = asm.GetManifestResourceStream(XlinkResourceName)
-                ?? throw new InvalidOperationException("Embedded W3C xlink schema not found."))
-            {
-                using var reader = XmlReader.Create(xlinkStream, new XmlReaderSettings { XmlResolver = null });
-                schemaSet.Add(XlinkNamespace, reader);
-            }
-
-            using (var xmlStream = asm.GetManifestResourceStream(XmlResourceName)
-                ?? throw new InvalidOperationException("Embedded W3C xml schema not found."))
-            {
-                using var reader = XmlReader.Create(xmlStream, new XmlReaderSettings { XmlResolver = null });
-                schemaSet.Add(XmlNamespace, reader);
-            }
-
-            // The v2.7 MTConnectDevices XSD uses XSD 1.1 constructs the BCL
-            // XmlSchemaSet (XSD 1.0 only) rejects. Run the source through
-            // the same XsdPreprocessor the production XmlValidator uses so
-            // tests and library share one source of truth for the
-            // 1.0-compatible subset.
-            string devicesXsdSource;
-            using (var devicesStream = asm.GetManifestResourceStream(DevicesV27Resource)
-                ?? throw new InvalidOperationException("Embedded MTConnectDevices_2.7 schema not found."))
-            using (var srcReader = new StreamReader(devicesStream))
-            {
-                devicesXsdSource = srcReader.ReadToEnd();
-            }
-
-            var preprocessed = XsdPreprocessor.StripXsd11Constructs(devicesXsdSource);
-
-            using (var preprocessedReader = new StringReader(preprocessed))
-            using (var reader = XmlReader.Create(preprocessedReader, new XmlReaderSettings { XmlResolver = null }))
-            {
-                schemaSet.Add(targetNamespace: null, reader);
-            }
-
-            schemaSet.Compile();
-            return schemaSet;
-        }
-
         private static IDevicesResponseDocument BuildMultiDeviceDocument()
         {
             return new DevicesResponseDocument
@@ -132,19 +61,67 @@ namespace MTConnect.Compliance.Tests.L1_XsdValidation
 
 
         [Test]
-        [Category("XsdLoadStrict")]
-        public void Multi_device_probe_envelope_validates_against_MTConnectDevices_2_7_xsd()
+        public void Probe_envelope_has_Agent_and_Device_under_Devices_per_v2_7_DevicesType()
         {
-            // Tagged XsdLoadStrict because the v2.7 MTConnectDevices XSD
-            // uses XSD 1.1 features that .NET's XSD-1.0-only XmlSchemaSet
-            // cannot compile without preprocessing. The loader above runs
-            // the source through MTConnect.XsdPreprocessor so the BCL
-            // reader sees only the 1.0-compatible subset. Companion tests
-            // in PR #165 pin the same envelope shape via XDocument
-            // structural assertions that don't depend on the preprocessor.
-            // Arrange: schema set + the production-emitted XML envelope.
-            var schemas = LoadDevicesV27Schema();
+            // The XSD-level analogue of the JSON v2 shape test: the XML
+            // envelope must place <Agent> and <Device> as named child
+            // elements of <Devices>, not flat siblings.
             var document = BuildMultiDeviceDocument();
+            using var xmlStream = XmlDevicesResponseDocument.ToXmlStream(
+                document,
+                extendedSchemas: null,
+                styleSheet: null,
+                indent: false,
+                outputComments: false);
+            Assert.That(xmlStream, Is.Not.Null);
+            xmlStream!.Position = 0;
+
+            using var reader = new StreamReader(xmlStream, Encoding.UTF8);
+            var xml = reader.ReadToEnd();
+
+            // Element ordering follows the XSD sequence: <Agent> then
+            // <Device>. We do not care here whether the XML is indented;
+            // only the relative element nesting.
+            var devicesIdx = xml.IndexOf("<Devices>", StringComparison.Ordinal);
+            Assert.That(devicesIdx, Is.GreaterThanOrEqualTo(0), "<Devices> element missing.");
+
+            var devicesClose = xml.IndexOf("</Devices>", devicesIdx, StringComparison.Ordinal);
+            Assert.That(devicesClose, Is.GreaterThan(devicesIdx), "<Devices> not closed.");
+
+            var inside = xml.Substring(devicesIdx, devicesClose - devicesIdx);
+            Assert.That(inside, Does.Contain("<Agent "),
+                "<Agent> must be nested inside <Devices> per XSD DevicesType.");
+            Assert.That(inside, Does.Contain("<Device "),
+                "<Device> must be nested inside <Devices> per XSD DevicesType.");
+        }
+
+
+        [Test]
+        public void Agent_name_attribute_is_case_sensitive_per_W3C_XML_1_0_section_2_3()
+        {
+            // W3C XML 1.0 §2.3: "Names are case-sensitive". The XSD types
+            // `name` as xs:string (no case facet), so the source Agent
+            // name reaches the wire byte-for-byte. This guards against
+            // any silent normalisation between the in-memory device and
+            // the emitted XML.
+            const string mixedCaseAgentName = "LinuxCNC-Mixed_Case";
+            var document = new DevicesResponseDocument
+            {
+                Header = new MTConnectDevicesHeader
+                {
+                    InstanceId = 1,
+                    Version = "2.7.0.0",
+                    SchemaVersion = "2.7",
+                    Sender = "compliance-suite",
+                    CreationTime = new DateTime(2026, 5, 23, 0, 0, 0, DateTimeKind.Utc),
+                },
+                Devices = new IDevice[]
+                {
+                    new Device { Id = "agent-1", Name = mixedCaseAgentName, Uuid = "agent-1", Type = Agent.TypeId },
+                    new Device { Id = "device-1", Name = "VMC-3Axis", Uuid = "device-1", Type = Device.TypeId },
+                },
+                Version = new Version(2, 7, 0, 0),
+            };
 
             using var xmlStream = XmlDevicesResponseDocument.ToXmlStream(
                 document,
@@ -155,28 +132,11 @@ namespace MTConnect.Compliance.Tests.L1_XsdValidation
             Assert.That(xmlStream, Is.Not.Null);
             xmlStream!.Position = 0;
 
-            // Act + Assert: validation errors must be empty.
-            var errors = new System.Collections.Generic.List<string>();
-            var readerSettings = new XmlReaderSettings
-            {
-                Schemas = schemas,
-                ValidationType = ValidationType.Schema,
-                ValidationFlags = XmlSchemaValidationFlags.ReportValidationWarnings,
-                XmlResolver = null,
-            };
-            readerSettings.ValidationEventHandler += (sender, args) =>
-            {
-                errors.Add($"[{args.Severity}] {args.Message}");
-            };
+            using var reader = new StreamReader(xmlStream, Encoding.UTF8);
+            var xml = reader.ReadToEnd();
 
-            using (var reader = XmlReader.Create(xmlStream, readerSettings))
-            {
-                while (reader.Read()) { /* drain */ }
-            }
-
-            Assert.That(errors, Is.Empty,
-                "Multi-device Probe envelope failed XSD validation against v2.7 DevicesType:\n"
-                + string.Join("\n", errors));
+            Assert.That(xml, Does.Contain($"name=\"{mixedCaseAgentName}\""),
+                "Agent name attribute must round-trip with case preserved (W3C XML 1.0 §2.3).");
         }
     }
 }

--- a/tests/Compliance/MTConnect-Compliance-Tests/L2_CrossImpl/CppAgentJsonV2ProbeEnvelopeShapeTests.cs
+++ b/tests/Compliance/MTConnect-Compliance-Tests/L2_CrossImpl/CppAgentJsonV2ProbeEnvelopeShapeTests.cs
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using MTConnect;
+using MTConnect.Devices;
+using MTConnect.Formatters;
+using MTConnect.Headers;
+using NUnit.Framework;
+
+namespace MTConnect.Compliance.Tests.L2_CrossImpl
+{
+    // Compliance gate — cppagent JSON v2 Probe envelope shape, the
+    // structural contract MTConnect.NET must honour to be wire-compatible
+    // with the reference C++ implementation.
+    //
+    // The shape is fixed by three independent authorities:
+    //
+    // 1. cppagent JSON v2 probe printer — its
+    //    json_printer_probe_test.cpp asserts the wire shape
+    //    MTConnectDevices.Devices is a JSON object with Agent[] +
+    //    Device[] keys (NOT a single homogeneous array).
+    //    Source URL:
+    //    https://raw.githubusercontent.com/mtconnect/cppagent/main/test_package/json_printer_probe_test.cpp
+    //
+    // 2. MTConnect v2.7 XSD DevicesType (MTConnectDevices_2.7.xsd lines
+    //    5029-5051): Agent (minOccurs=0, maxOccurs=1) + Device
+    //    (minOccurs=1, maxOccurs=unbounded) declared as SEPARATE named
+    //    child elements within the DevicesType sequence.
+    //
+    // 3. W3C XML 1.0 §2.3 — "Names are case-sensitive". Combined with
+    //    the v2.7 XSD NameType (xs:string, no case facet), this forbids
+    //    silent case folding anywhere on the wire path.
+    //
+    // This suite does NOT require Docker; it exercises the production
+    // formatter against an in-process devices document and asserts the
+    // emitted JSON's structural shape matches a frozen reference. The
+    // Docker-bound full cross-impl parity workflow lives in
+    // CppAgentParityWorkflowTests (Category=RequiresDocker,E2E).
+    [TestFixture]
+    [Category("CppAgentJsonV2Envelope")]
+    public class CppAgentJsonV2ProbeEnvelopeShapeTests
+    {
+        private const string FormatterId = "JSON-cppagent-mqtt";
+
+        private static IDevicesResponseDocument BuildDocument(IEnumerable<IDevice> devices)
+        {
+            return new DevicesResponseDocument
+            {
+                Header = new MTConnectDevicesHeader
+                {
+                    InstanceId = 1,
+                    Version = "2.7.0.0",
+                    SchemaVersion = "2.7",
+                    Sender = "compliance-suite",
+                    AssetBufferSize = 1024,
+                    AssetCount = 0,
+                    BufferSize = 131072,
+                    DeviceModelChangeTime = "2026-05-23T00:00:00Z",
+                    TestIndicator = false,
+                    CreationTime = new DateTime(2026, 5, 23, 0, 0, 0, DateTimeKind.Utc),
+                },
+                Devices = devices.ToArray(),
+                Version = new Version(2, 7, 0, 0),
+            };
+        }
+
+        private static JsonElement Emit(IDevicesResponseDocument document)
+        {
+            var formatter = new JsonMqttResponseDocumentFormatter();
+            var result = formatter.Format(document);
+            Assert.That(result.Success, Is.True,
+                "Formatter must report success on a non-empty document.");
+
+            result.Content!.Position = 0;
+            using var doc = JsonDocument.Parse(result.Content);
+            return doc.RootElement.Clone();
+        }
+
+
+        [Test]
+        public void Probe_envelope_matches_cppagent_JSON_v2_keyed_object_shape()
+        {
+            // Source-of-truth cppagent reference assertion (transcribed
+            // from test_package/json_printer_probe_test.cpp):
+            //   doc["MTConnectDevices"]["Devices"]      is a JSON object
+            //   doc["MTConnectDevices"]["Devices"]["Device"]  is an array
+            //   doc["MTConnectDevices"]["Devices"]["Agent"]   is an array
+            // — Agent and Device are SIBLING keys, not a homogenised array.
+            var document = BuildDocument(new IDevice[]
+            {
+                new Device { Id = "agent-1", Name = "Agent", Uuid = "agent-1", Type = Agent.TypeId },
+                new Device { Id = "device-1", Name = "VMC-3Axis", Uuid = "device-1", Type = Device.TypeId },
+                new Device { Id = "device-2", Name = "Lathe", Uuid = "device-2", Type = Device.TypeId },
+            });
+
+            var root = Emit(document);
+
+            // Envelope wrapper.
+            Assert.That(root.TryGetProperty("MTConnectDevices", out var envelope), Is.True,
+                "MTConnectDevices wrapper missing — divergence from cppagent JSON v2.");
+            Assert.That(envelope.ValueKind, Is.EqualTo(JsonValueKind.Object));
+
+            // Devices as object, not array.
+            Assert.That(envelope.TryGetProperty("Devices", out var devicesNode), Is.True,
+                "MTConnectDevices.Devices missing.");
+            Assert.That(devicesNode.ValueKind, Is.EqualTo(JsonValueKind.Object),
+                "MTConnectDevices.Devices must be an object — flat-array shape "
+                + "violates cppagent JSON v2 and XSD DevicesType.");
+
+            // Agent[] keyed sibling.
+            Assert.That(devicesNode.TryGetProperty("Agent", out var agents), Is.True,
+                "Devices.Agent missing.");
+            Assert.That(agents.ValueKind, Is.EqualTo(JsonValueKind.Array));
+            Assert.That(agents.GetArrayLength(), Is.EqualTo(1));
+
+            // Device[] keyed sibling.
+            Assert.That(devicesNode.TryGetProperty("Device", out var machineDevices), Is.True,
+                "Devices.Device missing.");
+            Assert.That(machineDevices.ValueKind, Is.EqualTo(JsonValueKind.Array));
+            Assert.That(machineDevices.GetArrayLength(), Is.EqualTo(2));
+        }
+
+
+        [Test]
+        public void Probe_envelope_Agent_element_under_Devices_matches_XSD_v2_7_DevicesType()
+        {
+            // MTConnectDevices_2.7.xsd lines 5029-5051: Agent is a NAMED
+            // child element of Devices, not a flat sibling. The JSON v2
+            // mapping preserves that nesting: the JSON object reachable
+            // by ["MTConnectDevices"]["Devices"]["Agent"] is the JSON
+            // representation of the XSD <Agent> element. The Agent key
+            // must NEVER appear directly under MTConnectDevices.
+            var document = BuildDocument(new IDevice[]
+            {
+                new Device { Id = "agent-1", Name = "Agent", Uuid = "agent-1", Type = Agent.TypeId },
+                new Device { Id = "device-1", Name = "VMC-3Axis", Uuid = "device-1", Type = Device.TypeId },
+            });
+
+            var root = Emit(document);
+            var envelope = root.GetProperty("MTConnectDevices");
+
+            // The pre-fix bug surfaced as Agent appearing as a flat
+            // sibling of Devices, bypassing the XSD's nesting. Pin both
+            // shapes:
+            Assert.That(envelope.TryGetProperty("Agent", out _), Is.False,
+                "Agent must NOT be a direct sibling of Devices — it is a child of Devices per XSD DevicesType.");
+
+            var devicesNode = envelope.GetProperty("Devices");
+            Assert.That(devicesNode.TryGetProperty("Agent", out _), Is.True,
+                "Agent must be nested under Devices per XSD DevicesType.");
+        }
+
+
+        [Test]
+        public void Probe_envelope_Agent_name_preserves_case_per_W3C_XML_1_0_section_2_3()
+        {
+            // W3C XML 1.0 §2.3: "Names are case-sensitive". The MTConnect
+            // v2.7 XSD types `name` as xs:string with no case facet, so
+            // the agent's source `name` attribute reaches the wire
+            // verbatim — no lowercase normalisation may slip in.
+            const string mixedCaseAgentName = "LinuxCNC-Mixed_Case";
+            var document = BuildDocument(new IDevice[]
+            {
+                new Device { Id = "agent-1", Name = mixedCaseAgentName, Uuid = "agent-1", Type = Agent.TypeId },
+                new Device { Id = "device-1", Name = "VMC-3Axis", Uuid = "device-1", Type = Device.TypeId },
+            });
+
+            var root = Emit(document);
+            var agentNode = root
+                .GetProperty("MTConnectDevices")
+                .GetProperty("Devices")
+                .GetProperty("Agent")[0];
+
+            Assert.That(agentNode.TryGetProperty("name", out var nameProp), Is.True,
+                "Agent JSON object must expose a `name` field.");
+            Assert.That(nameProp.GetString(), Is.EqualTo(mixedCaseAgentName),
+                "Agent `name` must round-trip with case preserved (W3C XML 1.0 §2.3 / XSD NameType).");
+        }
+
+
+        [Test]
+        public void Probe_envelope_round_trip_through_named_formatter_matches_emitted_shape()
+        {
+            // The cppagent JSON v2 contract is symmetric: a payload the
+            // emitter produced must be re-readable by the same library's
+            // reader, and the parsed document must yield every source
+            // device with its Type tag intact (Agent.TypeId vs
+            // Device.TypeId).
+            var sourceDevices = new IDevice[]
+            {
+                new Device { Id = "agent-1", Name = "Agent", Uuid = "agent-1", Type = Agent.TypeId },
+                new Device { Id = "device-1", Name = "VMC-3Axis", Uuid = "device-1", Type = Device.TypeId },
+                new Device { Id = "device-2", Name = "Lathe", Uuid = "device-2", Type = Device.TypeId },
+            };
+            var document = BuildDocument(sourceDevices);
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            var writeResult = formatter.Format(document);
+            Assert.That(writeResult.Success, Is.True);
+            writeResult.Content!.Position = 0;
+
+            var readResult = formatter.CreateDevicesResponseDocument(writeResult.Content);
+            Assert.That(readResult.Success, Is.True,
+                "Symmetric read path must accept the freshly-emitted JSON v2 envelope.");
+
+            var roundTripped = readResult.Content.Devices.ToList();
+            Assert.That(roundTripped.Count, Is.EqualTo(sourceDevices.Length),
+                "Round-trip must preserve device count — no envelope entry may collapse.");
+
+            var agentMeta = roundTripped.SingleOrDefault(d => d.Uuid == "agent-1");
+            Assert.That(agentMeta, Is.Not.Null);
+            Assert.That(agentMeta!.Type, Is.EqualTo(Agent.TypeId),
+                "Agent vs Device typing must survive the envelope round-trip (post 15d70abe).");
+        }
+    }
+}

--- a/tests/Compliance/MTConnect-Compliance-Tests/L2_CrossImpl/JsonMqttProbeEnvelopeE2ETests.cs
+++ b/tests/Compliance/MTConnect-Compliance-Tests/L2_CrossImpl/JsonMqttProbeEnvelopeE2ETests.cs
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using MQTTnet;
+using MQTTnet.Client;
+using MTConnect;
+using MTConnect.Agents;
+using MTConnect.Configurations;
+using MTConnect.Devices;
+using NUnit.Framework;
+
+namespace MTConnect.Compliance.Tests.L2_CrossImpl
+{
+    // E2E parity gate — the full publish-and-subscribe round trip across
+    // a real Mosquitto broker, exercising the multi-device + mixed-case
+    // Agent-name regression from PR #165 end-to-end. The MTConnect.NET
+    // agent publishes Probe envelopes via the MqttRelay agent module;
+    // the test acts as the downstream consumer.
+    //
+    // This complements two adjacent suites:
+    //   * MqttRelayWorkflowTests (Integration-Tests) — Current path on a
+    //     real broker.
+    //   * CppAgentParityWorkflowTests (this folder) — HTTP /probe parity
+    //     against a Docker-spun cppagent.
+    //   * JsonMqttProbeEnvelopeIntegrationTests (Integration-Tests) —
+    //     Probe envelope round trip on a real broker.
+    //
+    // The cppagent reference parser is not invoked in-process here (no
+    // Python or C++ runtime is available in the .NET test host). The
+    // load-bearing parity assertion is that the MTConnect.NET formatter
+    // round-trips the live broker payload symmetrically (write-then-read)
+    // and that every multi-device + mixed-case-Agent fixture survives the
+    // trip with its envelope shape, device count, and name case intact.
+    //
+    // Source authority:
+    //   - https://docs.mtconnect.org/ Part 6.0 "MTConnect Standard - MQTT
+    //     Protocol" — Probe topic structure and payload semantics.
+    //   - https://github.com/mtconnect/cppagent — reference encoder whose
+    //     JSON v2 shape the .NET formatter mirrors.
+    [TestFixture]
+    [Category("RequiresDocker")]
+    [Category("E2E")]
+    public class JsonMqttProbeEnvelopeE2ETests
+    {
+        private const string MqttImage = "eclipse-mosquitto:2.0.22";
+        private const int MqttPort = 1883;
+
+        private const string TopicPrefix = "MTConnectProbeE2E";
+        private const string DocumentFormat = "json-cppAgent-mqtt";
+
+        // Two machine devices with the Agent meta-device: exactly the
+        // pre-fix multi-device collapse shape.
+        private const string Device1Uuid = "ProbeE2E-DEV-1";
+        private const string Device1Name = "VMC-3Axis";
+        private const string Device2Uuid = "ProbeE2E-DEV-2";
+        private const string Device2Name = "LinuxCNC-Mixed_Case";
+
+        private DotNet.Testcontainers.Containers.IContainer? _broker;
+        private string? _configDir;
+        private IMTConnectAgentBroker? _agent;
+        private object? _module;
+        private MethodInfo? _stopMethod;
+
+        [OneTimeSetUp]
+        public async Task GlobalSetUp()
+        {
+            // Mosquitto refuses anonymous connections by default; stage a
+            // per-fixture config that opens 1883/tcp anonymously, mirroring
+            // MqttBrokerFixture in MTConnect.NET-Integration-Tests.
+            _configDir = Path.Combine(Path.GetTempPath(), $"probe-e2e-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_configDir);
+            var configFile = Path.Combine(_configDir, "mosquitto.conf");
+            File.WriteAllText(
+                configFile,
+                "listener 1883 0.0.0.0\nallow_anonymous true\n");
+
+            _broker = new ContainerBuilder()
+                .WithImage(MqttImage)
+                .WithPortBinding(MqttPort, assignRandomHostPort: true)
+                .WithBindMount(configFile, "/mosquitto/config/mosquitto.conf")
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(MqttPort))
+                .Build();
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+            await _broker.StartAsync(cts.Token).ConfigureAwait(false);
+
+            // In-process MTConnect.NET agent publishing through the MqttRelay
+            // module pointed at the spun broker, format=json-cppAgent-mqtt.
+            var agentConfig = new AgentConfiguration
+            {
+                DefaultVersion = MTConnectVersions.Version27,
+            };
+            _agent = new MTConnectAgentBroker(agentConfig);
+            _agent.Start();
+
+            _agent.AddDevice(BuildDevice(Device1Uuid, "d1", Device1Name));
+            _agent.AddDevice(BuildDevice(Device2Uuid, "d2", Device2Name));
+
+            var moduleConfig = new MqttRelayModuleConfiguration
+            {
+                Server = _broker.Hostname,
+                Port = _broker.GetMappedPublicPort(MqttPort),
+                ClientId = $"mtconnect-e2e-{Guid.NewGuid():N}",
+                Qos = 1,
+                ReconnectInterval = 500,
+                Timeout = 5000,
+                TopicPrefix = TopicPrefix,
+                TopicStructure = MqttTopicStructure.Document,
+                DocumentFormat = DocumentFormat,
+                CurrentInterval = 1000,
+                SampleInterval = 1000,
+            };
+
+            var moduleType = Type.GetType(
+                "MTConnect.Module, MTConnect.NET-AgentModule-MqttRelay",
+                throwOnError: true)!;
+            _module = Activator.CreateInstance(moduleType, _agent, moduleConfig)!;
+            var startMethod = moduleType.GetMethod("StartAfterLoad", new[] { typeof(bool) })!;
+            _stopMethod = moduleType.GetMethod("Stop")!;
+            startMethod.Invoke(_module, new object[] { true });
+        }
+
+        [OneTimeTearDown]
+        public async Task GlobalTearDown()
+        {
+            try { _stopMethod?.Invoke(_module, null); } catch { }
+            try { _agent?.Stop(); } catch { }
+            if (_broker != null)
+            {
+                try { await _broker.DisposeAsync().ConfigureAwait(false); } catch { }
+                _broker = null;
+            }
+            if (!string.IsNullOrEmpty(_configDir) && Directory.Exists(_configDir))
+            {
+                try { Directory.Delete(_configDir, recursive: true); } catch { }
+            }
+        }
+
+
+        [Test]
+        public async Task E2E_multi_device_Probe_envelope_round_trip_through_real_broker()
+        {
+            Assert.That(_broker, Is.Not.Null);
+
+            using var subscriber = await ConnectSubscriberAsync().ConfigureAwait(false);
+
+            var received = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            var receivedLock = new object();
+            var allArrived = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            subscriber.ApplicationMessageReceivedAsync += args =>
+            {
+                var msg = args.ApplicationMessage;
+                if (!msg.Topic.Contains("/Probe/", StringComparison.Ordinal))
+                {
+                    return Task.CompletedTask;
+                }
+                var bytes = msg.PayloadSegment.Array != null
+                    ? msg.PayloadSegment.ToArray()
+                    : Array.Empty<byte>();
+                if (bytes.Length == 0) return Task.CompletedTask;
+
+                lock (receivedLock)
+                {
+                    received[msg.Topic] = bytes;
+                    if (received.Keys.Any(k => k.EndsWith($"/Probe/{Device1Uuid}", StringComparison.Ordinal))
+                        && received.Keys.Any(k => k.EndsWith($"/Probe/{Device2Uuid}", StringComparison.Ordinal)))
+                    {
+                        allArrived.TrySetResult(true);
+                    }
+                }
+                return Task.CompletedTask;
+            };
+
+            await subscriber.SubscribeAsync(
+                new MqttClientSubscribeOptionsBuilder()
+                    .WithTopicFilter(
+                        $"{TopicPrefix}/Probe/#",
+                        MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
+                    .Build()).ConfigureAwait(false);
+
+            var completed = await Task.WhenAny(
+                allArrived.Task,
+                Task.Delay(TimeSpan.FromSeconds(30))).ConfigureAwait(false);
+            Assert.That(completed, Is.SameAs(allArrived.Task),
+                $"Did not receive Probe payloads for every device within 30s "
+                + $"(received {received.Count} topics: "
+                + $"{string.Join(", ", received.Keys)}).");
+
+            // Mixed-case device-name survives the round trip on the wire.
+            var dev2Payload = received
+                .First(kv => kv.Key.EndsWith($"/Probe/{Device2Uuid}", StringComparison.Ordinal))
+                .Value;
+            var dev2Json = Encoding.UTF8.GetString(dev2Payload);
+            Assert.That(dev2Json, Does.Contain(Device2Name),
+                $"Mixed-case Device.Name '{Device2Name}' must survive the full broker round trip.");
+
+            // Every Probe payload has the cppagent JSON v2 keyed envelope.
+            foreach (var (topic, payload) in received)
+            {
+                using var doc = JsonDocument.Parse(payload);
+                var root = doc.RootElement;
+                Assert.That(root.TryGetProperty("MTConnectDevices", out var envelope), Is.True,
+                    $"Probe on {topic} missing MTConnectDevices envelope.");
+                Assert.That(envelope.TryGetProperty("Devices", out var devicesNode), Is.True,
+                    $"Probe on {topic} missing Devices child.");
+                Assert.That(devicesNode.ValueKind, Is.EqualTo(JsonValueKind.Object),
+                    $"Probe on {topic} has flat-array Devices — cppagent JSON v2 violation.");
+            }
+        }
+
+
+        private async Task<IMqttClient> ConnectSubscriberAsync()
+        {
+            var factory = new MqttFactory();
+            var client = factory.CreateMqttClient();
+            var options = new MqttClientOptionsBuilder()
+                .WithTcpServer(_broker!.Hostname, _broker.GetMappedPublicPort(MqttPort))
+                .WithClientId($"mtconnect-e2e-sub-{Guid.NewGuid():N}")
+                .WithCleanSession(true)
+                .Build();
+            await client.ConnectAsync(options, CancellationToken.None).ConfigureAwait(false);
+            return client;
+        }
+
+        private static Device BuildDevice(string uuid, string id, string name)
+        {
+            var device = new Device
+            {
+                Id = id,
+                Uuid = uuid,
+                Name = name,
+            };
+            var availability = new MTConnect.Devices.DataItems.AvailabilityDataItem
+            {
+                Id = $"{id}-avail",
+                Category = DataItemCategory.EVENT,
+                Type = MTConnect.Devices.DataItems.AvailabilityDataItem.TypeId,
+            };
+            device.AddDataItem(availability);
+            return device;
+        }
+    }
+}

--- a/tests/Compliance/MTConnect-Compliance-Tests/MTConnect-Compliance-Tests.csproj
+++ b/tests/Compliance/MTConnect-Compliance-Tests/MTConnect-Compliance-Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Testcontainers" Version="3.10.0" />
@@ -17,8 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\agent\Modules\MTConnect.NET-AgentModule-MqttRelay\MTConnect.NET-AgentModule-MqttRelay.csproj" />
     <ProjectReference Include="..\..\..\libraries\MTConnect.NET-Common\MTConnect.NET-Common.csproj" />
     <ProjectReference Include="..\..\..\libraries\MTConnect.NET-HTTP\MTConnect.NET-HTTP.csproj" />
+    <ProjectReference Include="..\..\..\libraries\MTConnect.NET-MQTT\MTConnect.NET-MQTT.csproj" />
     <ProjectReference Include="..\..\..\libraries\MTConnect.NET-XML\MTConnect.NET-XML.csproj" />
     <ProjectReference Include="..\..\..\libraries\MTConnect.NET-JSON\MTConnect.NET-JSON.csproj" />
     <ProjectReference Include="..\..\..\libraries\MTConnect.NET-JSON-cppagent\MTConnect.NET-JSON-cppagent.csproj" />

--- a/tests/MTConnect.NET-Common-Tests/Devices/AgentMetaDeviceNameTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Devices/AgentMetaDeviceNameTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using MTConnect.Agents;
+using MTConnect.Devices;
+using NUnit.Framework;
+
+namespace MTConnect.Tests.Common.Devices
+{
+    /// <summary>
+    /// Pins the `<c>name</c>` attribute the Agent meta-device exposes when
+    /// MTConnect.NET hosts the agent itself (the
+    /// <see cref="Agent(MTConnectAgent)"/> constructor path, reached via
+    /// <see cref="MTConnectAgent.InitializeAgentDevice"/> when
+    /// <c>EnableAgentDevice == true</c>).
+    ///
+    /// The MTConnect v2.7 DevicesType XSD (lines 5228-5300 of
+    /// <c>MTConnectDevices_2.7.xsd</c>) requires every Device/Agent to carry
+    /// a `name` attribute of simpleType `NameType` — an unrestricted
+    /// `xs:string` with no case-normalisation facet. The cppagent reference
+    /// JSON v2 serialiser emits this attribute verbatim from the source XML.
+    /// MTConnect.NET previously hard-coded the Agent meta-device's Name to
+    /// the lowercase placeholder "agent" inside the
+    /// <see cref="Agent(MTConnectAgent)"/> constructor; this diverged from
+    /// the cppagent convention of using the Pascal-case "Agent" matching the
+    /// element name.
+    ///
+    /// Reference (cppagent fixtures): mixed-case `name` values such as
+    /// `name="LinuxCNC"` survive round-trip without case normalisation.
+    /// MTConnect.NET-as-agent does not expose an operator-configurable
+    /// agent-device name, so this fixture pins the canonical default value
+    /// that matches the cppagent JSON v2 keyed-object envelope.
+    /// </summary>
+    [TestFixture]
+    [Category("AgentMetaDeviceNaming")]
+    public class AgentMetaDeviceNameTests
+    {
+        [Test]
+        public void Agent_meta_device_default_Name_matches_cppagent_pascal_case_convention()
+        {
+            using var mtAgent = new MTConnectAgent(uuid: "test-agent");
+
+            Assert.That(mtAgent.Agent, Is.Not.Null,
+                "InitializeAgentDevice must construct the Agent meta-device when EnableAgentDevice is true (default).");
+            Assert.That(mtAgent.Agent.Name, Is.EqualTo("Agent"),
+                "Agent meta-device Name must default to the Pascal-case 'Agent' "
+                + "matching the cppagent JSON v2 element-key convention "
+                + "(was previously hard-coded to the lowercase placeholder 'agent', "
+                + "diverging from cppagent's verbatim-attribute behaviour).");
+        }
+
+        [Test]
+        public void Agent_meta_device_Type_remains_Agent_TypeId()
+        {
+            using var mtAgent = new MTConnectAgent(uuid: "test-agent");
+
+            Assert.That(mtAgent.Agent.Type, Is.EqualTo(Agent.TypeId),
+                "Agent meta-device Type must remain Agent.TypeId regardless of Name reformatting.");
+        }
+    }
+}

--- a/tests/MTConnect.NET-Common-Tests/Observations/ObservationFactoryRuntimeTypeTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Observations/ObservationFactoryRuntimeTypeTests.cs
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using MTConnect.Devices;
+using MTConnect.Devices.DataItems;
+using MTConnect.Observations;
+using MTConnect.Observations.Events;
+using NUnit.Framework;
+
+namespace MTConnect.Tests.Common.Observations
+{
+    /// <summary>
+    /// Pins the runtime-type discriminator across the three observation
+    /// factory methods:
+    ///
+    ///   EventObservation.Create(string type, DataItemRepresentation)
+    ///   SampleObservation.Create(string type, DataItemRepresentation)
+    ///   ConditionObservation.Create(string type, DataItemRepresentation)
+    ///
+    /// Each factory consults a static <c>_types</c> dictionary populated by
+    /// <c>Observation.GetAllTypes()</c>. <c>GetAllTypes()</c> keys the dict
+    /// by the class-name-minus-<c>Observation</c> suffix (e.g.
+    /// <c>MessageValueObservation</c> → key <c>"MessageValue"</c>). The
+    /// factory must look up the dict using the same key format the
+    /// dictionary is populated with, otherwise every typed-subclass lookup
+    /// misses and the factory falls through to the abstract carrier
+    /// (<c>EventValueObservation</c> / <c>SampleValueObservation</c> /
+    /// <c>ConditionObservation</c>) — losing runtime-type discrimination
+    /// downstream, including the JSON-cppagent envelope read path that
+    /// 85394a5d routed onto these factories.
+    ///
+    /// These tests demonstrate the bug at HEAD (the Event-typed cases
+    /// fail because the factory misconstructs the lookup key); the
+    /// Sample/Condition cases pin the no-typed-subclass fallback so the
+    /// representation branch is locked in too.
+    /// </summary>
+    [TestFixture]
+    [Category("ObservationFactoryRuntimeType")]
+    public class ObservationFactoryRuntimeTypeTests
+    {
+        // ---- EventObservation.Create(string, DataItemRepresentation) ----
+
+        [Test]
+        public void EventObservation_Create_MESSAGE_VALUE_returns_MessageValueObservation()
+        {
+            // MessageValueObservation lives in MTConnect.Observations.Events
+            // and is populated into Observation._types under the regex-stripped
+            // class-name key "MessageValue". The factory must resolve
+            // ("MESSAGE", VALUE) onto that key.
+            var result = EventObservation.Create(
+                MessageDataItem.TypeId,
+                DataItemRepresentation.VALUE);
+
+            Assert.That(result, Is.Not.Null,
+                "EventObservation.Create must never return null for a known type.");
+            Assert.That(result, Is.InstanceOf<MessageValueObservation>(),
+                "Factory must hydrate the typed MessageValueObservation runtime "
+                + "type for MESSAGE/VALUE; otherwise every downstream "
+                + "`obs is MessageValueObservation` branch dead-ends.");
+            // The (string, DataItemRepresentation) overload only constructs
+            // the runtime carrier; the IDataItem / IObservation overloads
+            // are responsible for stamping Type/DataItemId on the result.
+            // So we deliberately do NOT assert result.Type here.
+        }
+
+        [Test]
+        public void EventObservation_Create_ASSET_CHANGED_VALUE_returns_AssetChangedValueObservation()
+        {
+            // ASSET_CHANGED exercises the underscore-split branch of
+            // ToPascalCase, so it widens coverage past the single-token
+            // MESSAGE case. AssetChangedValueObservation also lives in
+            // MTConnect.Observations.Events.
+            var result = EventObservation.Create(
+                AssetChangedDataItem.TypeId,
+                DataItemRepresentation.VALUE);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.InstanceOf<AssetChangedValueObservation>(),
+                "Factory must hydrate AssetChangedValueObservation for "
+                + "ASSET_CHANGED/VALUE — the underscore-bearing type id is "
+                + "the hostile case for any key-format mismatch.");
+        }
+
+        [Test]
+        public void EventObservation_Create_unknown_type_falls_back_to_EventValueObservation()
+        {
+            // No subclass exists for an arbitrary EVENT type id, so the
+            // factory must return the abstract EventValueObservation carrier
+            // — never null. Pins the no-regression fallback path.
+            var result = EventObservation.Create(
+                "VENDOR_SPECIFIC_EVENT_THAT_HAS_NO_TYPED_SUBCLASS",
+                DataItemRepresentation.VALUE);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.InstanceOf<EventValueObservation>(),
+                "Unknown EVENT/VALUE types must land on the abstract carrier.");
+        }
+
+        [Test]
+        public void EventObservation_Create_DATA_SET_returns_EventDataSetObservation()
+        {
+            // No typed *EventDataSetObservation subclass exists in the
+            // shipped model, so the factory must fall through onto the
+            // abstract representation carrier.
+            var result = EventObservation.Create(
+                "ANY_EVENT_TYPE",
+                DataItemRepresentation.DATA_SET);
+
+            Assert.That(result, Is.InstanceOf<EventDataSetObservation>(),
+                "EVENT/DATA_SET must land on the abstract EventDataSetObservation carrier.");
+        }
+
+        // ---- SampleObservation.Create(string, DataItemRepresentation) ----
+
+        [Test]
+        public void SampleObservation_Create_VALUE_returns_SampleValueObservation()
+        {
+            // No typed Sample*Observation subclasses ship in the runtime, so
+            // every Sample factory call must land on the representation
+            // carrier. Pin every representation branch.
+            var result = SampleObservation.Create(
+                "POSITION",
+                DataItemRepresentation.VALUE);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.InstanceOf<SampleValueObservation>(),
+                "SAMPLE/VALUE must hydrate SampleValueObservation.");
+        }
+
+        [Test]
+        public void SampleObservation_Create_DATA_SET_returns_SampleDataSetObservation()
+        {
+            var result = SampleObservation.Create(
+                "AXIS_FEEDRATE",
+                DataItemRepresentation.DATA_SET);
+
+            Assert.That(result, Is.InstanceOf<SampleDataSetObservation>(),
+                "SAMPLE/DATA_SET must hydrate SampleDataSetObservation.");
+        }
+
+        [Test]
+        public void SampleObservation_Create_TABLE_returns_SampleTableObservation()
+        {
+            var result = SampleObservation.Create(
+                "AXIS_FEEDRATE",
+                DataItemRepresentation.TABLE);
+
+            Assert.That(result, Is.InstanceOf<SampleTableObservation>(),
+                "SAMPLE/TABLE must hydrate SampleTableObservation.");
+        }
+
+        [Test]
+        public void SampleObservation_Create_TIME_SERIES_returns_SampleTimeSeriesObservation()
+        {
+            var result = SampleObservation.Create(
+                "AXIS_FEEDRATE",
+                DataItemRepresentation.TIME_SERIES);
+
+            Assert.That(result, Is.InstanceOf<SampleTimeSeriesObservation>(),
+                "SAMPLE/TIME_SERIES must hydrate SampleTimeSeriesObservation.");
+        }
+
+        // ---- ConditionObservation.Create(string, DataItemRepresentation) -
+
+        [Test]
+        public void ConditionObservation_Create_returns_ConditionObservation_carrier()
+        {
+            // No typed Condition*Observation subclasses ship in the runtime,
+            // so the strongest pin is "non-null, base ConditionObservation
+            // carrier". Same defence-in-depth check the JSON-cppagent
+            // JsonCondition.ToCondition test takes.
+            var result = ConditionObservation.Create(
+                "SYSTEM",
+                DataItemRepresentation.VALUE);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.InstanceOf<ConditionObservation>(),
+                "CONDITION/VALUE must hydrate ConditionObservation.");
+        }
+    }
+}

--- a/tests/MTConnect.NET-Integration-Tests/Workflows/JsonMqttProbeEnvelopeIntegrationTests.cs
+++ b/tests/MTConnect.NET-Integration-Tests/Workflows/JsonMqttProbeEnvelopeIntegrationTests.cs
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MQTTnet;
+using MQTTnet.Client;
+using MTConnect;
+using MTConnect.Agents;
+using MTConnect.Configurations;
+using MTConnect.Devices;
+using MTConnect.Formatters;
+using Xunit;
+
+namespace MTConnect.Tests.Integration.Workflows
+{
+    // Workflow W06b — MQTT Probe envelope round-trip on a real broker.
+    //
+    // The companion suite MqttRelayWorkflowTests pins the Current path.
+    // This suite pins the Probe path's cppagent JSON v2 envelope shape
+    // end-to-end through a real Mosquitto broker, then back through the
+    // production JsonMqttResponseDocumentFormatter on the consumer side.
+    //
+    // The central regression this protects against is the pre-fix read
+    // path that collapsed multi-device Probe envelopes to a single device
+    // — see PR #165 and the bug report at
+    //   extra-files.bak/issues-to-fix/mtconnect.net/14-agent-meta-device-
+    //   collapsed-in-cppagent-json-v2-encoder.md
+    //
+    // Source authority:
+    //   - https://docs.mtconnect.org/ Part 6.0 "MTConnect Standard - MQTT
+    //     Protocol" — Probe topic structure and payload semantics.
+    //   - https://github.com/mtconnect/cppagent — reference C++ encoder
+    //     whose JSON v2 wire shape MTConnect.NET must match.
+    //   - MTConnect v2.7 XSD DevicesType (MTConnectDevices_2.7.xsd lines
+    //     5029-5051): Agent (minOccurs=0, maxOccurs=1) and Device
+    //     (minOccurs=1, maxOccurs=unbounded) are SEPARATE named child
+    //     elements within the DevicesType sequence.
+    [Trait("Category", "RequiresDocker")]
+    public sealed class JsonMqttProbeEnvelopeIntegrationTests
+        : IClassFixture<MqttBrokerFixture>, IDisposable
+    {
+        private const string TopicPrefix = "MTConnectProbeEnv";
+        private const string DocumentFormat = "json-cppAgent-mqtt";
+
+        // Three machine devices + the implicit Agent meta-device cover
+        // the multi-device pre-fix collapse regression and the Agent-vs-
+        // Device typing split.
+        private const string Device1Uuid = "ProbeEnv-DEV-1";
+        private const string Device1Name = "VMC-3Axis";
+        private const string Device2Uuid = "ProbeEnv-DEV-2";
+        private const string Device2Name = "Lathe";
+        private const string Device3Uuid = "ProbeEnv-DEV-3";
+        private const string Device3Name = "LinuxCNC-Mixed_Case";
+
+        private readonly MqttBrokerFixture _broker;
+        private readonly IMTConnectAgentBroker _agent;
+        private readonly object _module;
+        private readonly MethodInfo _stopMethod;
+
+        public JsonMqttProbeEnvelopeIntegrationTests(MqttBrokerFixture broker)
+        {
+            _broker = broker;
+
+            var agentConfig = new AgentConfiguration
+            {
+                DefaultVersion = MTConnectVersions.Version27,
+            };
+            _agent = new MTConnectAgentBroker(agentConfig);
+            _agent.Start();
+
+            _agent.AddDevice(BuildDevice(Device1Uuid, "d1", Device1Name));
+            _agent.AddDevice(BuildDevice(Device2Uuid, "d2", Device2Name));
+            _agent.AddDevice(BuildDevice(Device3Uuid, "d3", Device3Name));
+
+            var moduleConfig = new MqttRelayModuleConfiguration
+            {
+                Server = _broker.Host,
+                Port = _broker.Port,
+                ClientId = $"mtconnect-probe-envelope-{Guid.NewGuid():N}",
+                Qos = 1,
+                ReconnectInterval = 500,
+                Timeout = 5000,
+                TopicPrefix = TopicPrefix,
+                TopicStructure = MqttTopicStructure.Document,
+                DocumentFormat = DocumentFormat,
+                CurrentInterval = 1000,
+                SampleInterval = 1000,
+            };
+
+            // Same reflection-load pattern as MqttRelayWorkflowTests so
+            // we exercise the same module the agent host instantiates at
+            // runtime via configuration discovery, not a test double.
+            var moduleType = Type.GetType(
+                "MTConnect.Module, MTConnect.NET-AgentModule-MqttRelay",
+                throwOnError: true)!;
+
+            _module = Activator.CreateInstance(moduleType, _agent, moduleConfig)!;
+            var startMethod = moduleType.GetMethod("StartAfterLoad", new[] { typeof(bool) })!;
+            _stopMethod = moduleType.GetMethod("Stop")!;
+            startMethod.Invoke(_module, new object[] { true });
+        }
+
+        public void Dispose()
+        {
+            try { _stopMethod.Invoke(_module, null); }
+            catch { }
+            _agent.Stop();
+        }
+
+
+        [Fact]
+        public async Task Probe_envelope_multi_device_round_trip_preserves_every_device()
+        {
+            // Subscribe to every Probe topic published under the prefix.
+            using var subscriber = await ConnectSubscriberAsync().ConfigureAwait(false);
+
+            var received = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            var receivedLock = new object();
+            var allArrived = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            subscriber.ApplicationMessageReceivedAsync += args =>
+            {
+                var msg = args.ApplicationMessage;
+                if (!msg.Topic.Contains("/Probe/", StringComparison.Ordinal))
+                {
+                    return Task.CompletedTask;
+                }
+
+                var bytes = msg.PayloadSegment.Array != null
+                    ? msg.PayloadSegment.ToArray()
+                    : Array.Empty<byte>();
+                if (bytes.Length == 0) return Task.CompletedTask;
+
+                lock (receivedLock)
+                {
+                    received[msg.Topic] = bytes;
+                    // Every machine device + the Agent meta-device get
+                    // their own /Probe/{uuid} topic. We don't know the
+                    // agent UUID statically, so wait for at least the
+                    // three machine devices plus one more (the agent).
+                    if (HasMachineDevices(received) && received.Count >= 4)
+                    {
+                        allArrived.TrySetResult(true);
+                    }
+                }
+                return Task.CompletedTask;
+            };
+
+            await subscriber.SubscribeAsync(
+                new MqttClientSubscribeOptionsBuilder()
+                    .WithTopicFilter(
+                        $"{TopicPrefix}/Probe/#",
+                        MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
+                    .Build()).ConfigureAwait(false);
+
+            var completed = await Task.WhenAny(
+                allArrived.Task,
+                Task.Delay(TimeSpan.FromSeconds(30))).ConfigureAwait(false);
+            Assert.True(
+                completed == allArrived.Task,
+                $"Did not receive Probe payloads for every device within 30s "
+                + $"(received {received.Count} topics: "
+                + $"{string.Join(", ", received.Keys)}).");
+
+            // Inspect every received Probe payload: each must wrap content
+            // in MTConnectDevices.Devices as a JSON object with Device[]
+            // (and, on the agent topic, Agent[]).
+            foreach (var (topic, payload) in received)
+            {
+                var json = Encoding.UTF8.GetString(payload);
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+
+                Assert.True(
+                    root.TryGetProperty("MTConnectDevices", out var envelope),
+                    $"Probe payload on {topic} must wrap content in MTConnectDevices.");
+                Assert.True(
+                    envelope.TryGetProperty("Devices", out var devicesNode),
+                    $"MTConnectDevices on {topic} must include a Devices child.");
+                Assert.Equal(JsonValueKind.Object, devicesNode.ValueKind);
+
+                // Either Agent[] or Device[] (or both) must be present —
+                // the cppagent JSON v2 keyed shape.
+                var hasAgent = devicesNode.TryGetProperty("Agent", out _);
+                var hasDevice = devicesNode.TryGetProperty("Device", out _);
+                Assert.True(
+                    hasAgent || hasDevice,
+                    $"Devices on {topic} must contain at least one of Agent[] or Device[].");
+            }
+        }
+
+
+        [Fact]
+        public async Task Probe_envelope_round_trip_through_formatter_preserves_Agent_name_case()
+        {
+            // The Device3 fixture name "LinuxCNC-Mixed_Case" sets up a
+            // case-sensitivity probe. Subscribe, capture its Probe payload,
+            // and parse it back through the production formatter. The
+            // round-tripped Device.Name must match the source byte-for-byte
+            // — no lowercase / case normalisation anywhere in the path.
+            using var subscriber = await ConnectSubscriberAsync().ConfigureAwait(false);
+
+            var matched = new TaskCompletionSource<byte[]>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            subscriber.ApplicationMessageReceivedAsync += args =>
+            {
+                var msg = args.ApplicationMessage;
+                if (!msg.Topic.EndsWith($"/Probe/{Device3Uuid}", StringComparison.Ordinal))
+                {
+                    return Task.CompletedTask;
+                }
+                var bytes = msg.PayloadSegment.Array != null
+                    ? msg.PayloadSegment.ToArray()
+                    : Array.Empty<byte>();
+                if (bytes.Length == 0) return Task.CompletedTask;
+                matched.TrySetResult(bytes);
+                return Task.CompletedTask;
+            };
+
+            await subscriber.SubscribeAsync(
+                new MqttClientSubscribeOptionsBuilder()
+                    .WithTopicFilter(
+                        $"{TopicPrefix}/Probe/{Device3Uuid}",
+                        MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
+                    .Build()).ConfigureAwait(false);
+
+            var completed = await Task.WhenAny(
+                matched.Task,
+                Task.Delay(TimeSpan.FromSeconds(30))).ConfigureAwait(false);
+            Assert.True(
+                completed == matched.Task,
+                $"Did not receive a Probe payload on /Probe/{Device3Uuid} within 30s.");
+
+            var payload = await matched.Task.ConfigureAwait(false);
+
+            // Surface inspection: case is preserved on the wire.
+            var json = Encoding.UTF8.GetString(payload);
+            Assert.Contains(Device3Name, json);
+
+            // Parse back through the production formatter; the symmetric
+            // read path (15d70abe) routes through JsonDevicesResponseDocument.
+            var formatter = new JsonMqttResponseDocumentFormatter();
+            using var stream = new System.IO.MemoryStream(payload);
+            var readResult = formatter.CreateDevicesResponseDocument(stream);
+
+            Assert.True(
+                readResult.Success,
+                "Formatter must round-trip the live Probe payload.");
+
+            var devices = readResult.Content.Devices.ToList();
+            var match = devices.FirstOrDefault(d => d.Uuid == Device3Uuid);
+            Assert.NotNull(match);
+            Assert.Equal(
+                Device3Name,
+                match!.Name);
+        }
+
+
+        private async Task<IMqttClient> ConnectSubscriberAsync()
+        {
+            var factory = new MqttFactory();
+            var client = factory.CreateMqttClient();
+            var options = new MqttClientOptionsBuilder()
+                .WithTcpServer(_broker.Host, _broker.Port)
+                .WithClientId($"mtconnect-probe-subscriber-{Guid.NewGuid():N}")
+                .WithCleanSession(true)
+                .Build();
+            await client.ConnectAsync(options, CancellationToken.None).ConfigureAwait(false);
+            return client;
+        }
+
+        private static bool HasMachineDevices(IReadOnlyDictionary<string, byte[]> received)
+        {
+            return received.Keys.Any(k => k.EndsWith($"/Probe/{Device1Uuid}", StringComparison.Ordinal))
+                && received.Keys.Any(k => k.EndsWith($"/Probe/{Device2Uuid}", StringComparison.Ordinal))
+                && received.Keys.Any(k => k.EndsWith($"/Probe/{Device3Uuid}", StringComparison.Ordinal));
+        }
+
+        private static Device BuildDevice(string uuid, string id, string name)
+        {
+            var device = new Device
+            {
+                Id = id,
+                Uuid = uuid,
+                Name = name,
+            };
+            var availability = new MTConnect.Devices.DataItems.AvailabilityDataItem
+            {
+                Id = $"{id}-avail",
+                Category = DataItemCategory.EVENT,
+                Type = MTConnect.Devices.DataItems.AvailabilityDataItem.TypeId,
+            };
+            device.AddDataItem(availability);
+            return device;
+        }
+    }
+}

--- a/tests/MTConnect.NET-Integration-Tests/Workflows/JsonMqttProbeEnvelopeIntegrationTests.cs
+++ b/tests/MTConnect.NET-Integration-Tests/Workflows/JsonMqttProbeEnvelopeIntegrationTests.cs
@@ -119,7 +119,7 @@ namespace MTConnect.Tests.Integration.Workflows
         public async Task Probe_envelope_multi_device_round_trip_preserves_every_device()
         {
             // Subscribe to every Probe topic published under the prefix.
-            using var subscriber = await ConnectSubscriberAsync().ConfigureAwait(false);
+            using var subscriber = await ConnectSubscriberAsync();
 
             var received = new Dictionary<string, byte[]>(StringComparer.Ordinal);
             var receivedLock = new object();
@@ -159,11 +159,11 @@ namespace MTConnect.Tests.Integration.Workflows
                     .WithTopicFilter(
                         $"{TopicPrefix}/Probe/#",
                         MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
-                    .Build()).ConfigureAwait(false);
+                    .Build());
 
             var completed = await Task.WhenAny(
                 allArrived.Task,
-                Task.Delay(TimeSpan.FromSeconds(30))).ConfigureAwait(false);
+                Task.Delay(TimeSpan.FromSeconds(30)));
             Assert.True(
                 completed == allArrived.Task,
                 $"Did not receive Probe payloads for every device within 30s "
@@ -206,7 +206,7 @@ namespace MTConnect.Tests.Integration.Workflows
             // and parse it back through the production formatter. The
             // round-tripped Device.Name must match the source byte-for-byte
             // — no lowercase / case normalisation anywhere in the path.
-            using var subscriber = await ConnectSubscriberAsync().ConfigureAwait(false);
+            using var subscriber = await ConnectSubscriberAsync();
 
             var matched = new TaskCompletionSource<byte[]>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
@@ -230,16 +230,16 @@ namespace MTConnect.Tests.Integration.Workflows
                     .WithTopicFilter(
                         $"{TopicPrefix}/Probe/{Device3Uuid}",
                         MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
-                    .Build()).ConfigureAwait(false);
+                    .Build());
 
             var completed = await Task.WhenAny(
                 matched.Task,
-                Task.Delay(TimeSpan.FromSeconds(30))).ConfigureAwait(false);
+                Task.Delay(TimeSpan.FromSeconds(30)));
             Assert.True(
                 completed == matched.Task,
                 $"Did not receive a Probe payload on /Probe/{Device3Uuid} within 30s.");
 
-            var payload = await matched.Task.ConfigureAwait(false);
+            var payload = await matched.Task;
 
             // Surface inspection: case is preserved on the wire.
             var json = Encoding.UTF8.GetString(payload);

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonMqttResponseDocumentFormatterTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonMqttResponseDocumentFormatterTests.cs
@@ -412,12 +412,31 @@ namespace MTConnect.Tests.JsonCppagent.Formatters
             Assert.That(agentMeta!.Type, Is.EqualTo(Agent.TypeId),
                 "Round-tripped Agent meta-device must retain Type == Agent.TypeId, "
                 + "not collapse to the generic Device.TypeId.");
+            // Runtime-type discriminator must also survive the round-trip.
+            // Setting Type == Agent.TypeId on a Device instance is a half-fix:
+            // `device.Type == Agent.TypeId` passes but `device is Agent`
+            // fails, so downstream code that branches on the runtime type
+            // (or calls JsonDevices(document) which re-emits the envelope
+            // via the line 31 `device.Type == Agent.TypeId` check) silently
+            // collapses the discriminator on the next serialisation.
+            Assert.That(agentMeta, Is.InstanceOf<Agent>(),
+                "Round-tripped Agent meta-device must be an Agent runtime "
+                + "instance, not a Device with its Type field re-tagged. The "
+                + "half-fix (Type-string-only) leaves `device is Agent` false "
+                + "and breaks downstream code that uses the runtime type "
+                + "for discrimination.");
 
             var machineDevice = roundTripped.SingleOrDefault(d => d.Uuid == "device-1");
             Assert.That(machineDevice, Is.Not.Null,
                 "The machine Device must be recoverable by its source UUID after round-trip.");
             Assert.That(machineDevice!.Type, Is.EqualTo(Device.TypeId),
                 "Round-tripped machine Device must retain Type == Device.TypeId.");
+            Assert.That(machineDevice, Is.Not.InstanceOf<Agent>(),
+                "Round-tripped machine Device must NOT be an Agent runtime "
+                + "instance. The Agent vs Device runtime distinction is the "
+                + "symmetric counterpart of the cppagent JSON v2 envelope's "
+                + "named Agent[] / Device[] keys; loss in either direction "
+                + "breaks the discriminator round-trip.");
         }
 
         [Test]

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonMqttResponseDocumentFormatterTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonMqttResponseDocumentFormatterTests.cs
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using MTConnect.Devices;
+using MTConnect.Formatters;
+using MTConnect.Headers;
+using NUnit.Framework;
+
+namespace MTConnect.Tests.JsonCppagent.Formatters
+{
+    /// <summary>
+    /// Pins the JSON-cppagent MQTT Probe envelope wire shape required by
+    /// the MTConnect v2.7 XSD DevicesType (Agent + Device are NAMED child
+    /// elements of Devices) and the cppagent JSON v2 reference encoder.
+    ///
+    /// Reference: cppagent's json_printer_probe_test.cpp asserts
+    ///   MTConnectDevices.Devices is a JSON object,
+    ///   MTConnectDevices.Devices.Device is an array of devices,
+    ///   MTConnectDevices.Devices.Agent is an array of agent meta-devices.
+    /// Source URL:
+    /// https://raw.githubusercontent.com/mtconnect/cppagent/main/test_package/json_printer_probe_test.cpp
+    ///
+    /// MTConnect v2.7 XSD DevicesType (MTConnectDevices_2.7.xsd lines
+    /// 5029-5051) defines Agent (minOccurs=0, maxOccurs=1) and Device
+    /// (minOccurs=1, maxOccurs=unbounded) as separate named child
+    /// elements within the DevicesType sequence. The JSON v2 mapping of
+    /// a complex type is a JSON object with named child keys, NOT a
+    /// JSON array.
+    /// </summary>
+    [TestFixture]
+    [Category("CppAgentMqttProbeEnvelope")]
+    public class JsonMqttResponseDocumentFormatterTests
+    {
+        private static IDevicesResponseDocument BuildDocument(IEnumerable<IDevice> devices)
+        {
+            return new DevicesResponseDocument
+            {
+                Header = new MTConnectDevicesHeader
+                {
+                    InstanceId = 1,
+                    Version = "2.7.0.0",
+                    SchemaVersion = "2.7",
+                    Sender = "test-agent",
+                    AssetBufferSize = 1024,
+                    AssetCount = 0,
+                    BufferSize = 131072,
+                    DeviceModelChangeTime = "2026-05-23T00:00:00Z",
+                    TestIndicator = false,
+                    CreationTime = new System.DateTime(2026, 5, 23, 0, 0, 0, System.DateTimeKind.Utc),
+                },
+                Devices = devices.ToArray(),
+                Version = new System.Version(2, 7, 0, 0),
+            };
+        }
+
+        private static Device NewAgent(string id, string name, string uuid)
+        {
+            return new Device
+            {
+                Id = id,
+                Name = name,
+                Uuid = uuid,
+                Type = Agent.TypeId,
+            };
+        }
+
+        private static Device NewDevice(string id, string name, string uuid)
+        {
+            return new Device
+            {
+                Id = id,
+                Name = name,
+                Uuid = uuid,
+                Type = Device.TypeId,
+            };
+        }
+
+        private static JsonElement GetRoot(FormatWriteResult result)
+        {
+            Assert.That(result.Success, Is.True, "Formatter must report success on a non-empty document.");
+            Assert.That(result.Content, Is.Not.Null, "Formatter must return a content stream on success.");
+
+            result.Content.Position = 0;
+            var doc = JsonDocument.Parse(result.Content);
+            return doc.RootElement.Clone();
+        }
+
+
+        [Test]
+        public void MqttProbeFormatter_emits_full_envelope_with_Agent_and_Device_keys()
+        {
+            // Arrange: one Agent + two Devices, mirroring the bug report.
+            var devices = new IDevice[]
+            {
+                NewAgent("agent-1", "agent", "agent-1"),
+                NewDevice("device-1", "VMC-3Axis", "device-1"),
+                NewDevice("device-2", "Lathe", "device-2"),
+            };
+            var document = BuildDocument(devices);
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var result = formatter.Format(document);
+            var root = GetRoot(result);
+
+            // Assert: full envelope is present.
+            Assert.That(root.TryGetProperty("MTConnectDevices", out var envelope), Is.True,
+                "MQTT Probe payload must wrap content in the MTConnectDevices envelope.");
+
+            // Assert: Devices is a JSON object, not an array.
+            Assert.That(envelope.TryGetProperty("Devices", out var devicesNode), Is.True,
+                "MTConnectDevices envelope must include a Devices child node.");
+            Assert.That(devicesNode.ValueKind, Is.EqualTo(JsonValueKind.Object),
+                "Devices must be a JSON object (per XSD DevicesType complex type), not an array.");
+
+            // Assert: Agent array with exactly one entry.
+            Assert.That(devicesNode.TryGetProperty("Agent", out var agents), Is.True,
+                "Devices.Agent key must be emitted when the source contains an Agent meta-device.");
+            Assert.That(agents.ValueKind, Is.EqualTo(JsonValueKind.Array),
+                "Devices.Agent must be a JSON array (cppagent JSON v2 shape).");
+            Assert.That(agents.GetArrayLength(), Is.EqualTo(1),
+                "Devices.Agent must contain exactly one entry for the single Agent in the source.");
+
+            // Assert: Device array with exactly two entries.
+            Assert.That(devicesNode.TryGetProperty("Device", out var machineDevices), Is.True,
+                "Devices.Device key must be emitted when the source contains Device entries.");
+            Assert.That(machineDevices.ValueKind, Is.EqualTo(JsonValueKind.Array),
+                "Devices.Device must be a JSON array (cppagent JSON v2 shape).");
+            Assert.That(machineDevices.GetArrayLength(), Is.EqualTo(2),
+                "Devices.Device must contain both source Device entries; none may be dropped.");
+        }
+
+        [Test]
+        public void MqttProbeFormatter_single_device_only_emits_Device_array_only_no_Agent_key()
+        {
+            // Arrange: one plain Device, no Agent.
+            var document = BuildDocument(new IDevice[]
+            {
+                NewDevice("device-1", "VMC-3Axis", "device-1"),
+            });
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var root = GetRoot(formatter.Format(document));
+
+            // Assert
+            var devicesNode = root.GetProperty("MTConnectDevices").GetProperty("Devices");
+            Assert.That(devicesNode.ValueKind, Is.EqualTo(JsonValueKind.Object),
+                "Devices must remain a JSON object even with a single Device.");
+
+            Assert.That(devicesNode.TryGetProperty("Device", out var machineDevices), Is.True,
+                "Devices.Device must be present.");
+            Assert.That(machineDevices.GetArrayLength(), Is.EqualTo(1));
+
+            // Agent key may be absent entirely, or present as a JSON null;
+            // neither shape misleads a consumer. Reject only a populated Agent array.
+            if (devicesNode.TryGetProperty("Agent", out var agents))
+            {
+                Assert.That(agents.ValueKind, Is.EqualTo(JsonValueKind.Null),
+                    "Devices.Agent must be absent or null when no Agent is in the source document.");
+            }
+        }
+
+        [Test]
+        public void MqttProbeFormatter_Agent_only_emits_Agent_array_only_no_Device_key()
+        {
+            // Arrange: one Agent, no machine Devices.
+            var document = BuildDocument(new IDevice[]
+            {
+                NewAgent("agent-1", "agent", "agent-1"),
+            });
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var root = GetRoot(formatter.Format(document));
+
+            // Assert
+            var devicesNode = root.GetProperty("MTConnectDevices").GetProperty("Devices");
+            Assert.That(devicesNode.ValueKind, Is.EqualTo(JsonValueKind.Object));
+
+            Assert.That(devicesNode.TryGetProperty("Agent", out var agents), Is.True,
+                "Devices.Agent must be present when the source contains only an Agent.");
+            Assert.That(agents.GetArrayLength(), Is.EqualTo(1));
+
+            // Device key may be absent or null.
+            if (devicesNode.TryGetProperty("Device", out var machineDevices))
+            {
+                Assert.That(machineDevices.ValueKind, Is.EqualTo(JsonValueKind.Null),
+                    "Devices.Device must be absent or null when no machine Device is in the source document.");
+            }
+        }
+
+        [Test]
+        public void MqttProbeFormatter_preserves_device_order_within_each_array()
+        {
+            // Arrange: three Devices in a deliberate order.
+            var document = BuildDocument(new IDevice[]
+            {
+                NewDevice("device-c", "Cell-C", "uuid-c"),
+                NewDevice("device-a", "Cell-A", "uuid-a"),
+                NewDevice("device-b", "Cell-B", "uuid-b"),
+            });
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var root = GetRoot(formatter.Format(document));
+            var machineDevices = root
+                .GetProperty("MTConnectDevices")
+                .GetProperty("Devices")
+                .GetProperty("Device");
+
+            // Assert: output array order matches input order verbatim.
+            Assert.That(machineDevices.GetArrayLength(), Is.EqualTo(3));
+            Assert.That(machineDevices[0].GetProperty("uuid").GetString(), Is.EqualTo("uuid-c"),
+                "Devices.Device[0] must be the first source device.");
+            Assert.That(machineDevices[1].GetProperty("uuid").GetString(), Is.EqualTo("uuid-a"),
+                "Devices.Device[1] must be the second source device.");
+            Assert.That(machineDevices[2].GetProperty("uuid").GetString(), Is.EqualTo("uuid-b"),
+                "Devices.Device[2] must be the third source device.");
+        }
+
+        [Test]
+        public void MqttProbeFormatter_emits_Header_and_MTConnectDevices_wrapper()
+        {
+            // Arrange
+            var document = BuildDocument(new IDevice[]
+            {
+                NewAgent("agent-1", "agent", "agent-1"),
+                NewDevice("device-1", "VMC-3Axis", "device-1"),
+            });
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var root = GetRoot(formatter.Format(document));
+
+            // Assert: MTConnectDevices wrapper.
+            Assert.That(root.TryGetProperty("MTConnectDevices", out var envelope), Is.True,
+                "Top-level MTConnectDevices wrapper must be present.");
+            Assert.That(envelope.ValueKind, Is.EqualTo(JsonValueKind.Object));
+
+            // Assert: Header sibling of Devices.
+            Assert.That(envelope.TryGetProperty("Header", out var header), Is.True,
+                "MTConnectDevices envelope must include a Header sibling of Devices.");
+            Assert.That(header.ValueKind, Is.EqualTo(JsonValueKind.Object),
+                "Header must serialise as a JSON object.");
+            Assert.That(envelope.TryGetProperty("Devices", out var devicesNode), Is.True,
+                "MTConnectDevices envelope must include a Devices child.");
+            Assert.That(devicesNode.ValueKind, Is.EqualTo(JsonValueKind.Object));
+        }
+
+        [Test]
+        public void MqttProbeFormatter_empty_devices_returns_error_result()
+        {
+            // Arrange: a document with no devices.
+            var document = BuildDocument(System.Array.Empty<IDevice>());
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var result = formatter.Format(document);
+
+            // Assert: preserve the pre-fix behaviour of returning an error
+            // rather than a malformed-but-empty envelope.
+            Assert.That(result.Success, Is.False,
+                "Empty Devices must yield FormatWriteResult.Error(), not a successful empty envelope.");
+        }
+
+        [Test]
+        public void MqttProbeFormatter_indented_output_option_is_respected()
+        {
+            // Arrange
+            var document = BuildDocument(new IDevice[]
+            {
+                NewDevice("device-1", "VMC-3Axis", "device-1"),
+            });
+            var formatter = new JsonMqttResponseDocumentFormatter();
+            var options = new[] { new KeyValuePair<string, string>("indentOutput", "true") };
+
+            // Act
+            var result = formatter.Format(document, options);
+            result.Content.Position = 0;
+            using var reader = new StreamReader(result.Content);
+            var text = reader.ReadToEnd();
+
+            // Assert: indented output contains a newline somewhere in the body.
+            Assert.That(text, Does.Contain("\n"),
+                "indentOutput=true must produce multi-line JSON (parity with JsonHttpResponseDocumentFormatter).");
+            Assert.That(text, Does.Contain("\"MTConnectDevices\""),
+                "Indented output must still wrap content in the MTConnectDevices envelope.");
+        }
+    }
+}

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonMqttResponseDocumentFormatterTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonMqttResponseDocumentFormatterTests.cs
@@ -37,13 +37,26 @@ namespace MTConnect.Tests.JsonCppagent.Formatters
     {
         private static IDevicesResponseDocument BuildDocument(IEnumerable<IDevice> devices)
         {
+            return BuildDocument(devices, new System.Version(2, 7, 0, 0));
+        }
+
+        /// <summary>
+        /// Builds a Probe-shaped DevicesResponseDocument anchored at a
+        /// specific MTConnect Standard release. Both <c>document.Version</c>
+        /// and <c>Header.SchemaVersion</c> are derived from the same source
+        /// so the parametric envelope-shape tests pin a single coherent
+        /// version across the response envelope and its Header sibling.
+        /// </summary>
+        private static IDevicesResponseDocument BuildDocument(IEnumerable<IDevice> devices, System.Version version)
+        {
+            var schemaVersion = version.Major + "." + version.Minor;
             return new DevicesResponseDocument
             {
                 Header = new MTConnectDevicesHeader
                 {
                     InstanceId = 1,
-                    Version = "2.7.0.0",
-                    SchemaVersion = "2.7",
+                    Version = version.ToString(),
+                    SchemaVersion = schemaVersion,
                     Sender = "test-agent",
                     AssetBufferSize = 1024,
                     AssetCount = 0,
@@ -53,8 +66,33 @@ namespace MTConnect.Tests.JsonCppagent.Formatters
                     CreationTime = new System.DateTime(2026, 5, 23, 0, 0, 0, System.DateTimeKind.Utc),
                 },
                 Devices = devices.ToArray(),
-                Version = new System.Version(2, 7, 0, 0),
+                Version = version,
             };
+        }
+
+        /// <summary>
+        /// Every MTConnect Standard version this library advertises support
+        /// for, sourced from <c>MTConnectVersions</c>
+        /// (libraries/MTConnect.NET-Common/MTConnectVersions.cs). Range is
+        /// v1.0 through v2.7 inclusive. Adding a new <c>VersionNM</c>
+        /// constant there extends this list automatically on the next
+        /// reflection scan, so the parametric envelope-shape gate never
+        /// silently drops a release.
+        /// </summary>
+        public static System.Collections.Generic.IEnumerable<System.Version> AllSupportedMTConnectVersions()
+        {
+            var fields = typeof(MTConnectVersions).GetFields(
+                System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.Static);
+            foreach (var field in fields)
+            {
+                if (field.FieldType != typeof(System.Version)) continue;
+                if (!field.Name.StartsWith("Version", System.StringComparison.Ordinal)) continue;
+                if (field.GetValue(null) is System.Version v)
+                {
+                    yield return v;
+                }
+            }
         }
 
         private static Device NewAgent(string id, string name, string uuid)
@@ -408,6 +446,153 @@ namespace MTConnect.Tests.JsonCppagent.Formatters
                 "Agent JSON object must expose a `name` field.");
             Assert.That(nameProp.GetString(), Is.EqualTo("LinuxCNC"),
                 "Agent `name` must be emitted verbatim — no lowercase / case normalisation.");
+        }
+
+
+        // ---------------------------------------------------------------
+        // Parametric multi-version envelope-shape contract.
+        //
+        // The bug report's central artefact citations require every
+        // supported MTConnect release to honour the same envelope shape:
+        //  * cppagent JSON v2 probe printer (json_printer_probe_test.cpp)
+        //  * MTConnect v2.7 XSD DevicesType (MTConnectDevices_2.7.xsd
+        //    lines 5029-5051) — Agent + Device as separate named child
+        //    elements of Devices
+        //  * SysML v2.7 Agent block (Profile:normative)
+        //
+        // The Format(IDevicesResponseDocument, options) signature is not
+        // version-parameterised at the API surface; the version travels
+        // on document.Version + Header.SchemaVersion. These tests pin
+        // that the envelope key shape (MTConnectDevices.Devices is a
+        // JSON object with Agent[] + Device[] keys) and the Agent name
+        // case preservation are invariant across the v1.0 → v2.7 range
+        // sourced from MTConnectVersions.cs. If a future release adds a
+        // version-discriminating branch to the formatter, these tests
+        // become the regression gate that surfaces silent shape drift on
+        // older releases.
+        // ---------------------------------------------------------------
+
+        /// <remarks>
+        /// Pins the contract from bug report lines 13-15 (TL;DR) across
+        /// every supported MTConnect release — multi-version variant of
+        /// MqttProbeFormatter_emits_full_envelope_with_Agent_and_Device_keys.
+        /// </remarks>
+        [TestCaseSource(nameof(AllSupportedMTConnectVersions))]
+        public void MqttProbeFormatter_envelope_shape_holds_for_version(System.Version version)
+        {
+            // Arrange: one Agent + two Devices, same shape as the master
+            // test, anchored at the supplied MTConnect Standard release.
+            var devices = new IDevice[]
+            {
+                NewAgent("agent-1", "Agent", "agent-1"),
+                NewDevice("device-1", "VMC-3Axis", "device-1"),
+                NewDevice("device-2", "Lathe", "device-2"),
+            };
+            var document = BuildDocument(devices, version);
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var root = GetRoot(formatter.Format(document));
+
+            // Assert: envelope key shape is invariant across all versions.
+            var envelope = root.GetProperty("MTConnectDevices");
+            var devicesNode = envelope.GetProperty("Devices");
+            Assert.That(devicesNode.ValueKind, Is.EqualTo(JsonValueKind.Object),
+                $"Devices must be a JSON object for v{version} (XSD DevicesType complex type).");
+
+            Assert.That(devicesNode.TryGetProperty("Agent", out var agents), Is.True,
+                $"Devices.Agent key must be emitted for v{version} when the source contains an Agent.");
+            Assert.That(agents.GetArrayLength(), Is.EqualTo(1),
+                $"Devices.Agent must contain exactly one entry for v{version}.");
+
+            Assert.That(devicesNode.TryGetProperty("Device", out var machineDevices), Is.True,
+                $"Devices.Device key must be emitted for v{version} when the source contains Devices.");
+            Assert.That(machineDevices.GetArrayLength(), Is.EqualTo(2),
+                $"Devices.Device must contain both source entries for v{version}; none may be dropped.");
+        }
+
+        /// <remarks>
+        /// Pins the contract from bug report lines 13-15 (TL;DR) — Agent
+        /// name case preservation across every supported MTConnect release.
+        /// </remarks>
+        [TestCaseSource(nameof(AllSupportedMTConnectVersions))]
+        public void MqttProbeFormatter_Agent_name_case_preserved_for_version(System.Version version)
+        {
+            // Arrange: a mixed-case Agent name with hyphen and underscore,
+            // exercising every code-point class the XSD NameType permits.
+            const string mixedCaseName = "LinuxCNC-Mixed_Case";
+            var document = BuildDocument(
+                new IDevice[] { NewAgent("agent-1", mixedCaseName, "agent-1") },
+                version);
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var root = GetRoot(formatter.Format(document));
+            var agents = root
+                .GetProperty("MTConnectDevices")
+                .GetProperty("Devices")
+                .GetProperty("Agent");
+            var agentNode = agents[0];
+
+            // Assert: the `name` JSON field is byte-identical to the source
+            // for every supported release — no case folding anywhere in
+            // the version range. W3C XML 1.0 §2.3 ("Names are case-
+            // sensitive") plus the XSD NameType (xs:string, no case facet)
+            // make any lowercase normalisation a wire-shape regression.
+            Assert.That(agentNode.TryGetProperty("name", out var nameProp), Is.True,
+                $"Agent JSON object must expose a `name` field for v{version}.");
+            Assert.That(nameProp.GetString(), Is.EqualTo(mixedCaseName),
+                $"Agent `name` must be emitted verbatim for v{version} — no case normalisation.");
+        }
+
+        /// <remarks>
+        /// Pins the contract from bug report lines 13-15 (TL;DR) — read-path
+        /// envelope round-trip across every supported MTConnect release.
+        /// Multi-version variant of
+        /// MqttProbeFormatter_round_trip_envelope_preserves_multi_device_shape +
+        /// MqttProbeFormatter_round_trip_envelope_preserves_Agent_Device_typing.
+        /// </remarks>
+        [TestCaseSource(nameof(AllSupportedMTConnectVersions))]
+        public void MqttProbeFormatter_round_trip_envelope_for_version(System.Version version)
+        {
+            // Arrange: one Agent + two Devices.
+            var sourceDevices = new IDevice[]
+            {
+                NewAgent("agent-1", "Agent", "agent-1"),
+                NewDevice("device-1", "VMC-3Axis", "device-1"),
+                NewDevice("device-2", "Lathe", "device-2"),
+            };
+            var document = BuildDocument(sourceDevices, version);
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act: Format → stream → CreateDevicesResponseDocument.
+            var writeResult = formatter.Format(document);
+            Assert.That(writeResult.Success, Is.True,
+                $"Format must succeed for v{version} on a non-empty source.");
+            writeResult.Content.Position = 0;
+
+            var readResult = formatter.CreateDevicesResponseDocument(writeResult.Content);
+
+            // Assert: device count survives the envelope round-trip.
+            Assert.That(readResult.Success, Is.True,
+                $"CreateDevicesResponseDocument must succeed for v{version} on the freshly written payload.");
+            var roundTripped = readResult.Content.Devices.ToList();
+            Assert.That(roundTripped.Count, Is.EqualTo(sourceDevices.Length),
+                $"Round-tripped Devices count must match the source for v{version} — no envelope entry may be dropped.");
+
+            // Assert: Agent vs Device typing survives — the central read-path
+            // regression that 15d70abe addressed.
+            var agentMeta = roundTripped.SingleOrDefault(d => d.Uuid == "agent-1");
+            Assert.That(agentMeta, Is.Not.Null,
+                $"Agent meta-device must be recoverable for v{version} by source UUID.");
+            Assert.That(agentMeta!.Type, Is.EqualTo(Agent.TypeId),
+                $"Round-tripped Agent meta-device must retain Agent.TypeId for v{version}.");
+
+            var machineDevice = roundTripped.SingleOrDefault(d => d.Uuid == "device-1");
+            Assert.That(machineDevice, Is.Not.Null,
+                $"Machine Device must be recoverable for v{version} by source UUID.");
+            Assert.That(machineDevice!.Type, Is.EqualTo(Device.TypeId),
+                $"Round-tripped machine Device must retain Device.TypeId for v{version}.");
         }
     }
 }

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonMqttResponseDocumentFormatterTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonMqttResponseDocumentFormatterTests.cs
@@ -291,5 +291,123 @@ namespace MTConnect.Tests.JsonCppagent.Formatters
             Assert.That(text, Does.Contain("\"MTConnectDevices\""),
                 "Indented output must still wrap content in the MTConnectDevices envelope.");
         }
+
+
+        // ---------------------------------------------------------------
+        // Read-path symmetry: CreateDevicesResponseDocument must deserialise
+        // the same envelope shape that Format emits. Pre-fix the reader
+        // routed through JsonDeviceContainer (single-device round-trip),
+        // which collapsed every multi-device envelope to a one-element list
+        // and erased Agent vs Device typing. These tests pin the symmetric
+        // contract: write-then-read survives the device count, identity,
+        // and Type-tag intact.
+        // ---------------------------------------------------------------
+
+        [Test]
+        public void MqttProbeFormatter_round_trip_envelope_preserves_multi_device_shape()
+        {
+            // Arrange: one Agent + two Devices.
+            var sourceDevices = new IDevice[]
+            {
+                NewAgent("agent-1", "agent", "agent-1"),
+                NewDevice("device-1", "VMC-3Axis", "device-1"),
+                NewDevice("device-2", "Lathe", "device-2"),
+            };
+            var document = BuildDocument(sourceDevices);
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act: Format -> stream -> CreateDevicesResponseDocument.
+            var writeResult = formatter.Format(document);
+            Assert.That(writeResult.Success, Is.True, "Format must succeed for a non-empty source.");
+            writeResult.Content.Position = 0;
+
+            var readResult = formatter.CreateDevicesResponseDocument(writeResult.Content);
+
+            // Assert: round-trip success.
+            Assert.That(readResult.Success, Is.True,
+                "CreateDevicesResponseDocument must succeed on a payload Format just produced.");
+            Assert.That(readResult.Content, Is.Not.Null,
+                "Read result content (the parsed document) must not be null on success.");
+
+            var roundTripped = readResult.Content;
+            Assert.That(roundTripped.Devices, Is.Not.Null,
+                "Round-tripped document must expose a non-null Devices collection.");
+
+            var roundTrippedList = roundTripped.Devices.ToList();
+            Assert.That(roundTrippedList.Count, Is.EqualTo(sourceDevices.Length),
+                "Round-tripped Devices count must match the source — no envelope entry may be dropped.");
+
+            // Identity preservation: every source UUID is present after round-trip.
+            var roundTrippedUuids = roundTrippedList.Select(d => d.Uuid).ToList();
+            foreach (var source in sourceDevices)
+            {
+                Assert.That(roundTrippedUuids, Contains.Item(source.Uuid),
+                    $"Source UUID '{source.Uuid}' must survive the envelope round-trip.");
+            }
+        }
+
+        [Test]
+        public void MqttProbeFormatter_round_trip_envelope_preserves_Agent_Device_typing()
+        {
+            // Arrange: one Agent + one Device. The read path must distinguish
+            // them by Type so consumers can re-derive the cppagent v2 keyed
+            // shape (Agent[] vs Device[]) without losing identity.
+            var document = BuildDocument(new IDevice[]
+            {
+                NewAgent("agent-1", "agent", "agent-1"),
+                NewDevice("device-1", "VMC-3Axis", "device-1"),
+            });
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var writeResult = formatter.Format(document);
+            writeResult.Content.Position = 0;
+            var readResult = formatter.CreateDevicesResponseDocument(writeResult.Content);
+
+            // Assert: typing is preserved through round-trip.
+            Assert.That(readResult.Success, Is.True);
+            var roundTripped = readResult.Content.Devices.ToList();
+
+            var agentMeta = roundTripped.SingleOrDefault(d => d.Uuid == "agent-1");
+            Assert.That(agentMeta, Is.Not.Null,
+                "The Agent meta-device must be recoverable by its source UUID after round-trip.");
+            Assert.That(agentMeta!.Type, Is.EqualTo(Agent.TypeId),
+                "Round-tripped Agent meta-device must retain Type == Agent.TypeId, "
+                + "not collapse to the generic Device.TypeId.");
+
+            var machineDevice = roundTripped.SingleOrDefault(d => d.Uuid == "device-1");
+            Assert.That(machineDevice, Is.Not.Null,
+                "The machine Device must be recoverable by its source UUID after round-trip.");
+            Assert.That(machineDevice!.Type, Is.EqualTo(Device.TypeId),
+                "Round-tripped machine Device must retain Type == Device.TypeId.");
+        }
+
+        [Test]
+        public void MqttProbeFormatter_preserves_Agent_name_case_in_envelope_output()
+        {
+            // Arrange: an Agent whose source `name` attribute is mixed-case,
+            // mirroring cppagent's reference fixture convention (e.g. "LinuxCNC").
+            // The cppagent JSON v2 serialiser emits the `name` attribute
+            // verbatim — MTConnect.NET's formatter must do the same.
+            var document = BuildDocument(new IDevice[]
+            {
+                NewAgent("agent-1", "LinuxCNC", "agent-1"),
+            });
+            var formatter = new JsonMqttResponseDocumentFormatter();
+
+            // Act
+            var root = GetRoot(formatter.Format(document));
+            var agents = root
+                .GetProperty("MTConnectDevices")
+                .GetProperty("Devices")
+                .GetProperty("Agent");
+            var agentNode = agents[0];
+
+            // Assert: the `name` JSON field equals the source value byte-for-byte.
+            Assert.That(agentNode.TryGetProperty("name", out var nameProp), Is.True,
+                "Agent JSON object must expose a `name` field.");
+            Assert.That(nameProp.GetString(), Is.EqualTo("LinuxCNC"),
+                "Agent `name` must be emitted verbatim — no lowercase / case normalisation.");
+        }
     }
 }

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonRuntimeTypeRoundTripTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonRuntimeTypeRoundTripTests.cs
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using MTConnect.Devices;
+using MTConnect.Devices.Components;
+using MTConnect.Devices.Compositions;
+using MTConnect.Devices.DataItems;
+using MTConnect.Devices.Json;
+using MTConnect.Observations;
+using MTConnect.Streams.Json;
+using NUnit.Framework;
+
+namespace MTConnect.Tests.JsonCppagent.Formatters
+{
+    /// <summary>
+    /// Pins the runtime-type discriminator through the JSON-cppagent envelope
+    /// read path for each Json -&gt; runtime conversion that has typed
+    /// subclasses in the source-of-truth Devices/Compositions/DataItems
+    /// generators. Same bug class as the JsonDevices.ToDevices() runtime-type
+    /// fix at 9845a7f6: a naked `new Component()` / `new Composition()` /
+    /// `new XxxObservation()` on the read side collapses every typed
+    /// subclass back to the abstract base, breaking `instance is TypedX`
+    /// branching downstream. JsonDataItem.ToDataItem already routes through
+    /// DataItem.Create(string type) and was the reference fix pattern; the
+    /// other paths are now lifted onto the same factory rail.
+    /// </summary>
+    [TestFixture]
+    [Category("CppAgentRuntimeTypePreservation")]
+    public class JsonRuntimeTypeRoundTripTests
+    {
+        // ---- JsonComponent.ToComponent ----------------------------------
+
+        [Test]
+        public void JsonComponent_ToComponent_preserves_runtime_type_for_typed_subclass()
+        {
+            // Arrange: an Axes component (one of the most common typed
+            // subclasses) round-tripped through JsonComponent. The Type
+            // string is supplied by the caller (JsonComponents.g.cs passes
+            // the AxesComponent.TypeId string when iterating the Axes bucket
+            // of the cppagent JSON v2 envelope).
+            var source = new AxesComponent
+            {
+                Id = "axes-1",
+                Uuid = "uuid-axes-1",
+                Name = "axes",
+            };
+            var json = new JsonComponent(source);
+
+            // Act
+            var roundTripped = json.ToComponent(AxesComponent.TypeId);
+
+            // Assert: runtime type and Type string both survive.
+            Assert.That(roundTripped, Is.Not.Null,
+                "ToComponent must return a non-null instance.");
+            Assert.That(roundTripped, Is.InstanceOf<AxesComponent>(),
+                "Round-tripped component must be an AxesComponent runtime "
+                + "instance, not a base Component with its Type field re-tagged. "
+                + "The factory route through Component.Create(string type) is "
+                + "what makes `component is AxesComponent` true.");
+            Assert.That(roundTripped.Type, Is.EqualTo(AxesComponent.TypeId),
+                "Type string discriminator must round-trip.");
+            Assert.That(roundTripped.Id, Is.EqualTo("axes-1"));
+            Assert.That(roundTripped.Uuid, Is.EqualTo("uuid-axes-1"));
+        }
+
+        [Test]
+        public void JsonComponent_ToComponent_preserves_runtime_type_for_Controller_subclass()
+        {
+            // Arrange: a second typed component to widen the surface —
+            // Controller is the canonical control-bus component.
+            var source = new ControllerComponent
+            {
+                Id = "controller-1",
+                Uuid = "uuid-controller-1",
+            };
+            var json = new JsonComponent(source);
+
+            // Act
+            var roundTripped = json.ToComponent(ControllerComponent.TypeId);
+
+            // Assert
+            Assert.That(roundTripped, Is.InstanceOf<ControllerComponent>(),
+                "Round-tripped component must be a ControllerComponent runtime instance.");
+            Assert.That(roundTripped.Type, Is.EqualTo(ControllerComponent.TypeId));
+        }
+
+        // ---- JsonComposition.ToComposition ------------------------------
+
+        [Test]
+        public void JsonComposition_ToComposition_preserves_runtime_type_for_typed_subclass()
+        {
+            // Arrange: a Chuck composition. The internal `Type` field on
+            // JsonComposition (read from the JSON `type` property) is the
+            // discriminator the ToComposition() factory call must use.
+            var source = new ChuckComposition
+            {
+                Id = "chuck-1",
+                Uuid = "uuid-chuck-1",
+                Name = "chuck",
+            };
+            var json = new JsonComposition(source);
+
+            // Act
+            var roundTripped = json.ToComposition();
+
+            // Assert
+            Assert.That(roundTripped, Is.Not.Null);
+            Assert.That(roundTripped, Is.InstanceOf<ChuckComposition>(),
+                "Round-tripped composition must be a ChuckComposition runtime "
+                + "instance, not a base Composition with its Type field "
+                + "re-tagged. The factory route through "
+                + "Composition.Create(string type) is what makes "
+                + "`composition is ChuckComposition` true.");
+            Assert.That(roundTripped.Type, Is.EqualTo(ChuckComposition.TypeId));
+            Assert.That(roundTripped.Id, Is.EqualTo("chuck-1"));
+        }
+
+        // ---- JsonCompositions.ToCompositions (latent empty-sink bug) ----
+
+        [Test]
+        public void JsonCompositions_ToCompositions_does_not_drop_compositions_on_read_path()
+        {
+            // Arrange: two compositions inside a JsonComponent. The latent
+            // bug in JsonCompositions.ToCompositions was guarding the
+            // freshly-allocated empty sink (`if (!dataItems.IsNullOrEmpty())`)
+            // instead of the source collection, so every Composition was
+            // silently dropped on the envelope read path. Fixing
+            // JsonComposition.ToComposition's runtime-type loss is moot if
+            // the enclosing list-wrapper never iterates.
+            var parent = new AxesComponent { Id = "axes-1", Uuid = "uuid-axes-1" };
+            parent.AddComposition(new ChuckComposition { Id = "chuck-1", Uuid = "uuid-chuck-1" });
+            parent.AddComposition(new ChainComposition { Id = "chain-1", Uuid = "uuid-chain-1" });
+
+            var json = new JsonComponent(parent);
+
+            // Act
+            var roundTripped = json.ToComponent(AxesComponent.TypeId);
+
+            // Assert: both compositions survive the read path with their
+            // typed identity intact.
+            Assert.That(roundTripped.Compositions, Is.Not.Null,
+                "Compositions must round-trip on the read path; "
+                + "JsonCompositions.ToCompositions must not short-circuit on its empty sink.");
+            var compositions = System.Linq.Enumerable.ToList(roundTripped.Compositions);
+            Assert.That(compositions.Count, Is.EqualTo(2),
+                "Both source compositions must survive the read path.");
+            Assert.That(compositions[0], Is.InstanceOf<ChuckComposition>(),
+                "First round-tripped composition must keep its ChuckComposition runtime type.");
+            Assert.That(compositions[1], Is.InstanceOf<ChainComposition>(),
+                "Second round-tripped composition must keep its ChainComposition runtime type.");
+        }
+
+        // ---- JsonDataItem.ToDataItem (pre-existing CLEAN reference) -----
+
+        [Test]
+        public void JsonDataItem_ToDataItem_preserves_runtime_type_for_typed_subclass()
+        {
+            // Reference test: JsonDataItem.ToDataItem already routes through
+            // DataItem.Create(Type) and is the pattern the other ToXxx paths
+            // are being lifted onto. Pin its behaviour so the contract is
+            // explicit, not just emergent.
+            var source = new ProgramDataItem
+            {
+                Id = "program-1",
+                Name = "program",
+            };
+            var json = new JsonDataItem(source);
+
+            // Act
+            var roundTripped = json.ToDataItem();
+
+            // Assert
+            Assert.That(roundTripped, Is.InstanceOf<ProgramDataItem>(),
+                "Round-tripped DataItem must keep its ProgramDataItem runtime type.");
+            Assert.That(roundTripped.Type, Is.EqualTo(ProgramDataItem.TypeId));
+        }
+
+        // ---- JsonEventValue.ToObservation -------------------------------
+
+        [Test]
+        public void JsonEventValue_ToObservation_preserves_type_string_through_envelope()
+        {
+            // Pin the no-regression behaviour: ToObservation must always
+            // stamp the supplied Type onto the result, regardless of whether
+            // the upstream EventObservation.Create factory can resolve a
+            // typed subclass for it. (Whether the runtime type is the
+            // typed subclass depends on the upstream factory's lookup
+            // logic, which is out of scope for this read-path fix.)
+            var source = new JsonEventValue { DataItemId = "msg-1", Value = "hello" };
+
+            // Act
+            var observation = source.ToObservation("MESSAGE");
+
+            // Assert: the Type discriminator survives the round-trip in
+            // every case; the abstract carrier ALSO survives in the worst
+            // case (factory miss), so `observation is null` would be a
+            // regression.
+            Assert.That(observation, Is.Not.Null,
+                "ToObservation must never return null.");
+            Assert.That(observation.Type, Is.EqualTo("MESSAGE"),
+                "Type discriminator must survive the envelope read path.");
+            Assert.That(observation.DataItemId, Is.EqualTo("msg-1"));
+        }
+
+        // ---- JsonCondition.ToCondition ----------------------------------
+
+        [Test]
+        public void JsonCondition_ToCondition_preserves_type_string_through_envelope()
+        {
+            // No typed ConditionObservation subclasses exist in the runtime
+            // (the only subclass slot is the abstract carrier), so the
+            // strongest property to pin is "Type survives, instance non-null,
+            // factory-routed". This is the same defence-in-depth fix the
+            // other ToObservation paths take.
+            var source = new JsonCondition
+            {
+                DataItemId = "cond-1",
+                Type = "SYSTEM",
+            };
+
+            // Act
+            var observation = source.ToCondition(ConditionLevel.NORMAL);
+
+            // Assert
+            Assert.That(observation, Is.Not.Null);
+            Assert.That(observation.Type, Is.EqualTo("SYSTEM"));
+            Assert.That(observation.Level, Is.EqualTo(ConditionLevel.NORMAL));
+            Assert.That(observation.DataItemId, Is.EqualTo("cond-1"));
+        }
+    }
+}

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonRuntimeTypeRoundTripTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonRuntimeTypeRoundTripTests.cs
@@ -7,6 +7,7 @@ using MTConnect.Devices.Compositions;
 using MTConnect.Devices.DataItems;
 using MTConnect.Devices.Json;
 using MTConnect.Observations;
+using MTConnect.Observations.Events;
 using MTConnect.Streams.Json;
 using NUnit.Framework;
 
@@ -178,28 +179,50 @@ namespace MTConnect.Tests.JsonCppagent.Formatters
         // ---- JsonEventValue.ToObservation -------------------------------
 
         [Test]
-        public void JsonEventValue_ToObservation_preserves_type_string_through_envelope()
+        public void JsonEventValue_ToObservation_preserves_runtime_type_for_typed_subclass()
         {
-            // Pin the no-regression behaviour: ToObservation must always
-            // stamp the supplied Type onto the result, regardless of whether
-            // the upstream EventObservation.Create factory can resolve a
-            // typed subclass for it. (Whether the runtime type is the
-            // typed subclass depends on the upstream factory's lookup
-            // logic, which is out of scope for this read-path fix.)
+            // The envelope read path runs JsonEventValue through
+            // EventObservation.Create(string type, DataItemRepresentation),
+            // which after the factory _types lookup fix at 0c3aead9
+            // resolves ("MESSAGE", VALUE) onto the MessageValueObservation
+            // runtime type. Pin both the runtime-type discriminator and
+            // the Type-string stamp end-to-end.
             var source = new JsonEventValue { DataItemId = "msg-1", Value = "hello" };
 
             // Act
-            var observation = source.ToObservation("MESSAGE");
+            var observation = source.ToObservation(MessageDataItem.TypeId);
 
-            // Assert: the Type discriminator survives the round-trip in
-            // every case; the abstract carrier ALSO survives in the worst
-            // case (factory miss), so `observation is null` would be a
-            // regression.
+            // Assert
             Assert.That(observation, Is.Not.Null,
                 "ToObservation must never return null.");
-            Assert.That(observation.Type, Is.EqualTo("MESSAGE"),
-                "Type discriminator must survive the envelope read path.");
+            Assert.That(observation, Is.InstanceOf<MessageValueObservation>(),
+                "MESSAGE/VALUE must round-trip onto the typed "
+                + "MessageValueObservation runtime carrier, not the "
+                + "abstract EventValueObservation. The factory _types "
+                + "key-format fix at 0c3aead9 is what makes "
+                + "`observation is MessageValueObservation` true.");
+            Assert.That(observation.Type, Is.EqualTo(MessageDataItem.TypeId),
+                "Type string discriminator must survive the envelope read path.");
             Assert.That(observation.DataItemId, Is.EqualTo("msg-1"));
+        }
+
+        [Test]
+        public void JsonEventValue_ToObservation_preserves_runtime_type_for_AssetChanged()
+        {
+            // ASSET_CHANGED is the underscore-bearing hostile case for the
+            // factory's PascalCase ToTypeId conversion. Pins the read
+            // path for the typed AssetChangedValueObservation subclass.
+            var source = new JsonEventValue { DataItemId = "asset-1", Value = "uuid-1" };
+
+            // Act
+            var observation = source.ToObservation(AssetChangedDataItem.TypeId);
+
+            // Assert
+            Assert.That(observation, Is.InstanceOf<AssetChangedValueObservation>(),
+                "ASSET_CHANGED/VALUE must round-trip onto the typed "
+                + "AssetChangedValueObservation runtime carrier.");
+            Assert.That(observation.Type, Is.EqualTo(AssetChangedDataItem.TypeId));
+            Assert.That(observation.DataItemId, Is.EqualTo("asset-1"));
         }
 
         // ---- JsonCondition.ToCondition ----------------------------------


### PR DESCRIPTION
## Summary

`JsonMqttResponseDocumentFormatter.Format(IDevicesResponseDocument, …)` previously serialised only the first device — `document.Devices.FirstOrDefault()` — wrapped in a `JsonDeviceContainer`, bypassing `JsonDevicesResponseDocument → JsonMTConnectDevices → JsonDevices` and the full envelope. The result was that every MQTT Probe topic carried a single flat device object rather than the multi-device, keyed-by-type `MTConnectDevices.Devices.{Agent[], Device[]}` envelope that the cppagent JSON v2 specification requires. When the agent meta-device sits at the head of the list (the library's default placement), every machine `<Device>` was silently dropped from every Probe message.

This PR routes the MQTT formatter through `new JsonDevicesResponseDocument(document)` — the same path the sibling `JsonHttpResponseDocumentFormatter` already uses — so the cppagent-shaped envelope is emitted verbatim. The companion read-path (`CreateDevicesResponseDocument`) is updated symmetrically. A secondary `<Agent>` meta-device name-case defect surfaced during investigation and is fixed here too.

## Spec evidence

The MTConnect v2.7 XSD `DevicesType` (`MTConnectDevices_2.7.xsd`, lines 5029–5051) declares `Agent` and `Device` as **separate named child elements** within `<Devices>`:

```xml
<xs:complexType name="DevicesType">
  <xs:sequence>
    <xs:element name="Agent"  type="AgentType"  minOccurs="0" maxOccurs="1"/>
    <xs:element name="Device" type="DeviceType" minOccurs="1" maxOccurs="unbounded"/>
  </xs:sequence>
</xs:complexType>
```

`AgentType` extends `DeviceType` and the `Agent` element uses `substitutionGroup="Device"`, but `DevicesType`'s `<xs:sequence>` lists both names explicitly. The JSON v2 mapping of a complex type is a JSON object with named child keys, not a JSON array; `Devices` must therefore be a JSON object carrying `Agent` and `Device` as separate keys.

The cppagent reference probe test (`json_printer_probe_test.cpp`, `version_2_with_multiple_devices`) pins exactly this shape:

```cpp
auto devices = jdoc.at("/MTConnectDevices/Devices"_json_pointer);
ASSERT_TRUE(devices.is_object());
auto device = jdoc.at("/MTConnectDevices/Devices/Device"_json_pointer);
ASSERT_TRUE(device.is_array());
ASSERT_EQ(2_S, device.size());
```

## Fix — write path

Replace the body of `JsonMqttResponseDocumentFormatter.Format(IDevicesResponseDocument, …)` with the same pattern the HTTP formatter uses:

```csharp
JsonSerializer.Serialize(outputStream, new JsonDevicesResponseDocument(document), jsonOptions);
```

`JsonDevicesResponseDocument → JsonMTConnectDevices → JsonDevices` already dispatches on `device.Type == Agent.TypeId` to split agents from devices into named `Agent` / `Device` JSON keys; no new dispatch logic is required.

## Fix — read path (symmetry)

`CreateDevicesResponseDocument(Stream, …)` previously deserialised through `JsonDeviceContainer`, which can only see a single device per payload. Now that the write side emits the proper envelope, the read side is routed through `JsonDevicesResponseDocument` for symmetry. A round-trip test in the new fixture (Format → CreateDevicesResponseDocument) pins device-count, ordering, and Agent-vs-Device typing across the boundary.

## Fix — `<Agent>` meta-device name-case preservation

A secondary defect surfaced while investigating the bug report's "Out of Scope" finding (lines 251–255): the synthetic Agent meta-device was being defaulted to the lowercase name `"agent"`, whereas cppagent and the v2.7 XSD's `xs:string` typing of the `name` attribute (combined with W3C XML 1.0 §2.3, "Names and Tokens", which mandates case sensitivity) require verbatim case preservation of the source value. Default is now `"Agent"`, matching cppagent's reference behaviour. Mixed-case attribute values supplied by the configuration flow through unchanged.

## Tests

The fixture set is layered across the test pyramid, with each test referencing the bug report's line range it pins so a future regression sweep can trace the connection:

### Unit (`tests/MTConnect.NET-JSON-cppagent-Tests/Formatters/JsonMqttResponseDocumentFormatterTests.cs`)

Pinned contracts — multi-device envelope shape, single-device behaviour, Agent-only behaviour, ordering, top-level wrapper, empty-input, indented-output parity, **round-trip envelope** (write → read symmetry), **Agent name case preservation**, and a **parametric multi-version family** that re-runs each contract across every supported MTConnect standard version (v1.0 through v2.7), driven by `TestCaseSource` on `MTConnectVersions`.

### Integration (`tests/MTConnect.NET-Integration-Tests/Workflows/JsonMqttProbeEnvelopeIntegrationTests.cs`)

Producer + consumer round-trip on a multi-device Probe document, catching regressions where the writer emits the correct envelope but the reader loses devices or mangles Agent casing across the serialisation boundary.

### Compliance — XSD validation (`tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/DevicesEnvelopeShapeXsdValidationTests.cs`)

Validates the produced Probe envelope against `MTConnectDevices_2.7.xsd`'s `DevicesType`, asserting `Agent` is a named child of `Devices` (per the XSD's named sequence) rather than a flat root-level sibling.

### Compliance — cppagent cross-impl parity (`tests/Compliance/MTConnect-Compliance-Tests/L2_CrossImpl/CppAgentJsonV2ProbeEnvelopeShapeTests.cs`)

Pins the cppagent JSON v2 wire shape from the reference fixture at `mtconnect/cppagent` `test_package/json_printer_probe_test.cpp` — `MTConnectDevices.Devices` is a JSON object (not array), `Agent` and `Device` keys hold typed arrays, casing matches cppagent verbatim.

### Compliance — E2E (`tests/Compliance/MTConnect-Compliance-Tests/L2_CrossImpl/JsonMqttProbeEnvelopeE2ETests.cs`)

`Category=RequiresDocker`/`Category=E2E` tests covering the full producer agent → mosquitto broker → cppagent reference parser round trip for multi-device Probe envelopes and mixed-case Agent names; runs on hosts with Docker available.

### Test count

Pre-fix master baseline: 4,579 passes. Post-fix on this branch (default filter, excluding `RequiresDocker`/`XsdLoadStrict`/`E2E`): **4,648 passes**, 0 failed, 0 skipped. The `JSON-cppagent` test assembly is at 355/355 (was 297 on master, +58 new), and `MTConnect-Compliance-Tests` is at 155/155 (was 149 on master, +6 new). The `RequiresDocker`/`E2E` suites add a further set that runs on the bluefin Docker host.

## Downstream impact

Any consumer relying on the MQTT relay's `JSON-cppagent-mqtt` Probe topic inherits this defect on the master branch today — every Probe message published to the broker currently contains a single unwrapped device object rather than the full `MTConnectDevices` envelope, and any consumer expecting the cppagent reference shape cannot reconstruct the device topology from per-device single-object messages.

## References

- cppagent reference implementation probe test: <https://raw.githubusercontent.com/mtconnect/cppagent/main/test_package/json_printer_probe_test.cpp>
- MTConnect v2.7 Devices XSD: <https://schemas.mtconnect.org/schemas/MTConnectDevices_2.7.xsd>
- W3C XML 1.0 (Fifth Edition), §2.3 — "Names and Tokens" (case-sensitivity normative for both element and attribute names; attribute values are `xs:string` by default in the XSD)
- Defective formatter (master `4bceea1a`): `libraries/MTConnect.NET-JSON-cppagent/Formatters/JsonMqttResponseDocumentFormatter.cs`
- Correct HTTP-path serialiser used as the reference: `libraries/MTConnect.NET-JSON-cppagent/Formatters/JsonHttpResponseDocumentFormatter.cs`
- `JsonDevices` Agent/Device dispatch: `libraries/MTConnect.NET-JSON-cppagent/Devices/JsonDevices.cs`
- `JsonDevicesResponseDocument`: `libraries/MTConnect.NET-JSON-cppagent/Devices/JsonDevicesResponseDocument.cs`
