### PR TITLE
ci(repo): add workflow_dispatch trigger to dotnet.yml for ad-hoc runs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,6 +22,12 @@ on:
     paths-ignore:
       - 'README.md'
       - 'docs/**'
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Branch to run CI against (default: the dispatching branch)'
+        required: false
+        type: string
 
 jobs:
   build-and-test:
@@ -29,7 +35,7 @@ jobs:
     # Skip drafts: run only on push-to-master + ready (non-draft) PRs.
     # The pull_request `types` list above includes `ready_for_review` so
     # CI fires the moment a draft is flipped to ready.
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Adds a \`workflow_dispatch:\` trigger to \`.github/workflows/dotnet.yml\` so the CI workflow can be invoked on-demand from the Actions tab without a \`push\` event.

- Add \`workflow_dispatch:\` as a third top-level trigger alongside the existing \`push:\` and \`pull_request:\` triggers.
- Optionally accept a \`target_branch\` input so dispatchers can run CI against a specific branch from the form.
- Update the job-level \`if:\` guard to pass \`workflow_dispatch\` events through (previously only \`push\` and non-draft PRs were allowed past the draft-skip condition).
- Leave the existing \`push:\` and \`pull_request:\` triggers unchanged.

The motivation is ad-hoc CI validation on draft PRs: when diagnosing a flake or verifying a fix on a non-queue-head PR, a manual dispatch lets the run happen without flipping the PR to ready (which would otherwise be the only way to trigger the per-PR matrix on a non-default branch).