### PR TITLE
fix(common): preflight XML doc warnings for strict-gate composition

### DIFF
--- a/libraries/MTConnect.NET-Common/Configurations/IAdapterApplicationConfiguration.cs
+++ b/libraries/MTConnect.NET-Common/Configurations/IAdapterApplicationConfiguration.cs
@@ -49,7 +49,6 @@ namespace MTConnect.Configurations
 
 
         /// <summary>
-        /// <summary>
         /// Changes the service name when installing or removing the service. This allows multiple Adapters to run as services on the same machine.
         /// </summary>
         string ServiceName { get; set; }

--- a/libraries/MTConnect.NET-Common/Streams/DeviceStream.cs
+++ b/libraries/MTConnect.NET-Common/Streams/DeviceStream.cs
@@ -27,7 +27,7 @@ namespace MTConnect.Streams
         public IEnumerable<IComponentStream> ComponentStreams { get; set; }
 
         /// <summary>
-        /// Gets All Observations (Samples, Events, & Conditions)
+        /// Gets All Observations (Samples, Events, &amp; Conditions)
         /// </summary>
         public IEnumerable<IObservation> Observations
         {

--- a/libraries/MTConnect.NET-Common/Streams/IComponentStream.cs
+++ b/libraries/MTConnect.NET-Common/Streams/IComponentStream.cs
@@ -43,7 +43,7 @@ namespace MTConnect.Streams
         string Uuid { get; }
 
         /// <summary>
-        /// Gets All Observations (Samples, Events, & Conditions)
+        /// Gets All Observations (Samples, Events, &amp; Conditions)
         /// </summary>
         IEnumerable<IObservation> Observations { get; }
 

--- a/libraries/MTConnect.NET-Common/Streams/IDeviceStream.cs
+++ b/libraries/MTConnect.NET-Common/Streams/IDeviceStream.cs
@@ -27,7 +27,7 @@ namespace MTConnect.Streams
         IEnumerable<IComponentStream> ComponentStreams { get; }
 
         /// <summary>
-        /// Gets All Observations (Samples, Events, & Conditions)
+        /// Gets All Observations (Samples, Events, &amp; Conditions)
         /// </summary>
         IEnumerable<IObservation> Observations { get; }
 

--- a/libraries/MTConnect.NET-Common/Streams/IStreamsResponseDocument.cs
+++ b/libraries/MTConnect.NET-Common/Streams/IStreamsResponseDocument.cs
@@ -29,7 +29,7 @@ namespace MTConnect.Streams
         Version Version { get; }
 
         /// <summary>
-        /// Gets All Observations (Samples, Events, & Conditions)
+        /// Gets All Observations (Samples, Events, &amp; Conditions)
         /// </summary>
         IEnumerable<IObservation> GetObservations();
     }

--- a/libraries/MTConnect.NET-Common/Streams/Output/DeviceStreamOutput.cs
+++ b/libraries/MTConnect.NET-Common/Streams/Output/DeviceStreamOutput.cs
@@ -27,7 +27,7 @@ namespace MTConnect.Streams.Output
         public IComponentStreamOutput[] ComponentStreams { get; set; }
 
         /// <summary>
-        /// Gets All Observations (Samples, Events, & Conditions)
+        /// Gets All Observations (Samples, Events, &amp; Conditions)
         /// </summary>
         public IEnumerable<IObservationOutput> Observations
         {

--- a/libraries/MTConnect.NET-Common/Streams/Output/IComponentStreamOutput.cs
+++ b/libraries/MTConnect.NET-Common/Streams/Output/IComponentStreamOutput.cs
@@ -42,7 +42,7 @@ namespace MTConnect.Streams.Output
         string Uuid { get; }
 
         /// <summary>
-        /// Gets All Observations (Samples, Events, & Conditions)
+        /// Gets All Observations (Samples, Events, &amp; Conditions)
         /// </summary>
         IObservationOutput[] Observations { get; }
     }  

--- a/libraries/MTConnect.NET-Common/Streams/Output/IDeviceStreamOutput.cs
+++ b/libraries/MTConnect.NET-Common/Streams/Output/IDeviceStreamOutput.cs
@@ -27,7 +27,7 @@ namespace MTConnect.Streams.Output
         IComponentStreamOutput[] ComponentStreams { get; }
 
         /// <summary>
-        /// Gets All Observations (Samples, Events, & Conditions)
+        /// Gets All Observations (Samples, Events, &amp; Conditions)
         /// </summary>
         IEnumerable<IObservationOutput> Observations { get; }
     }

