### PR TITLE
chore(tests+xml): XSD 1.1 preprocessor in XmlValidator + L1 split coverage + DinD path-agnostic + coverlet 6.x + CI matrix-include

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -35,6 +35,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        include:
+          # ubuntu-latest runs the full sweep: Docker is pre-installed
+          # on GitHub-hosted Linux runners and Testcontainers can spawn
+          # the eclipse-mosquitto + mtconnect/agent images the
+          # RequiresDocker / E2E suites need; the XSD source-of-truth
+          # files ship in-repo, so XsdLoadStrict also has every
+          # prerequisite. Empty filter = no exclusions.
+          - os: ubuntu-latest
+            testFilter: ""
+          # windows-latest GitHub-hosted runners do NOT pre-install
+          # Docker for Linux containers (only Windows containers via
+          # Hyper-V), so the RequiresDocker / E2E suites that boot
+          # Linux images (eclipse-mosquitto:2.0.22,
+          # mtconnect/agent:latest) cannot run there. Skip both
+          # categories on the Windows leg; XsdLoadStrict has no
+          # platform dependency and still runs.
+          - os: windows-latest
+            testFilter: "Category!=RequiresDocker&Category!=E2E"
 
     steps:
       - name: Checkout
@@ -64,15 +82,34 @@ jobs:
       # file cannot win against this solution-wide --settings; running
       # the project as its own step is the only way to give it
       # different coverage scoping. See the integration .csproj comment.
+      #
+      # The --filter expression is matrix-controlled so each OS leg runs
+      # the categories it can physically support. ubuntu-latest carries
+      # an empty filter (the full sweep: RequiresDocker + E2E +
+      # XsdLoadStrict all included); windows-latest carries
+      # Category!=RequiresDocker&Category!=E2E (no Linux-image Docker
+      # on the hosted Windows runner). See the strategy.matrix.include
+      # block above for the rationale.
       - name: Run unit tests with coverage
+        env:
+          TEST_FILTER: ${{ matrix.testFilter }}
         run: |
-          dotnet test MTConnect.NET.sln \
-            --configuration Debug \
-            --no-build \
-            --settings tests/coverlet.runsettings \
-            --results-directory TestResults \
-            --logger "trx;LogFileName=test-results-${{ matrix.os }}.trx" \
-            --filter "Category!=RequiresDocker&Category!=XsdLoadStrict"
+          if [ -n "$TEST_FILTER" ]; then
+            dotnet test MTConnect.NET.sln \
+              --configuration Debug \
+              --no-build \
+              --settings tests/coverlet.runsettings \
+              --results-directory TestResults \
+              --logger "trx;LogFileName=test-results-${{ matrix.os }}.trx" \
+              --filter "$TEST_FILTER"
+          else
+            dotnet test MTConnect.NET.sln \
+              --configuration Debug \
+              --no-build \
+              --settings tests/coverlet.runsettings \
+              --results-directory TestResults \
+              --logger "trx;LogFileName=test-results-${{ matrix.os }}.trx"
+          fi
         shell: bash
 
       # Same zero-test false-green guard as the integration step, on
@@ -129,14 +166,16 @@ jobs:
       # solution-built non-test assembly would discover 0 tests and the
       # step would false-green.
       #
-      # The E2E category is excluded alongside RequiresDocker: the
-      # heavy in-process-server workflow fixtures (HttpProbe /
-      # HttpAsset / ConfigurationPolymorphicHttpProbe workflow tests)
-      # are tagged Category=E2E and re-introduce the timing fragility
-      # the coverage-isolation split exists to avoid; they run only
-      # under MTCONNECT_E2E_DOCKER. ClientAgentCommunicationTests,
+      # As with the unit step, the integration step's --filter is
+      # matrix-controlled: ubuntu-latest runs the full sweep
+      # (RequiresDocker + E2E + XsdLoadStrict — the campaign-added
+      # MqttRelay / JsonMqttProbeEnvelope / HttpProbe / HttpAsset /
+      # ConfigurationPolymorphicHttpProbe workflow tests all run on a
+      # real broker via Testcontainers), windows-latest excludes
+      # RequiresDocker + E2E (no Linux-image Docker on the hosted
+      # Windows runner). ClientAgentCommunicationTests,
       # GenerateDevicesXmlTests and HttpServerLoopbackBindingTests
-      # carry no category and still run here.
+      # carry no category and run on both legs unconditionally.
       - name: Build integration project with IntegrationCoverage flag
         run: |
           dotnet build tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj \
@@ -146,15 +185,27 @@ jobs:
         shell: bash
 
       - name: Run integration tests with coverage
+        env:
+          TEST_FILTER: ${{ matrix.testFilter }}
         run: |
-          dotnet test tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj \
-            --configuration Debug \
-            --no-build \
-            -p:IntegrationCoverage=true \
-            --settings tests/coverlet.integration.runsettings \
-            --results-directory TestResults \
-            --logger "trx;LogFileName=test-results-integration-${{ matrix.os }}.trx" \
-            --filter "Category!=RequiresDocker&Category!=XsdLoadStrict&Category!=E2E"
+          if [ -n "$TEST_FILTER" ]; then
+            dotnet test tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj \
+              --configuration Debug \
+              --no-build \
+              -p:IntegrationCoverage=true \
+              --settings tests/coverlet.integration.runsettings \
+              --results-directory TestResults \
+              --logger "trx;LogFileName=test-results-integration-${{ matrix.os }}.trx" \
+              --filter "$TEST_FILTER"
+          else
+            dotnet test tests/MTConnect.NET-Integration-Tests/MTConnect.NET-Integration-Tests.csproj \
+              --configuration Debug \
+              --no-build \
+              -p:IntegrationCoverage=true \
+              --settings tests/coverlet.integration.runsettings \
+              --results-directory TestResults \
+              --logger "trx;LogFileName=test-results-integration-${{ matrix.os }}.trx"
+          fi
         shell: bash
 
       # Hard-fail the job if the integration step discovered/executed 0

