### PR TITLE
chore(repo): drop redundant package.json ignore/override pair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ build/MTConnect.NET.Builder/config.production.yaml
 gulpfile.js
 *.zip
 
-package.json
-package-lock.json
-
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot


### PR DESCRIPTION
## Summary

Drops a redundant ignore/override pair from \`.gitignore\`: the broad \`package.json\` + \`package-lock.json\` ignore plus the \`!docs/package.json\` + \`!docs/package-lock.json\` overrides that re-allow the docs site's manifest.

- The repo is C#/.NET; the only npm-using surface is \`docs/\` (VitePress).
- No other \`package.json\` files exist in the tree that need to be ignored.
- Removing the broad ignore + the override pair leaves \`docs/package.json\` and \`docs/package-lock.json\` tracked naturally, with simpler \`.gitignore\` semantics.