### PR TITLE
chore(repo): normalize sln line endings and doc OG image URL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,12 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# Visual Studio solution files are canonically CRLF. Pin the line-ending
+# so cross-platform edits (mixed-OS contributors, scripted regenerators
+# that emit LF, editors that drop the trailing CR on save) do not drift
+# the file off the format Visual Studio + MSBuild expect.
+*.sln    text eol=crlf
+
 # Custom for Visual Studio
 *.cs     diff=csharp
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,6 +2,14 @@ import { defineConfig } from 'vitepress';
 import { withMermaid } from 'vitepress-plugin-mermaid';
 import { apiSidebar, referenceSidebar } from './sidebar';
 
+// Absolute base URL for the deployed site. Social-card crawlers (LinkedIn,
+// Slack unfurl, the classic X crawler) require absolute `https://…` URLs in
+// og:image / twitter:image; root-relative paths are silently discarded.
+// Override at workflow level via DOCS_CANONICAL_URL for custom domains.
+const docsCanonicalUrl =
+  process.env.DOCS_CANONICAL_URL ?? 'https://trakhound.github.io/MTConnect.NET';
+const ogImage = `${docsCanonicalUrl}/logo.png`;
+
 /**
  * VitePress config for the MTConnect.NET documentation site.
  *
@@ -62,7 +70,7 @@ export default withMermaid(
             'The .NET implementation of the MTConnect Standard — 100% public-surface API coverage, 100% MTConnect Standard compliance.',
         },
       ],
-      ['meta', { property: 'og:image', content: '/logo.png' }],
+      ['meta', { property: 'og:image', content: ogImage }],
       ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
       ['meta', { name: 'twitter:title', content: 'MTConnect.NET' }],
       [
@@ -72,7 +80,7 @@ export default withMermaid(
           content: 'The .NET implementation of the MTConnect Standard.',
         },
       ],
-      ['meta', { name: 'twitter:image', content: '/logo.png' }],
+      ['meta', { name: 'twitter:image', content: ogImage }],
     ],
 
     themeConfig: {

--- a/tests/MTConnect.NET-Docs-Tests/RouteCheckTests.cs
+++ b/tests/MTConnect.NET-Docs-Tests/RouteCheckTests.cs
@@ -312,9 +312,13 @@ public class RouteCheckTests
                 "favicon type attribute is not 'image/png'");
 
             // Open Graph — title + image surface so social previews render.
+            // og:image must be an absolute https:// URL; LinkedIn, Slack unfurl,
+            // and the classic X crawler reject root-relative paths for social cards.
             Assert.That(probes.OgTitle, Is.EqualTo("MTConnect.NET"),
                 "og:title meta does not match the expected site title");
             Assert.That(probes.OgImage, Is.Not.Null.And.Not.Empty, "og:image meta missing");
+            Assert.That(probes.OgImage, Does.StartWith("https://"),
+                $"og:image must be an absolute https:// URL for social-card crawlers — got '{probes.OgImage}'");
             Assert.That(probes.OgImage, Does.EndWith("/logo.png"),
                 $"og:image does not point at /logo.png — got '{probes.OgImage}'");
 
@@ -322,6 +326,8 @@ public class RouteCheckTests
             Assert.That(probes.TwitterCard, Is.EqualTo("summary_large_image"),
                 "twitter:card meta is not 'summary_large_image'");
             Assert.That(probes.TwitterImage, Is.Not.Null.And.Not.Empty, "twitter:image meta missing");
+            Assert.That(probes.TwitterImage, Does.StartWith("https://"),
+                $"twitter:image must be an absolute https:// URL for social-card crawlers — got '{probes.TwitterImage}'");
             Assert.That(probes.TwitterImage, Does.EndWith("/logo.png"),
                 $"twitter:image does not point at /logo.png — got '{probes.TwitterImage}'");
 


### PR DESCRIPTION
## What changed

- `.gitattributes` now declares `*.sln text eol=crlf` so Visual Studio for Windows no longer re-encodes `MTConnect.NET.sln` on open. Git stores the blob with LF normalization and delivers CRLF to the working tree on every checkout, so Windows contributors stop seeing a dirty diff every time they open the solution.
- `docs/.vitepress/config.ts` now derives the canonical Open Graph image URL from `DOCS_CANONICAL_URL` (defaulting to the GitHub Pages host for this repository). LinkedIn, Slack unfurl, and the classic X crawler require absolute `https://…` URLs for social-card images; the previous root-relative `/logo.png` was silently discarded by those crawlers and produced blank social previews. Operators deploying to a custom domain can override the default via `DOCS_CANONICAL_URL` at workflow level.
- The landing-page house-style E2E test gains two `StartsWith("https://")` assertions for `og:image` and `twitter:image` so a future regression back to a root-relative path fails the test suite.

## Why

Both items are mechanical cleanups that surfaced during a review of the merged docs and solution-wireup PRs but were deferred past merge. Folding them into one chore PR avoids two single-commit train slots.

## Verification

- `dotnet build MTConnect.NET.sln` — 0 warnings, 0 errors.
- `dotnet test` (non-E2E) — all pass.
- `npm run build` in `docs/` — VitePress build green; `og:image` and `twitter:image` render as `https://trakhound.github.io/MTConnect.NET/logo.png` in the default deploy.
- `docs/scripts/generate-api-ref.sh` — 0 errors, 2146 pages generated.