### PR TITLE
fix(test): snapshot received topics under lock in probe-envelope race

### DIFF
--- a/tests/MTConnect.NET-Integration-Tests/Workflows/JsonMqttProbeEnvelopeIntegrationTests.cs
+++ b/tests/MTConnect.NET-Integration-Tests/Workflows/JsonMqttProbeEnvelopeIntegrationTests.cs
@@ -164,16 +164,29 @@ namespace MTConnect.Tests.Integration.Workflows
             var completed = await Task.WhenAny(
                 allArrived.Task,
                 Task.Delay(TimeSpan.FromSeconds(30)));
+
+            // Freeze the received-topic set under the lock before
+            // inspecting it. The MQTT subscriber handler is still
+            // live after Task.WhenAny -- QoS-1 retransmits or late
+            // deliveries can fire after allArrived.TrySetResult, and
+            // an unlocked Dictionary read on the assertion path
+            // collides with the locked write site at line 144.
+            KeyValuePair<string, byte[]>[] snapshot;
+            lock (receivedLock)
+            {
+                snapshot = received.ToArray();
+            }
+
             Assert.True(
                 completed == allArrived.Task,
                 $"Did not receive Probe payloads for every device within 30s "
-                + $"(received {received.Count} topics: "
-                + $"{string.Join(", ", received.Keys)}).");
+                + $"(received {snapshot.Length} topics: "
+                + $"{string.Join(", ", snapshot.Select(kv => kv.Key))}).");
 
             // Inspect every received Probe payload: each must wrap content
             // in MTConnectDevices.Devices as a JSON object with Device[]
             // (and, on the agent topic, Agent[]).
-            foreach (var (topic, payload) in received)
+            foreach (var (topic, payload) in snapshot)
             {
                 var json = Encoding.UTF8.GetString(payload);
                 using var doc = JsonDocument.Parse(json);


### PR DESCRIPTION
## Symptom

`Probe_envelope_multi_device_round_trip_preserves_every_device` fails on `ubuntu-latest` CI with:

```
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.Dictionary`2.Enumerator.MoveNext()
```

The failure is timing-sensitive -- it did not reproduce on the local Docker-in-Docker loop -- and surfaced on the CI run for PR #162 after it inherited master at `1be96a1e` (merged via PR #165).

## Race

The `ApplicationMessageReceivedAsync` subscriber handler in this test writes to `received` (a `Dictionary<string, byte[]>`) under `lock (receivedLock)`. After `Task.WhenAny(allArrived.Task, Task.Delay(30s))` returns, the subscriber is still live: QoS-1 retransmits or late deliveries can fire even after `allArrived.TrySetResult(true)` has been called. Three sites on the assertion path read `received` without taking the lock:

- `received.Count` in the timeout-message string
- `received.Keys` in the topic-list string
- the `foreach (var (topic, payload) in received)` iteration

A concurrent write inside the foreach is what `ubuntu-latest` hits. This is not a test-infrastructure flake -- it is a real concurrent-mutation defect that manifests under contended scheduling.

## Fix

Take the lock once immediately after `Task.WhenAny` returns, snapshot `received` into a `KeyValuePair<string, byte[]>[]` via `received.ToArray()`, then route the assertion message and the foreach through the snapshot. The live dictionary is no longer read outside the lock; the handler itself is unchanged.

The companion test `Probe_envelope_round_trip_through_formatter_preserves_Agent_name_case` uses a `TaskCompletionSource<byte[]>` rather than a `Dictionary`, so it is not affected.

## Merge train

Inserts ahead of the current `#162 -> #160 -> #164 -> #157` queue at the head, since #162's CI is blocked on this defect until it lands. After merge, PRs #162, #160, and #164 cascade-rebase onto the new master tip; rerere should absorb the trivial test-only diff.