--- a/libraries/MTConnect.NET-Common/Streams/Output/IStreamsResponseOutputDocument.cs
+++ b/libraries/MTConnect.NET-Common/Streams/Output/IStreamsResponseOutputDocument.cs
@@ -29,7 +29,7 @@ namespace MTConnect.Streams.Output
         Version Version { get; }
 
         /// <summary>
-        /// Gets All Observations (Samples, Events, & Conditions)
+        /// Gets All Observations (Samples, Events, &amp; Conditions)
         /// </summary>
         IEnumerable<IObservationOutput> GetObservations();
 

--- a/libraries/MTConnect.NET-SysML/Xmi/XmiDeserializer.cs
+++ b/libraries/MTConnect.NET-SysML/Xmi/XmiDeserializer.cs
@@ -18,7 +18,6 @@ namespace MTConnect.SysML.Xmi
         /// Constructs a new instance of the deserializer with a reference to the source document.
         /// </summary>
         /// <param name="xmlDocument">A source of XMI to deserialize</param>
-        /// <param name="logger"><inheritdoc cref="ILogger" path="/summary"/></param>
         public XmiDeserializer(XmlDocument xmlDocument)
         {
             xDoc = xmlDocument;
@@ -78,7 +77,6 @@ namespace MTConnect.SysML.Xmi
         /// Creates a <see cref="XmiDeserializer"/> from a reference to the filepath of a XMI document.
         /// </summary>
         /// <param name="filename">Filepath to a XMI-formatted XML document.</param>
-        /// <param name="logger"><inheritdoc cref="ILogger" path="/summary"/></param>
         /// <returns><inheritdoc cref="XmiDeserializer" path="/summary"/></returns>
         public static XmiDeserializer FromFile(string filename)
         {
@@ -106,7 +104,6 @@ namespace MTConnect.SysML.Xmi
         /// Creates a <see cref="XmiDeserializer"/> from raw XML.
         /// </summary>
         /// <param name="xml">Raw XML string</param>
-        /// <param name="logger"><inheritdoc cref="ILogger" path="/summary"/></param>
         /// <returns><inheritdoc cref="XmiDeserializer" path="/summary"/></returns>
         public static XmiDeserializer FromXml(string xml)
         {


### PR DESCRIPTION
## Summary

Fixes pre-existing XML doc structural defects that surface only when `GenerateDocumentationFile=true` and `TreatWarningsAsErrors=true` compose. Two families:

- **CS1570 (bare `&` in `///` comments)** — escape `&` to `&amp;` in 8 sites under `libraries/MTConnect.NET-Common/Streams/`. Bare `&` in a doc-comment is interpreted as the start of an XML entity reference; the doc-file build step then reports "badly formed XML in include comment".
- **CS1570 (nested `<summary>` tag)** — remove the duplicated `<summary>` opener in `IAdapterApplicationConfiguration.ServiceName`, which produces "Expected an end tag for element 'summary'".
- **CS1572 + CS1574 (orphan `<param name="logger">` + cref `ILogger`)** — three sites in `MTConnect.NET-SysML/Xmi/XmiDeserializer.cs` carry stale param tags referring to a parameter that no longer exists, and cite a type (`ILogger`) the project doesn't reference. Drop the lines; the surviving tags cover every real parameter.

These are silent warnings on `master` today; the build only goes red when a downstream branch flips both gates. Preflighting them here keeps the downstream branch's diff focused on its real change.

## Deferred follow-up

Investigation under the strict-gate composition surfaced **~114 additional XML-doc-comment-vs-signature mismatches** beyond the structural defects fixed here:

- 104 × CS1573 (parameter has no matching `<param>` tag)
- 4 × CS1572 (orphan `<param>` tags at other sites)
- 2 × CS1712 (missing `<typeparam>`)
- 2 × CS1711 (typeparam for non-existent type parameter)
- 2 × CS1570 (other malformed XML — including one with literal `0x02` in a copy-pasted XML body)

These concentrate in `libraries/MTConnect.NET-Common/{Configurations,Agents,Devices}/` (`DeviceConfiguration.cs`, `ConfigurationFileWatcher.cs`, `MTConnectAgentBroker.cs`, `IMTConnectAgentBroker.cs`, `IDevicesDocument.cs`). They are pre-existing on `master` and turn into errors under the same strict gates. Tracking as a follow-up rather than expanding this PR's scope, since the fix is per-signature reconciliation (semantic content review of each `<param>` block) rather than mechanical escaping.