--- a/libraries/MTConnect.NET-XML/XmlValidator.cs
+++ b/libraries/MTConnect.NET-XML/XmlValidator.cs
@@ -35,7 +35,18 @@ namespace MTConnect
                             {
                                 try
                                 {
-                                    using (var reader = new StringReader(schemaXml))
+                                    // Strip XSD 1.1-only constructs (xs:assert,
+                                    // xs:override, notNamespace) before handing
+                                    // the source to the BCL XSD 1.0 reader.
+                                    // The official MTConnect XSDs from v1.3
+                                    // onwards carry XSD 1.1 features that
+                                    // XmlSchema.Read otherwise rejects with
+                                    // "notNamespace not supported".
+                                    var preprocessed = schemaXml != null
+                                        ? XsdPreprocessor.StripXsd11Constructs(schemaXml)
+                                        : null;
+
+                                    using (var reader = new StringReader(preprocessed ?? string.Empty))
                                     {
                                         var schema = XmlSchema.Read(reader, null);
                                         if (schema != null) schemas.Add(schema);

--- a/libraries/MTConnect.NET-XML/XsdPreprocessor.cs
+++ b/libraries/MTConnect.NET-XML/XsdPreprocessor.cs
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace MTConnect
+{
+    /// <summary>
+    /// Strips XSD 1.1-only constructs from an XSD source document so the
+    /// .NET BCL <see cref="System.Xml.Schema.XmlSchemaSet"/> (XSD 1.0 only)
+    /// can compile the schema's 1.0-compatible subset.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The official MTConnect XSDs (v1.3 onwards) carry XSD 1.1 constructs —
+    /// <c>&lt;xs:assert&gt;</c>, <c>&lt;xs:override&gt;</c>, and the
+    /// <c>notNamespace</c> attribute on <c>&lt;xs:any&gt;</c> /
+    /// <c>&lt;xs:anyAttribute&gt;</c>. .NET's BCL XSD reader rejects these
+    /// outright (<c>XmlSchemaException: notNamespace not supported</c>), so a
+    /// downstream consumer that hands the official XSD to
+    /// <see cref="System.Xml.Schema.XmlSchema.Read(System.IO.TextReader, System.Xml.Schema.ValidationEventHandler)"/>
+    /// never gets to the validation step.
+    /// </para>
+    /// <para>
+    /// This preprocessor removes those constructs (and downgrades
+    /// <c>notNamespace</c> by stripping the attribute, which leaves the
+    /// <c>xs:any</c>/<c>xs:anyAttribute</c> in its default-permissive
+    /// XSD-1.0 form). The resulting schema is a valid XSD 1.0 subset that
+    /// the BCL reader accepts; it loses some of the spec's negative-namespace
+    /// constraints but keeps every structural rule the 1.0-compatible subset
+    /// expresses. For full XSD 1.1 validation, a Saxon-HE-backed validator
+    /// is the correct upgrade path.
+    /// </para>
+    /// </remarks>
+    public static class XsdPreprocessor
+    {
+        private const string XsdNamespace = "http://www.w3.org/2001/XMLSchema";
+
+        /// <summary>
+        /// Returns a copy of <paramref name="xsdSourceXml"/> with every XSD
+        /// 1.1-only construct removed. Idempotent: re-running on the
+        /// preprocessed output is a no-op.
+        /// </summary>
+        /// <param name="xsdSourceXml">The raw XSD source as XML text.</param>
+        /// <returns>An XSD-1.0-compatible XML string.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="xsdSourceXml"/> is null.
+        /// </exception>
+        public static string StripXsd11Constructs(string xsdSourceXml)
+        {
+            if (xsdSourceXml == null) throw new ArgumentNullException(nameof(xsdSourceXml));
+            if (xsdSourceXml.Length == 0) return xsdSourceXml;
+
+            XDocument doc;
+            try
+            {
+                using var reader = new StringReader(xsdSourceXml);
+                doc = XDocument.Load(reader, LoadOptions.PreserveWhitespace);
+            }
+            catch (System.Xml.XmlException)
+            {
+                // Not well-formed XML — let the downstream BCL reader emit
+                // the parse error so the caller's error path stays
+                // consistent.
+                return xsdSourceXml;
+            }
+
+            if (doc.Root == null) return xsdSourceXml;
+
+            // xs:override and xs:assert have no XSD 1.0 equivalent — remove
+            // wholesale. Snapshot the descendants list before mutating; the
+            // live-axes view would otherwise mis-iterate after Remove().
+            XName overrideName = XName.Get("override", XsdNamespace);
+            XName assertName = XName.Get("assert", XsdNamespace);
+            var toRemove = doc.Descendants()
+                .Where(e => e.Name == overrideName || e.Name == assertName)
+                .ToList();
+            foreach (var element in toRemove)
+            {
+                element.Remove();
+            }
+
+            // notNamespace / notQName are XSD 1.1-only attributes on
+            // xs:any / xs:anyAttribute. Two paths:
+            //
+            //   * xs:anyAttribute carrying notNamespace/notQName — strip the
+            //     attribute and let the element fall back to its 1.0 default
+            //     of namespace='##any'. Attribute wildcards do not create the
+            //     content-model ambiguity below, so the permissive 1.0 form
+            //     is structurally equivalent for load-time validation.
+            //
+            //   * xs:any carrying notNamespace/notQName — REMOVE the element.
+            //     Falling back to '##any' would produce a wildcard adjacent
+            //     to concrete elements in the target namespace and XSD 1.0
+            //     would reject the schema with "Wildcard '##any' allows
+            //     element '...' and causes the content model to become
+            //     ambiguous" (unique-particle-attribution). Dropping the
+            //     wildcard is lossy with respect to the spec's extensibility
+            //     contract, but the 1.0-compatible subset is what the BCL
+            //     reader can compile — full XSD 1.1 validation is the
+            //     Saxon-HE upgrade path.
+            XName anyName = XName.Get("any", XsdNamespace);
+            XName anyAttributeName = XName.Get("anyAttribute", XsdNamespace);
+
+            var anyAttributeWildcards = doc.Descendants(anyAttributeName).ToList();
+            foreach (var wildcard in anyAttributeWildcards)
+            {
+                wildcard.Attribute("notNamespace")?.Remove();
+                wildcard.Attribute("notQName")?.Remove();
+            }
+
+            var elementWildcardsToRemove = doc.Descendants(anyName)
+                .Where(e => e.Attribute("notNamespace") != null || e.Attribute("notQName") != null)
+                .ToList();
+            foreach (var wildcard in elementWildcardsToRemove)
+            {
+                wildcard.Remove();
+            }
+
+            // Two more XSD 1.1 features the BCL XSD 1.0 reader rejects when
+            // they appear inside xs:all:
+            //
+            //   * xs:any inside xs:all (XSD 1.1 §3.8.6 group all extension).
+            //     XSD 1.0 disallows xs:any as an all-particle entirely; the
+            //     reader emits "The 'http://www.w3.org/2001/XMLSchema:any'
+            //     element is not supported in this context." Remove the
+            //     offending xs:any.
+            //
+            //   * xs:element with maxOccurs > 1 inside xs:all (XSD 1.1
+            //     relaxes the 1.0 constraint that all-particles must have
+            //     maxOccurs in {0, 1}). XSD 1.0's reader rejects with "The
+            //     'maxOccurs' attribute of all the particles of an 'all'
+            //     group must be 0 or 1." Clamp maxOccurs to 1.
+            XName allName = XName.Get("all", XsdNamespace);
+            XName elementName = XName.Get("element", XsdNamespace);
+            XName extensionName = XName.Get("extension", XsdNamespace);
+            XName restrictionName = XName.Get("restriction", XsdNamespace);
+
+            // XSD 1.1 §3.8 allows xs:all directly inside an xs:extension /
+            // xs:restriction derivation. XSD 1.0 forbids it and the BCL
+            // reader rejects with "'all' is not the only particle in a
+            // group, or is being used as an extension." Rewrite those
+            // xs:all groups to xs:sequence. Sequence is order-sensitive
+            // where all is not, so the resulting schema is more restrictive
+            // than the 1.1 original — acceptable for load-time validation
+            // of the 1.0-compatible subset.
+            var allInsideDerivation = doc.Descendants(allName)
+                .Where(a => a.Parent != null && (a.Parent.Name == extensionName || a.Parent.Name == restrictionName))
+                .ToList();
+            foreach (var allGroup in allInsideDerivation)
+            {
+                allGroup.Name = XName.Get("sequence", XsdNamespace);
+            }
+
+            foreach (var allGroup in doc.Descendants(allName))
+            {
+                var anyParticles = allGroup.Elements(anyName).ToList();
+                foreach (var particle in anyParticles)
+                {
+                    particle.Remove();
+                }
+
+                foreach (var elementParticle in allGroup.Elements(elementName))
+                {
+                    var maxOccurs = elementParticle.Attribute("maxOccurs");
+                    if (maxOccurs != null && !IsZeroOrOne(maxOccurs.Value))
+                    {
+                        maxOccurs.Value = "1";
+                    }
+                }
+            }
+
+            // Use a UTF-8-without-BOM writer so the output stays byte-
+            // identical to what the BCL reader expects on the wire.
+            var sb = new StringBuilder();
+            using (var writer = System.Xml.XmlWriter.Create(sb, new System.Xml.XmlWriterSettings
+            {
+                OmitXmlDeclaration = doc.Declaration == null,
+                Encoding = new UTF8Encoding(false),
+                Indent = false,
+            }))
+            {
+                doc.Save(writer);
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Convenience batch overload — applies <see cref="StripXsd11Constructs(string)"/>
+        /// to each entry in <paramref name="xsdSourceXmls"/>.
+        /// </summary>
+        public static IEnumerable<string> StripXsd11Constructs(IEnumerable<string> xsdSourceXmls)
+        {
+            if (xsdSourceXmls == null) throw new ArgumentNullException(nameof(xsdSourceXmls));
+            return xsdSourceXmls.Select(StripXsd11Constructs);
+        }
+
+        private static bool IsZeroOrOne(string maxOccurs)
+        {
+            return string.Equals(maxOccurs, "0", StringComparison.Ordinal)
+                || string.Equals(maxOccurs, "1", StringComparison.Ordinal);
+        }
+    }
+}

--- a/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/DevicesEnvelopeShapeXsdValidationTests.cs
+++ b/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/DevicesEnvelopeShapeXsdValidationTests.cs
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Xml;
+using System.Xml.Schema;
+using MTConnect;
+using MTConnect.Devices;
+using MTConnect.Devices.Xml;
+using MTConnect.Headers;
+using NUnit.Framework;
+
+namespace MTConnect.Compliance.Tests.L1_XsdValidation
+{
+    // Compliance gate — multi-device Probe envelope MUST validate against
+    // MTConnectDevices_2.7.xsd. The XSD's DevicesType (lines 5029-5051)
+    // declares Agent (minOccurs=0, maxOccurs=1) + Device (minOccurs=1,
+    // maxOccurs=unbounded) as separate named child elements within the
+    // DevicesType sequence — a flat-array shape under Devices does not
+    // schema-validate. This is the load-bearing assertion that grounds
+    // the JSON v2 keyed-object envelope: the JSON shape mirrors the
+    // XSD's element nesting; the XML shape is the canonical reference.
+    //
+    // SchemaLoadTests already pins that the v2.7 XSD itself loads cleanly
+    // (and pre-seeds the W3C xlink + xml schemas it imports). This suite
+    // re-uses the same loader pattern, then validates a sample Probe
+    // document built by the production XML formatter.
+    //
+    // The v2.7 MTConnectDevices XSD carries XSD 1.1 constructs that .NET's
+    // BCL XmlSchemaSet (XSD 1.0 only) refuses to compile. The loader runs
+    // the schema source through MTConnect.XsdPreprocessor.StripXsd11Constructs
+    // — the same code path the production XmlValidator uses — to drop those
+    // constructs before the BCL reader sees them. The W3C xml.xsd and
+    // xlink.xsd imports are XSD-1.0-compatible already and are added
+    // unmodified.
+    //
+    // Source authority:
+    //   - MTConnect v2.7 XSD MTConnectDevices_2.7.xsd lines 5029-5051
+    //     (DevicesType complex type).
+    //   - W3C XML Schema 1.0 — recommends element-sequence validation.
+    [TestFixture]
+    [Category("CppAgentJsonV2Envelope")]
+    public class DevicesEnvelopeShapeXsdValidationTests
+    {
+        private const string ResourcePrefix = "MTConnect.Compliance.Tests.Schemas.";
+        private const string XlinkResourceName = ResourcePrefix + "w3c.xlink.xsd";
+        private const string XmlResourceName = ResourcePrefix + "w3c.xml.xsd";
+        private const string DevicesV27Resource = ResourcePrefix + "v2_7.MTConnectDevices_2.7.xsd";
+
+        private const string XlinkNamespace = "http://www.w3.org/1999/xlink";
+        private const string XmlNamespace = "http://www.w3.org/XML/1998/namespace";
+
+        private static XmlSchemaSet LoadDevicesV27Schema()
+        {
+            // Defense-in-depth: never resolve external schema locations
+            // from disk or network. The W3C imports the MTConnect XSD
+            // references (xlink + xml) are pre-seeded into the set so
+            // targetNamespace matching resolves them in-memory.
+            var schemaSet = new XmlSchemaSet
+            {
+                XmlResolver = null,
+            };
+
+            var asm = typeof(DevicesEnvelopeShapeXsdValidationTests).Assembly;
+
+            using (var xlinkStream = asm.GetManifestResourceStream(XlinkResourceName)
+                ?? throw new InvalidOperationException("Embedded W3C xlink schema not found."))
+            {
+                using var reader = XmlReader.Create(xlinkStream, new XmlReaderSettings { XmlResolver = null });
+                schemaSet.Add(XlinkNamespace, reader);
+            }
+
+            using (var xmlStream = asm.GetManifestResourceStream(XmlResourceName)
+                ?? throw new InvalidOperationException("Embedded W3C xml schema not found."))
+            {
+                using var reader = XmlReader.Create(xmlStream, new XmlReaderSettings { XmlResolver = null });
+                schemaSet.Add(XmlNamespace, reader);
+            }
+
+            // The v2.7 MTConnectDevices XSD uses XSD 1.1 constructs the BCL
+            // XmlSchemaSet (XSD 1.0 only) rejects. Run the source through
+            // the same XsdPreprocessor the production XmlValidator uses so
+            // tests and library share one source of truth for the
+            // 1.0-compatible subset.
+            string devicesXsdSource;
+            using (var devicesStream = asm.GetManifestResourceStream(DevicesV27Resource)
+                ?? throw new InvalidOperationException("Embedded MTConnectDevices_2.7 schema not found."))
+            using (var srcReader = new StreamReader(devicesStream))
+            {
+                devicesXsdSource = srcReader.ReadToEnd();
+            }
+
+            var preprocessed = XsdPreprocessor.StripXsd11Constructs(devicesXsdSource);
+
+            using (var preprocessedReader = new StringReader(preprocessed))
+            using (var reader = XmlReader.Create(preprocessedReader, new XmlReaderSettings { XmlResolver = null }))
+            {
+                schemaSet.Add(targetNamespace: null, reader);
+            }
+
+            schemaSet.Compile();
+            return schemaSet;
+        }
+
+        private static IDevicesResponseDocument BuildMultiDeviceDocument()
+        {
+            return new DevicesResponseDocument
+            {
+                Header = new MTConnectDevicesHeader
+                {
+                    InstanceId = 1,
+                    Version = "2.7.0.0",
+                    SchemaVersion = "2.7",
+                    Sender = "compliance-suite",
+                    AssetBufferSize = 1024,
+                    AssetCount = 0,
+                    BufferSize = 131072,
+                    DeviceModelChangeTime = "2026-05-23T00:00:00Z",
+                    TestIndicator = false,
+                    CreationTime = new DateTime(2026, 5, 23, 0, 0, 0, DateTimeKind.Utc),
+                },
+                Devices = new IDevice[]
+                {
+                    new Device { Id = "agent-1", Name = "Agent", Uuid = "agent-1", Type = Agent.TypeId },
+                    new Device { Id = "device-1", Name = "VMC-3Axis", Uuid = "device-1", Type = Device.TypeId },
+                    new Device { Id = "device-2", Name = "Lathe", Uuid = "device-2", Type = Device.TypeId },
+                },
+                Version = new Version(2, 7, 0, 0),
+            };
+        }
+
+
+        [Test]
+        [Category("XsdLoadStrict")]
+        public void Multi_device_probe_envelope_validates_against_MTConnectDevices_2_7_xsd()
+        {
+            // Tagged XsdLoadStrict because the v2.7 MTConnectDevices XSD
+            // uses XSD 1.1 features that .NET's XSD-1.0-only XmlSchemaSet
+            // cannot compile without preprocessing. The loader above runs
+            // the source through MTConnect.XsdPreprocessor so the BCL
+            // reader sees only the 1.0-compatible subset. Companion tests
+            // in PR #165 pin the same envelope shape via XDocument
+            // structural assertions that don't depend on the preprocessor.
+            // Arrange: schema set + the production-emitted XML envelope.
+            var schemas = LoadDevicesV27Schema();
+            var document = BuildMultiDeviceDocument();
+
+            using var xmlStream = XmlDevicesResponseDocument.ToXmlStream(
+                document,
+                extendedSchemas: null,
+                styleSheet: null,
+                indent: false,
+                outputComments: false);
+            Assert.That(xmlStream, Is.Not.Null);
+            xmlStream!.Position = 0;
+
+            // Act + Assert: validation errors must be empty.
+            var errors = new System.Collections.Generic.List<string>();
+            var readerSettings = new XmlReaderSettings
+            {
+                Schemas = schemas,
+                ValidationType = ValidationType.Schema,
+                ValidationFlags = XmlSchemaValidationFlags.ReportValidationWarnings,
+                XmlResolver = null,
+            };
+            readerSettings.ValidationEventHandler += (sender, args) =>
+            {
+                errors.Add($"[{args.Severity}] {args.Message}");
+            };
+
+            using (var reader = XmlReader.Create(xmlStream, readerSettings))
+            {
+                while (reader.Read()) { /* drain */ }
+            }
+
+            Assert.That(errors, Is.Empty,
+                "Multi-device Probe envelope failed XSD validation against v2.7 DevicesType:\n"
+                + string.Join("\n", errors));
+        }
+    }
+}

--- a/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/SchemaLoadTests.cs
+++ b/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/SchemaLoadTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Schema;
+using MTConnect;
 using NUnit.Framework;
 
 namespace MTConnect.Compliance.Tests.L1_XsdValidation
@@ -161,6 +162,19 @@ namespace MTConnect.Compliance.Tests.L1_XsdValidation
             using var stream = asm.GetManifestResourceStream(resourceName);
             Assert.That(stream, Is.Not.Null, $"Embedded resource '{resourceName}' not found.");
 
+            // Pre-process the XSD source through the library's
+            // XsdPreprocessor so the BCL XmlSchemaSet (XSD 1.0 only) can
+            // compile the 1.0-compatible subset of the official MTConnect
+            // XSDs. Tests and library share a single source of truth — if
+            // the preprocessor drift ever introduces a regression, both
+            // sides surface it.
+            string xsdSource;
+            using (var srcReader = new StreamReader(stream!))
+            {
+                xsdSource = srcReader.ReadToEnd();
+            }
+            var preprocessed = XsdPreprocessor.StripXsd11Constructs(xsdSource);
+
             var errors = new List<string>();
 
             var settings = new XmlReaderSettings
@@ -190,7 +204,8 @@ namespace MTConnect.Compliance.Tests.L1_XsdValidation
             AddEmbeddedSchema(asm, schemaSet, settings, XmlResourceName, "w3c/xml.xsd");
             AddEmbeddedSchema(asm, schemaSet, settings, XlinkResourceName, "w3c/xlink.xsd");
 
-            using var reader = XmlReader.Create(stream!, settings, ToDisplayPath(resourceName));
+            using var preprocessedReader = new StringReader(preprocessed);
+            using var reader = XmlReader.Create(preprocessedReader, settings, ToDisplayPath(resourceName));
             schemaSet.Add(null, reader);
             schemaSet.Compile();
 

--- a/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/SchemaLoadTests.cs
+++ b/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/SchemaLoadTests.cs
@@ -61,7 +61,12 @@ namespace MTConnect.Compliance.Tests.L1_XsdValidation
         //
         // Display paths use the format produced by ToDisplayPath
         // (e.g. "v1_7/MTConnectDevices_1.7.xsd").
-        private static readonly HashSet<string> Xsd11BlockedSchemas = new(StringComparer.Ordinal)
+        // Made internal so the sibling Xsd11FeaturePresenceTests fixture
+        // can drive its per-schema XSD 1.1 marker assertions off the
+        // same authoritative list. Keeping the set in one place avoids
+        // copy-paste drift when a future MTConnect XSD adds (or removes)
+        // 1.1-only constructs.
+        internal static readonly HashSet<string> Xsd11BlockedSchemas = new(StringComparer.Ordinal)
         {
             "v1_3/MTConnectAssets_1.3.xsd",
             "v1_3/MTConnectDevices_1.3.xsd",

--- a/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/Xsd11FeaturePresenceTests.cs
+++ b/tests/Compliance/MTConnect-Compliance-Tests/L1_XsdValidation/Xsd11FeaturePresenceTests.cs
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using NUnit.Framework;
+
+namespace MTConnect.Compliance.Tests.L1_XsdValidation
+{
+    /// <summary>
+    /// Parses each XSD on the <see cref="SchemaLoadTests.Xsd11BlockedSchemas"/>
+    /// roster as raw XML and asserts the XSD 1.1 features the schema is
+    /// documented to carry are present and well-formed. Pairs with
+    /// <see cref="SchemaLoadTests"/>: the load fixture proves the
+    /// 1.0-compatible subset compiles cleanly after
+    /// <c>MTConnect.XsdPreprocessor</c>; this fixture proves the 1.1-only
+    /// constructs the preprocessor strips are actually there to strip.
+    /// Together the two fixtures fence the schema source against silent
+    /// upstream drift in either direction.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// XSD 1.1 features surveyed (from §3.10 of the XSD 1.1 spec):
+    /// </para>
+    /// <list type="bullet">
+    /// <item><c>xs:any[@notNamespace]</c> — negative-namespace wildcard
+    /// on element / attribute particles. Dominant in Assets / Devices
+    /// from v1.3 onwards.</item>
+    /// <item><c>xs:any</c> as a particle inside <c>xs:all</c> — the
+    /// XSD 1.1 §3.8.6 group-all extension.</item>
+    /// <item><c>xs:element[@maxOccurs!='1']</c> inside <c>xs:all</c> —
+    /// the XSD 1.1 cardinality relaxation. Dominant in Streams from
+    /// v1.7 onwards.</item>
+    /// <item><c>xs:all</c> directly inside <c>xs:extension</c> /
+    /// <c>xs:restriction</c> — the XSD 1.1 derivation extension.
+    /// Present in Assets v1.7+.</item>
+    /// </list>
+    /// <para>
+    /// Not surveyed (absent from current MTConnect XSDs):
+    /// <c>xs:assert</c>, <c>xs:override</c>, <c>notQName</c>. The
+    /// preprocessor handles them for forward-compatibility but the
+    /// shipped schemas do not yet exercise them. A sentinel test below
+    /// fails if that changes — so the absence assumption is testable.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    public class Xsd11FeaturePresenceTests
+    {
+        private const string XsdNamespace = "http://www.w3.org/2001/XMLSchema";
+        private const string ResourcePrefix = "MTConnect.Compliance.Tests.Schemas.";
+
+        public static IEnumerable<TestCaseData> Xsd11BlockedDisplayPaths()
+        {
+            // Drive the parametrisation off SchemaLoadTests.Xsd11BlockedSchemas
+            // so this fixture and the load fixture share a single source
+            // of truth for which schemas need 1.1 handling.
+            foreach (var displayPath in SchemaLoadTests.Xsd11BlockedSchemas.OrderBy(s => s, StringComparer.Ordinal))
+            {
+                yield return new TestCaseData(displayPath)
+                    .SetName($"XSD 1.1 markers present: {displayPath}");
+            }
+        }
+
+        // Each schema on the XsdLoadStrict roster must carry at least one
+        // XSD 1.1 feature — otherwise it was tagged unnecessarily. The
+        // OR-disjunction across known XSD 1.1 markers covers per-family
+        // editorial spread (Assets/Devices: notNamespace; Streams: xs:all
+        // + maxOccurs > 1; Error: xs:any inside xs:all) without per-family
+        // case-pinning that would fragility-couple to upstream's editing
+        // style.
+        [TestCaseSource(nameof(Xsd11BlockedDisplayPaths))]
+        public void Schema_carries_at_least_one_xsd_1_1_feature(string displayPath)
+        {
+            var doc = LoadSchemaAsXDocument(displayPath);
+            Assert.That(doc.Root, Is.Not.Null, $"{displayPath}: schema root element missing.");
+
+            var ns = (XNamespace)XsdNamespace;
+            var anyName = ns + "any";
+            var allName = ns + "all";
+            var elementName = ns + "element";
+            var extensionName = ns + "extension";
+            var restrictionName = ns + "restriction";
+            var anyAttributeName = ns + "anyAttribute";
+
+            var hasNotNamespace = doc.Descendants()
+                .Where(e => e.Name == anyName || e.Name == anyAttributeName)
+                .Any(e => e.Attribute("notNamespace") != null);
+
+            var hasAnyInsideAll = doc.Descendants(allName)
+                .SelectMany(a => a.Elements(anyName))
+                .Any();
+
+            var hasUnboundedAllElement = doc.Descendants(allName)
+                .SelectMany(a => a.Elements(elementName))
+                .Any(e => e.Attribute("maxOccurs") != null
+                          && e.Attribute("maxOccurs")!.Value != "0"
+                          && e.Attribute("maxOccurs")!.Value != "1");
+
+            var hasAllInDerivation = doc.Descendants(allName)
+                .Any(a => a.Parent != null
+                          && (a.Parent.Name == extensionName || a.Parent.Name == restrictionName));
+
+            var markers = new List<string>();
+            if (hasNotNamespace) markers.Add("xs:any[@notNamespace]");
+            if (hasAnyInsideAll) markers.Add("xs:all > xs:any");
+            if (hasUnboundedAllElement) markers.Add("xs:all > xs:element[maxOccurs>1]");
+            if (hasAllInDerivation) markers.Add("xs:all inside xs:extension/xs:restriction");
+
+            Assert.That(markers, Is.Not.Empty,
+                $"{displayPath}: schema is on the XsdLoadStrict roster but carries no "
+                + "detectable XSD 1.1 features. Either drop the roster tag (the BCL "
+                + "reader handles this schema unaided) or update the marker survey if "
+                + "a new XSD 1.1 construct appeared.");
+        }
+
+        // Sanity test: xs:assert and xs:override are not present in any
+        // current MTConnect XSD. If a future spec revision introduces
+        // them, this test will fail and the preprocessor's handling can
+        // be exercised end-to-end (the preprocessor already strips both;
+        // the test surfaces that the schemas now exercise the path).
+        [Test]
+        public void No_schema_carries_xs_assert_or_xs_override_yet()
+        {
+            var ns = (XNamespace)XsdNamespace;
+            var assertName = ns + "assert";
+            var overrideName = ns + "override";
+
+            var offenders = new List<string>();
+            foreach (var displayPath in SchemaLoadTests.Xsd11BlockedSchemas)
+            {
+                var doc = LoadSchemaAsXDocument(displayPath);
+                if (doc.Descendants(assertName).Any()
+                    || doc.Descendants(overrideName).Any())
+                {
+                    offenders.Add(displayPath);
+                }
+            }
+
+            Assert.That(offenders, Is.Empty,
+                "An upstream XSD now carries xs:assert or xs:override. The preprocessor "
+                + "already strips both, but this sentinel should be removed and the "
+                + "Schema_carries_at_least_one_xsd_1_1_feature OR-set should add the new "
+                + "marker. Offending schemas: " + string.Join(", ", offenders));
+        }
+
+        // xs:any with notNamespace, where present, must carry the
+        // '##targetNamespace' token (the negation of the schema's own
+        // target namespace) — i.e., "any extension element not in MY
+        // namespace". A future WG-side change to '##other' or to a
+        // literal URI list is structurally fine but worth pinning so a
+        // typo (e.g. '#targetNamespace') surfaces here.
+        [Test]
+        public void notNamespace_attribute_value_is_targetNamespace_token()
+        {
+            var ns = (XNamespace)XsdNamespace;
+            var anyName = ns + "any";
+            var anyAttributeName = ns + "anyAttribute";
+
+            var offenders = new List<string>();
+            foreach (var displayPath in SchemaLoadTests.Xsd11BlockedSchemas)
+            {
+                var doc = LoadSchemaAsXDocument(displayPath);
+                var wildcards = doc.Descendants()
+                    .Where(e => e.Name == anyName || e.Name == anyAttributeName)
+                    .Where(e => e.Attribute("notNamespace") != null);
+                foreach (var wildcard in wildcards)
+                {
+                    var value = wildcard.Attribute("notNamespace")!.Value;
+                    if (value != "##targetNamespace")
+                    {
+                        offenders.Add($"{displayPath}: notNamespace='{value}' (expected '##targetNamespace')");
+                    }
+                }
+            }
+
+            Assert.That(offenders, Is.Empty,
+                "A notNamespace attribute uses an unexpected value. The preprocessor still "
+                + "strips it correctly, but the WG editorial convention has drifted. "
+                + "Offenders:\n  - " + string.Join("\n  - ", offenders));
+        }
+
+        private static XDocument LoadSchemaAsXDocument(string displayPath)
+        {
+            // displayPath is e.g. "v1_7/MTConnectAssets_1.7.xsd"; the
+            // manifest name flattens '/' to '.' and prepends the
+            // resource prefix.
+            var manifestName = ResourcePrefix + displayPath.Replace('/', '.');
+
+            var asm = typeof(Xsd11FeaturePresenceTests).Assembly;
+            using var stream = asm.GetManifestResourceStream(manifestName);
+            if (stream == null)
+            {
+                throw new FileNotFoundException(
+                    $"Embedded XSD resource not found: {manifestName} (from displayPath '{displayPath}'). " +
+                    "Check the EmbeddedResource glob in MTConnect-Compliance-Tests.csproj.");
+            }
+            return XDocument.Load(stream, LoadOptions.None);
+        }
+    }
+}

--- a/tests/Compliance/MTConnect-Compliance-Tests/L2_CrossImpl/CppAgentParityWorkflowTests.cs
+++ b/tests/Compliance/MTConnect-Compliance-Tests/L2_CrossImpl/CppAgentParityWorkflowTests.cs
@@ -104,11 +104,26 @@ namespace MTConnect.Compliance.Tests.L2_CrossImpl
                 "ServiceName = MTConnect Agent\n" +
                 "SchemaVersion = \"2.5\"\n");
 
+            // Use WithResourceMapping(byte[], string) — copies the
+            // configured bytes into the container at start-up via the
+            // Docker API — rather than WithBindMount, which couples to a
+            // host path. On Docker-in-Docker setups (e.g. bluefin) the
+            // test-host container's view of /tmp doesn't match the Docker
+            // daemon host's view; a bind-mount would resolve to an empty
+            // directory inside the started container. ResourceMapping
+            // pushes bytes through the API and is path-agnostic.
+            //
+            // The host-side staging file remains because the in-process
+            // .NET agent's DeviceConfiguration.FromFile requires a file
+            // path; the container side no longer touches that path.
+            var agentCfgBytes = File.ReadAllBytes(_agentCfgPath);
+            var devicesXmlBytes = File.ReadAllBytes(_fixtureXmlPath);
+
             _cppAgent = new ContainerBuilder()
                 .WithImage(CppAgentImage)
                 .WithPortBinding(CppAgentPort, assignRandomHostPort: true)
-                .WithBindMount(_agentCfgPath, "/mtconnect/config/agent.cfg")
-                .WithBindMount(_fixtureXmlPath, "/mtconnect/config/Devices.xml")
+                .WithResourceMapping(agentCfgBytes, "/mtconnect/config/agent.cfg")
+                .WithResourceMapping(devicesXmlBytes, "/mtconnect/config/Devices.xml")
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(CppAgentPort))
                 .WithStartupCallback(async (_, _) => await Task.Delay(500).ConfigureAwait(false))
                 .Build();

--- a/tests/Compliance/MTConnect-Compliance-Tests/MTConnect-Compliance-Tests.csproj
+++ b/tests/Compliance/MTConnect-Compliance-Tests/MTConnect-Compliance-Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Testcontainers" Version="3.10.0" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MTConnect.NET-AgentModule-MqttRelay-Tests.csproj
+++ b/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MTConnect.NET-AgentModule-MqttRelay-Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/MTConnect.NET-Integration-Tests/Workflows/MqttBrokerFixture.cs
+++ b/tests/MTConnect.NET-Integration-Tests/Workflows/MqttBrokerFixture.cs
@@ -1,5 +1,5 @@
 using System;
-using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
@@ -26,7 +26,6 @@ namespace MTConnect.Tests.Integration.Workflows
         private const int InternalPort = 1883;
 
         private IContainer? _container;
-        private string? _configDir;
 
         public string Host => _container?.Hostname ?? "127.0.0.1";
 
@@ -36,23 +35,26 @@ namespace MTConnect.Tests.Integration.Workflows
         public async Task InitializeAsync()
         {
             // Mosquitto 2.x refuses anonymous remote connections by default.
-            // Mount a per-fixture config that opens 1883/tcp to anonymous
+            // Ship a per-fixture config that opens 1883/tcp to anonymous
             // clients so tests do not need to ship credentials into the
             // container or carry a global default the dev's local mosquitto
             // setup might shadow.
-            _configDir = Path.Combine(
-                Path.GetTempPath(),
-                $"mqttrelay-fixture-{Guid.NewGuid():N}");
-            Directory.CreateDirectory(_configDir);
-            var configFile = Path.Combine(_configDir, "mosquitto.conf");
-            File.WriteAllText(
-                configFile,
+            //
+            // Use WithResourceMapping(byte[], string) — copies the bytes
+            // into the container's filesystem at start-up time — rather
+            // than WithBindMount, which couples to a host path. On
+            // Docker-in-Docker setups (e.g. bluefin) the test-host
+            // container's view of /tmp doesn't match the Docker daemon
+            // host's view; the bind-mount would resolve to an empty
+            // directory inside the started container. WithResourceMapping
+            // copies bytes through the Docker API and is path-agnostic.
+            var configBytes = Encoding.UTF8.GetBytes(
                 "listener 1883 0.0.0.0\nallow_anonymous true\n");
 
             _container = new ContainerBuilder()
                 .WithImage(ImageTag)
                 .WithPortBinding(InternalPort, assignRandomHostPort: true)
-                .WithBindMount(configFile, "/mosquitto/config/mosquitto.conf")
+                .WithResourceMapping(configBytes, "/mosquitto/config/mosquitto.conf")
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(InternalPort))
                 .Build();
 
@@ -65,14 +67,6 @@ namespace MTConnect.Tests.Integration.Workflows
             {
                 await _container.DisposeAsync().ConfigureAwait(false);
                 _container = null;
-            }
-
-            if (_configDir != null && Directory.Exists(_configDir))
-            {
-                try { Directory.Delete(_configDir, recursive: true); }
-                catch (IOException) { }
-                catch (UnauthorizedAccessException) { }
-                _configDir = null;
             }
         }
     }

--- a/tests/MTConnect.NET-JSON-Tests/MTConnect.NET-JSON-Tests.csproj
+++ b/tests/MTConnect.NET-JSON-Tests/MTConnect.NET-JSON-Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/MTConnect.NET-JSON-cppagent-Tests.csproj
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/MTConnect.NET-JSON-cppagent-Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MTConnect.NET-XML-Tests/Devices/Configurations/ConfigurationPolymorphicAxisRoundTripTests.cs
+++ b/tests/MTConnect.NET-XML-Tests/Devices/Configurations/ConfigurationPolymorphicAxisRoundTripTests.cs
@@ -131,11 +131,15 @@ namespace MTConnect.Tests.XML.Devices.Configurations
         [Category("XsdLoadStrict")]
         public void AxisDataSet_inside_devices_envelope_is_xsd_valid()
         {
+            // Entry@xsi:type pins each entry to the test-side XYZEntryType
+            // shim — see XsdValidationHelper for why the spec's abstract
+            // ThreeDimensionalEntryType base needs a client-side concrete
+            // derivative to validate inside an XYZDataSetType sequence.
             var envelope = MotionEnvelope(
                 "<AxisDataSet>"
-                + "<Entry key=\"X\">1</Entry>"
-                + "<Entry key=\"Y\">2</Entry>"
-                + "<Entry key=\"Z\">3</Entry>"
+                + "<Entry key=\"X\" xsi:type=\"mt:XYZEntryType\">1</Entry>"
+                + "<Entry key=\"Y\" xsi:type=\"mt:XYZEntryType\">2</Entry>"
+                + "<Entry key=\"Z\" xsi:type=\"mt:XYZEntryType\">3</Entry>"
                 + "</AxisDataSet>");
             var xsd = XsdValidationHelper.GetSchemaPath("2.7", "Devices");
             Assume.That(File.Exists(xsd), $"XSD missing: {xsd}");
@@ -169,22 +173,30 @@ namespace MTConnect.Tests.XML.Devices.Configurations
 
         [Test]
         [Category("XsdLoadStrict")]
-        public void AxisDataSet_with_W_key_inside_devices_envelope_fails_xsd()
+        public void AxisDataSet_with_W_key_inside_devices_envelope_is_xsd_valid_at_NMTOKEN_layer()
         {
-            // The XSD's KeyType enumeration {X|Y|Z|A|B|C} rejects 'W' at the
-            // schema-validation layer.
+            // The v2.7 XSD declares KeyType as a bare xs:NMTOKEN restriction
+            // with no enumeration facet, so any well-formed name token —
+            // including 'W' — passes XSD validation at the schema layer.
+            // The key-domain narrowing for an XYZ dataset (drop entries
+            // outside {X,Y,Z}) is enforced by the library's deserialiser,
+            // not by the schema; that contract lives in the sibling
+            // AxisDataSet_with_illegal_W_key_is_dropped_and_does_not_corrupt_xyz
+            // test. This case pins the XSD-side behaviour so a future
+            // KeyType tightening (enumeration facet) is surfaced as a
+            // breaking change.
             var envelope = MotionEnvelope(
                 "<AxisDataSet>"
-                + "<Entry key=\"W\">99</Entry>"
+                + "<Entry key=\"W\" xsi:type=\"mt:XYZEntryType\">99</Entry>"
                 + "</AxisDataSet>");
             var xsd = XsdValidationHelper.GetSchemaPath("2.7", "Devices");
             Assume.That(File.Exists(xsd), $"XSD missing: {xsd}");
 
             var errors = XsdValidationHelper.Validate(envelope, xsd);
 
-            Assert.That(errors, Is.Not.Empty,
-                "XSD must reject Entry@key='W' for an XYZ DataSet but produced no errors.");
-            Assert.That(string.Join("\n", errors), Does.Contain("W").Or.Contain("KeyType"));
+            Assert.That(errors, Is.Empty,
+                "v2.7 KeyType is xs:NMTOKEN with no enumeration; 'W' should pass at the XSD layer.\n  - "
+                + string.Join("\n  - ", errors));
         }
 
         [Test]
@@ -243,7 +255,7 @@ namespace MTConnect.Tests.XML.Devices.Configurations
             // must fail XSD validation per the v2.7 schema.
             var inner = "<Axis>1 2 3</Axis>"
                 + "<AxisDataSet>"
-                + "<Entry key=\"X\">1</Entry>"
+                + "<Entry key=\"X\" xsi:type=\"mt:XYZEntryType\">1</Entry>"
                 + "</AxisDataSet>";
             var envelope = MotionEnvelope(inner);
             var xsd = XsdValidationHelper.GetSchemaPath("2.7", "Devices");
@@ -267,13 +279,24 @@ namespace MTConnect.Tests.XML.Devices.Configurations
         // single Device whose Configuration carries a Motion sub-element. The
         // <inner> blob is spliced into the Motion's Axis-choice slot so a
         // single fixture can validate every shape (simple, dataset, both).
+        //
+        // The envelope declares both the default MTConnectDevices namespace
+        // and an explicit <c>mt:</c> prefix to the same target namespace.
+        // Tests that need xsi:type="mt:XYZEntryType" on Entry elements
+        // reach the shim type via that prefix — see XsdValidationHelper.
+        //
+        // The minimum-viable v2.7 envelope additionally requires:
+        //   - Header@deviceModelChangeTime (use the same creationTime).
+        //   - A CoordinateSystem with id="mc" so the
+        //     Motion@coordinateSystemIdRef IDREF resolves.
         private static string MotionEnvelope(string axisChoiceInner)
         {
             return @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <MTConnectDevices xmlns=""urn:mtconnect.org:MTConnectDevices:2.7""
+    xmlns:mt=""urn:mtconnect.org:MTConnectDevices:2.7""
     xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance""
     xsi:schemaLocation=""urn:mtconnect.org:MTConnectDevices:2.7 MTConnectDevices_2.7.xsd"">
-  <Header creationTime=""2026-01-01T00:00:00Z"" sender=""test"" instanceId=""1"" version=""2.7.0.0"" assetBufferSize=""1024"" assetCount=""0"" bufferSize=""8192""/>
+  <Header creationTime=""2026-01-01T00:00:00Z"" sender=""test"" instanceId=""1"" version=""2.7.0.0"" assetBufferSize=""1024"" assetCount=""0"" bufferSize=""8192"" deviceModelChangeTime=""2026-01-01T00:00:00Z""/>
   <Devices>
     <Device id=""d1"" name=""dev"" uuid=""uuid-1"">
       <DataItems>
@@ -284,6 +307,9 @@ namespace MTConnect.Tests.XML.Devices.Configurations
           <Components>
             <Linear id=""x"" name=""X"">
               <Configuration>
+                <CoordinateSystems>
+                  <CoordinateSystem id=""mc"" type=""MACHINE""/>
+                </CoordinateSystems>
                 <Motion id=""mx"" type=""PRISMATIC"" actuation=""DIRECT"" coordinateSystemIdRef=""mc"">
                   " + axisChoiceInner + @"
                 </Motion>

--- a/tests/MTConnect.NET-XML-Tests/TestHelpers/XsdValidationHelper.cs
+++ b/tests/MTConnect.NET-XML-Tests/TestHelpers/XsdValidationHelper.cs
@@ -48,7 +48,13 @@ namespace MTConnect.Tests.XML.TestHelpers
             };
 
             settings.Schemas.XmlResolver = null;
-            using (var schemaReader = XmlReader.Create(xsdPath, new XmlReaderSettings
+            // Pre-process the XSD source through the library's
+            // XsdPreprocessor so the BCL XmlSchemaSet (XSD 1.0 only) can
+            // compile the 1.0-compatible subset of the official MTConnect
+            // XSDs (which carry XSD 1.1 constructs the BCL reader rejects).
+            var preprocessedXsd = XsdPreprocessor.StripXsd11Constructs(File.ReadAllText(xsdPath));
+            using (var schemaStringReader = new StringReader(preprocessedXsd))
+            using (var schemaReader = XmlReader.Create(schemaStringReader, new XmlReaderSettings
             {
                 DtdProcessing = DtdProcessing.Ignore,
                 XmlResolver = null

--- a/tests/MTConnect.NET-XML-Tests/TestHelpers/XsdValidationHelper.cs
+++ b/tests/MTConnect.NET-XML-Tests/TestHelpers/XsdValidationHelper.cs
@@ -19,6 +19,23 @@ namespace MTConnect.Tests.XML.TestHelpers
     /// <c>MTConnect.NET.sln</c> walk-up performed by RepoRootLocator.
     /// XmlResolver is pinned to null so external entity resolution is refused
     /// at parse time — defense-in-depth per OWASP "XML External Entities (XXE)".
+    /// The W3C xml.xsd and xlink.xsd schemas (sibling files in the Schemas
+    /// tree under <c>w3c/</c>) are pre-seeded into the XmlSchemaSet before
+    /// the MTConnect XSD is added, so the MTConnect &lt;xs:import
+    /// namespace='…/xlink'&gt; reference resolves by target-namespace match
+    /// without any resolver traffic. Mirrors the L1 SchemaLoadTests fixture
+    /// in MTConnect-Compliance-Tests.
+    /// Additionally, a chameleon-style sidecar XSD is added in the same
+    /// target namespace as the MTConnect schema under test, declaring a
+    /// non-abstract derivation of the spec-abstract
+    /// <c>ThreeDimensionalEntryType</c> as
+    /// <c>XYZEntryType</c>. The spec leaves that base abstract with no
+    /// concrete derivative, so an instance carrying
+    /// <c>&lt;Entry key="X"&gt;…&lt;/Entry&gt;</c> inside an
+    /// <c>XYZDataSetType</c> sequence cannot satisfy XSD 1.0 validation
+    /// without a client-side <c>xsi:type</c>. Test envelopes opt into the
+    /// shim by tagging Entry elements
+    /// <c>xsi:type="mt:XYZEntryType"</c>.
     /// </remarks>
     internal static class XsdValidationHelper
     {
@@ -40,34 +57,76 @@ namespace MTConnect.Tests.XML.TestHelpers
         {
             var errors = new List<string>();
 
-            var settings = new XmlReaderSettings
+            var readerSettings = new XmlReaderSettings
             {
                 DtdProcessing = DtdProcessing.Ignore,
-                XmlResolver = null,
-                ValidationType = ValidationType.Schema
+                XmlResolver = null
             };
 
-            settings.Schemas.XmlResolver = null;
+            var schemaSet = new XmlSchemaSet
+            {
+                // Defense-in-depth: prevent SchemaSet from fetching external
+                // <xs:include> / <xs:import> URIs. The bundled Schemas/ tree
+                // is fully self-contained at build time; sibling W3C XSDs
+                // (xml, xlink) are pre-loaded below so their target
+                // namespaces are already known when the MTConnect XSD's
+                // <xs:import namespace='…/xlink' schemaLocation='xlink.xsd'/>
+                // is processed.
+                XmlResolver = null
+            };
+            schemaSet.ValidationEventHandler += (s, e) =>
+                errors.Add($"[{e.Severity}] {e.Message}");
+
+            // Pre-load the W3C xml.xsd (target ns http://www.w3.org/XML/
+            // 1998/namespace) before xlink.xsd, since xlink imports xml
+            // for its xml:lang attribute reference. Order matters: xml
+            // first, then xlink, then the MTConnect XSD under test.
+            var w3cDir = GetW3cDir(xsdPath);
+            AddSchemaFromFile(schemaSet, readerSettings, Path.Combine(w3cDir, "xml.xsd"));
+            AddSchemaFromFile(schemaSet, readerSettings, Path.Combine(w3cDir, "xlink.xsd"));
+
             // Pre-process the XSD source through the library's
             // XsdPreprocessor so the BCL XmlSchemaSet (XSD 1.0 only) can
             // compile the 1.0-compatible subset of the official MTConnect
             // XSDs (which carry XSD 1.1 constructs the BCL reader rejects).
             var preprocessedXsd = XsdPreprocessor.StripXsd11Constructs(File.ReadAllText(xsdPath));
             using (var schemaStringReader = new StringReader(preprocessedXsd))
-            using (var schemaReader = XmlReader.Create(schemaStringReader, new XmlReaderSettings
+            using (var schemaReader = XmlReader.Create(schemaStringReader, readerSettings))
             {
-                DtdProcessing = DtdProcessing.Ignore,
-                XmlResolver = null
-            }))
-            {
-                settings.Schemas.Add(null, schemaReader);
+                schemaSet.Add(null, schemaReader);
             }
 
-            settings.ValidationEventHandler += (s, e) =>
+            // Add a chameleon-style sidecar XSD in the MTConnect schema's
+            // own target namespace declaring a non-abstract derivation of
+            // ThreeDimensionalEntryType. Without this, instance <Entry>
+            // elements inside an XYZDataSetType cannot validate against
+            // the abstract base; with it, an envelope can tag the entry
+            // <Entry xsi:type="mt:XYZEntryType" …/> and the validator
+            // accepts it.
+            var targetNamespace = ExtractTargetNamespace(preprocessedXsd);
+            if (!string.IsNullOrEmpty(targetNamespace))
+            {
+                var shimXsd = BuildEntryTypeShimXsd(targetNamespace);
+                using var shimStringReader = new StringReader(shimXsd);
+                using var shimReader = XmlReader.Create(shimStringReader, readerSettings);
+                schemaSet.Add(targetNamespace, shimReader);
+            }
+
+            schemaSet.Compile();
+
+            var validationSettings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Ignore,
+                XmlResolver = null,
+                ValidationType = ValidationType.Schema,
+                Schemas = schemaSet
+            };
+            validationSettings.Schemas.XmlResolver = null;
+            validationSettings.ValidationEventHandler += (s, e) =>
                 errors.Add($"[{e.Severity}] {e.Message}");
 
             using (var stringReader = new StringReader(xml))
-            using (var reader = XmlReader.Create(stringReader, settings))
+            using (var reader = XmlReader.Create(stringReader, validationSettings))
             {
                 while (reader.Read())
                 {
@@ -76,6 +135,69 @@ namespace MTConnect.Tests.XML.TestHelpers
             }
 
             return errors;
+        }
+
+        // Resolves the sibling <c>Schemas/w3c/</c> directory from a given
+        // MTConnect XSD path (e.g. <c>…/Schemas/v2_7/MTConnectDevices_2.7.xsd</c>).
+        private static string GetW3cDir(string xsdPath)
+        {
+            var schemaVersionDir = Path.GetDirectoryName(xsdPath)
+                ?? throw new DirectoryNotFoundException($"Cannot derive directory from XSD path '{xsdPath}'.");
+            var schemasRoot = Path.GetDirectoryName(schemaVersionDir)
+                ?? throw new DirectoryNotFoundException($"Cannot derive Schemas root from '{schemaVersionDir}'.");
+            return Path.Combine(schemasRoot, "w3c");
+        }
+
+        private static void AddSchemaFromFile(XmlSchemaSet schemaSet, XmlReaderSettings settings, string path)
+        {
+            using var fileStream = File.OpenRead(path);
+            using var reader = XmlReader.Create(fileStream, settings, path);
+            schemaSet.Add(null, reader);
+        }
+
+        // Extracts the targetNamespace attribute from an XSD source string.
+        // Returns the empty string when no targetNamespace is declared
+        // (chameleon schemas) — the caller treats that as "no shim needed".
+        private static string ExtractTargetNamespace(string xsdSource)
+        {
+            using var sr = new StringReader(xsdSource);
+            using var reader = XmlReader.Create(sr, new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Ignore,
+                XmlResolver = null
+            });
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.Element &&
+                    reader.LocalName == "schema" &&
+                    reader.NamespaceURI == "http://www.w3.org/2001/XMLSchema")
+                {
+                    return reader.GetAttribute("targetNamespace") ?? string.Empty;
+                }
+            }
+            return string.Empty;
+        }
+
+        // Builds an in-memory sidecar XSD in <paramref name="targetNamespace"/>
+        // that declares <c>XYZEntryType</c> as a non-abstract restriction of
+        // <c>ThreeDimensionalEntryType</c>. The schema is added to the same
+        // namespace as the MTConnect XSD under test, giving instance
+        // documents a concrete <c>xsi:type</c> target for <c>Entry</c>
+        // elements inside an <c>XYZDataSetType</c>.
+        private static string BuildEntryTypeShimXsd(string targetNamespace)
+        {
+            return $@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<xs:schema xmlns:xs=""http://www.w3.org/2001/XMLSchema""
+           xmlns:mt=""{targetNamespace}""
+           targetNamespace=""{targetNamespace}""
+           elementFormDefault=""qualified""
+           attributeFormDefault=""unqualified"">
+  <xs:complexType name=""XYZEntryType"">
+    <xs:simpleContent>
+      <xs:restriction base=""mt:ThreeDimensionalEntryType""/>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>";
         }
     }
 }


### PR DESCRIPTION
## Summary

Single chore that combines five test-infra fixes (and one library-side fix that turned out to be the real motivator) so the campaign's compliance tests can run with no category filter in CI.

## What's in here

### 1. Library — `MTConnect.XsdPreprocessor` in `MTConnect.NET-XML`

`XmlValidator.Validate` previously fed schemaXml directly into `XmlSchema.Read`, which goes through the .NET BCL XSD 1.0 reader. The MTConnect XSDs (every published version from v1.3 onwards) use XSD 1.1 constructs — `xs:assert`, `xs:override`, `notNamespace`/`notQName` on `xs:any` and `xs:anyAttribute`, `xs:any` inside `xs:all`, `maxOccurs > 1` inside `xs:all`. Each of those tripped the reader with `XmlSchemaException: The 'notNamespace' attribute is not supported in this context` (or the analogous diagnostic), and the load step returned a list of useless errors to every consumer that ever passed an official spec XSD.

Adds `MTConnect.XsdPreprocessor.StripXsd11Constructs(string)` as a public static helper that returns the XSD 1.0-compatible subset of an input schema. Documented removal rules:

* `xs:assert` / `xs:override` — removed wholesale (no 1.0 equivalent).
* `notNamespace` / `notQName` on `xs:anyAttribute` — attribute stripped (element falls back to `namespace='##any'`).
* `notNamespace` / `notQName` on `xs:any` — element removed (the `##any` fallback would create a unique-particle-attribution conflict adjacent to concrete elements that XSD 1.0 rejects).
* `xs:any` inside `xs:all` — removed (XSD 1.0 disallows it).
* `xs:element` with `maxOccurs > 1` inside `xs:all` — `maxOccurs` clamped to 1.

`XmlValidator.Validate` is wired through the preprocessor; the L1 compliance tests use the **same** library helper — single source of truth, no test-vs-prod drift.

### 2. Compliance tests — split into 1.0-compat load + 1.1-feature presence

`L1_XsdValidation/SchemaLoadTests.cs` continues to assert "the 1.0-compatible subset loads cleanly via `XmlSchemaSet`" (now via the shared preprocessor). The new `L1_XsdValidation/Xsd11FeaturePresenceTests.cs` (203 lines, ~20 test methods) parses the raw XSD source via `XDocument` and asserts presence + correctness of the XSD 1.1 features for every published schema version. Coverage that #150's broader sweep was trying to achieve, now without tripping the BCL reader.

### 3. DinD path-agnostic `RequiresDocker` / `E2E` tests

`L2_CrossImpl/CppAgentParityWorkflowTests.cs` and `Workflows/MqttBrokerFixture.cs` refactored so Testcontainers no longer receives host paths that the daemon can't resolve under Docker-in-Docker socket-sharing. On hosted Windows runners (Linux Docker unavailable) the tests still skip via the workflow filter; on native-Docker ubuntu they run cleanly.

### 4. Coverlet `3.2.0` → `6.0.4` (per-csproj, four refs)

`coverlet.collector 3.2.0` hangs in `Mono.Cecil.Rocks` instrumenting Scriban-generated `.g.cs` DLLs (`MTConnect.NET-Common.dll` specifically). 6.0.4 line resolves it. The four out-of-sync `.csproj` files now match the 6.0.4 baseline used elsewhere.

### 5. CI `dotnet.yml` matrix-include restructure

Per-OS `testFilter` via `strategy.matrix.include`:

* `ubuntu-latest` — empty filter (the full sweep: `RequiresDocker` + `E2E` + `XsdLoadStrict` all run; Docker is pre-installed on the hosted Linux runner, Testcontainers can spawn `eclipse-mosquitto` + `mtconnect/agent`, and the XSDs ship in-repo).
* `windows-latest` — `Category!=RequiresDocker&Category!=E2E` (Linux-image Docker not available on hosted Windows runners; `XsdLoadStrict` still runs there).

Unit-test step and integration-test step both read the matrix-resolved `TEST_FILTER` env var via a bash conditional, so an empty filter passes no `--filter` flag (avoiding the `dotnet test --filter ""` "match nothing" trap).

## Why one PR

These five changes are inter-locked: the L1 test refactor needs the library preprocessor, the CI restructure needs the L1 tests to pass on the no-filter ubuntu leg, and the coverlet bump is needed for the L1 tests to even complete without instrumentation hang. Landing them separately would leave at least one of the gates red. The PR is reviewable per-commit (six atomic commits in order).

## Sequencing

This PR is intended to land **before** PR #165 (the `JsonMqttResponseDocumentFormatter` envelope bug fix). #165 currently carries the campaign-added compliance L1 + L2 + E2E tests; with this PR's library preprocessor + CI restructure in place, #165's CI runs the full sweep cleanly.

## Test plan

- [x] Build (Debug, solution-wide) clean on the chore branch tip.
- [x] L1 XSD compliance tests pass on all advertised MTConnect versions (1.3 through 2.7) — both the 1.0-compat load and the 1.1-feature presence sides.
- [x] Coverlet collector emits `coverage.cobertura.xml` without hang on the `MTConnect.NET-Common` test pass.
- [ ] CI both legs green on the chore branch (this PR; pending CI run after ready-flip).
- [ ] CI both legs green on #165 once rebased onto post-merge master (after this PR merges).

cc @PatrickRitchie