### PR TITLE
chore(ci): unblock master (docs drift, Scriban CVE, nav-title test)

### DIFF
--- a/build/MTConnect.NET-SysML-Import/MTConnect.NET-SysML-Import.csproj
+++ b/build/MTConnect.NET-SysML-Import/MTConnect.NET-SysML-Import.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Scriban" Version="7.2.0" />
+		<PackageReference Include="Scriban" Version="7.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -15,19 +15,19 @@ Routes are registered inside `MTConnectHttpServer.ConfigureServer` and dispatche
 
 | Method | Path | Handler | Source |
 | --- | --- | --- | --- |
-| `GET` | `(any)` | `probeHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:323` |
-| `GET` | `/` | `probeHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:335` |
-| `GET` | `/*/assets` | `assetsHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:343` |
-| `GET` | `/*/current` | `currentHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:339` |
-| `GET` | `/*/probe` | `probeHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:337` |
-| `GET` | `/*/sample` | `sampleHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:341` |
-| `GET` | `/asset/*` | `assetHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:344` |
-| `GET` | `/assets` | `assetsHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:342` |
-| `GET` | `/current` | `currentHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:338` |
-| `GET` | `/probe` | `probeHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:336` |
-| `GET` | `/sample` | `sampleHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:340` |
-| `POST` | `(any)` | `postHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:331` |
-| `PUT` | `(any)` | `putHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:327` |
+| `GET` | `(any)` | `probeHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:345` |
+| `GET` | `/` | `probeHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:331` |
+| `GET` | `/*/assets` | `assetsHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:339` |
+| `GET` | `/*/current` | `currentHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:335` |
+| `GET` | `/*/probe` | `probeHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:333` |
+| `GET` | `/*/sample` | `sampleHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:337` |
+| `GET` | `/asset/*` | `assetHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:340` |
+| `GET` | `/assets` | `assetsHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:338` |
+| `GET` | `/current` | `currentHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:334` |
+| `GET` | `/probe` | `probeHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:332` |
+| `GET` | `/sample` | `sampleHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:336` |
+| `POST` | `(any)` | `postHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:327` |
+| `PUT` | `(any)` | `putHandler` | `libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:323` |
 
 ## Per-endpoint detail
 
@@ -35,7 +35,7 @@ Routes are registered inside `MTConnectHttpServer.ConfigureServer` and dispatche
 
 - **Handler**: `probeHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:323`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L323)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:345`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L345)
 
 Method-gated dispatcher; routes the request to the handler matching the request method.
 
@@ -43,7 +43,7 @@ Method-gated dispatcher; routes the request to the handler matching the request 
 
 - **Handler**: `probeHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:335`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L335)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:331`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L331)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the MTConnect Probe endpoint (GET /probe and GET /{deviceKey}/probe, plus the bare GET / alias). Returns an MTConnectDevices Response Document describing the device metadata visible to the agent. The optional leading path segment selects a single device by name or UUID. The response document format is negotiated via the documentFormat query parameter (xml | json | json-cppagent) and defaults to XML; deviceType, version, validationLevel, indentOutput, and outputComments further shape the payload.
@@ -63,7 +63,7 @@ Ceen request handler for the MTConnect Probe endpoint (GET /probe and GET /{devi
 
 - **Handler**: `assetsHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:343`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L343)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:339`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L339)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the MTConnect Assets endpoint (GET /assets and GET /{deviceKey}/assets). Returns an MTConnectAssets Response Document containing the asset records known to the agent. The optional leading path segment scopes the response to assets owned by a specific device; the type, removed, and count query parameters filter the asset set; documentFormat (xml | json | json-cppagent, default XML) and indentOutput negotiate the rendered representation.
@@ -82,7 +82,7 @@ Ceen request handler for the MTConnect Assets endpoint (GET /assets and GET /{de
 
 - **Handler**: `currentHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:339`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L339)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:335`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L335)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the MTConnect Current endpoint (GET /current and GET /{deviceKey}/current). Returns an MTConnectStreams Response Document containing the current observation snapshot for every data item visible to the agent, optionally filtered by an XPath in the path query parameter and anchored to a sequence number via at. When interval is supplied, the handler upgrades the response to a multipart x-mixed-replace stream and emits a fresh snapshot every interval milliseconds, interleaved with heartbeats. The response document format is negotiated via documentFormat (xml | json | json-cppagent), defaulting to XML; deviceType, version, indentOutput, and outputComments further shape the payload.
@@ -105,7 +105,7 @@ Ceen request handler for the MTConnect Current endpoint (GET /current and GET /{
 
 - **Handler**: `probeHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:337`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L337)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:333`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L333)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the MTConnect Probe endpoint (GET /probe and GET /{deviceKey}/probe, plus the bare GET / alias). Returns an MTConnectDevices Response Document describing the device metadata visible to the agent. The optional leading path segment selects a single device by name or UUID. The response document format is negotiated via the documentFormat query parameter (xml | json | json-cppagent) and defaults to XML; deviceType, version, validationLevel, indentOutput, and outputComments further shape the payload.
@@ -125,7 +125,7 @@ Ceen request handler for the MTConnect Probe endpoint (GET /probe and GET /{devi
 
 - **Handler**: `sampleHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:341`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L341)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:337`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L337)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the MTConnect Sample endpoint (GET /sample and GET /{deviceKey}/sample). Returns an MTConnectStreams Response Document containing a slice of historical observations bounded by the from / to / count query parameters, optionally filtered by an XPath in path. When interval is supplied, the handler upgrades the response to a multipart x-mixed-replace stream and emits successive sample windows every interval milliseconds, interleaved with heartbeats. The response document format is negotiated via documentFormat (xml | json | json-cppagent), defaulting to XML; deviceType, version, indentOutput, and outputComments further shape the payload.
@@ -150,7 +150,7 @@ Ceen request handler for the MTConnect Sample endpoint (GET /sample and GET /{de
 
 - **Handler**: `assetHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:344`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L344)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:340`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L340)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the single-asset MTConnect endpoint (GET /asset/{assetId}). Returns an MTConnectAssets Response Document containing the asset identified by the trailing path segment, or an MTConnectError document with status 404 when no such asset exists. The response document format is negotiated via the documentFormat query parameter (xml | json | json-cppagent) and defaults to XML.
@@ -166,7 +166,7 @@ Ceen request handler for the single-asset MTConnect endpoint (GET /asset/{assetI
 
 - **Handler**: `assetsHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:342`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L342)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:338`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L338)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the MTConnect Assets endpoint (GET /assets and GET /{deviceKey}/assets). Returns an MTConnectAssets Response Document containing the asset records known to the agent. The optional leading path segment scopes the response to assets owned by a specific device; the type, removed, and count query parameters filter the asset set; documentFormat (xml | json | json-cppagent, default XML) and indentOutput negotiate the rendered representation.
@@ -185,7 +185,7 @@ Ceen request handler for the MTConnect Assets endpoint (GET /assets and GET /{de
 
 - **Handler**: `currentHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:338`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L338)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:334`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L334)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the MTConnect Current endpoint (GET /current and GET /{deviceKey}/current). Returns an MTConnectStreams Response Document containing the current observation snapshot for every data item visible to the agent, optionally filtered by an XPath in the path query parameter and anchored to a sequence number via at. When interval is supplied, the handler upgrades the response to a multipart x-mixed-replace stream and emits a fresh snapshot every interval milliseconds, interleaved with heartbeats. The response document format is negotiated via documentFormat (xml | json | json-cppagent), defaulting to XML; deviceType, version, indentOutput, and outputComments further shape the payload.
@@ -208,7 +208,7 @@ Ceen request handler for the MTConnect Current endpoint (GET /current and GET /{
 
 - **Handler**: `probeHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:336`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L336)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:332`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L332)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the MTConnect Probe endpoint (GET /probe and GET /{deviceKey}/probe, plus the bare GET / alias). Returns an MTConnectDevices Response Document describing the device metadata visible to the agent. The optional leading path segment selects a single device by name or UUID. The response document format is negotiated via the documentFormat query parameter (xml | json | json-cppagent) and defaults to XML; deviceType, version, validationLevel, indentOutput, and outputComments further shape the payload.
@@ -228,7 +228,7 @@ Ceen request handler for the MTConnect Probe endpoint (GET /probe and GET /{devi
 
 - **Handler**: `sampleHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:340`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L340)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:336`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L336)
 - **Response status codes**: 200, 400, 404, 406, 500
 
 Ceen request handler for the MTConnect Sample endpoint (GET /sample and GET /{deviceKey}/sample). Returns an MTConnectStreams Response Document containing a slice of historical observations bounded by the from / to / count query parameters, optionally filtered by an XPath in path. When interval is supplied, the handler upgrades the response to a multipart x-mixed-replace stream and emits successive sample windows every interval milliseconds, interleaved with heartbeats. The response document format is negotiated via documentFormat (xml | json | json-cppagent), defaulting to XML; deviceType, version, indentOutput, and outputComments further shape the payload.
@@ -253,7 +253,7 @@ Ceen request handler for the MTConnect Sample endpoint (GET /sample and GET /{de
 
 - **Handler**: `postHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:331`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L331)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:327`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L327)
 
 Method-gated dispatcher; routes the request to the handler matching the request method.
 
@@ -261,7 +261,7 @@ Method-gated dispatcher; routes the request to the handler matching the request 
 
 - **Handler**: `putHandler`
 - **Surface**: Agent
-- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:327`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L327)
+- **Source**: [`libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs:323`](https://github.com/TrakHound/MTConnect.NET/blob/master/libraries/MTConnect.NET-HTTP/Servers/MTConnectHttpServer.cs#L323)
 
 Method-gated dispatcher; routes the request to the handler matching the request method.
 

--- a/tests/MTConnect.NET-Docs-Tests/RouteCheckTests.cs
+++ b/tests/MTConnect.NET-Docs-Tests/RouteCheckTests.cs
@@ -345,11 +345,16 @@ public class RouteCheckTests
             // VitePress's default home layout renders the hero image as
             // .VPHero .VPImage when `hero.image.src` is set in index.md;
             // the fallback `.VPHero img[src*='logo']` covers theme-overridden
-            // cases where a custom hero component is in play.
+            // cases where a custom hero component is in play. Per maintainer
+            // commit c2041cef ("Updated Docs Site" 2026-06-26), the hero
+            // image points at `logo-large.png` — a bigger asset than the
+            // 32-px favicon `logo.png` — so the assertion accepts any
+            // `/logo*.png` variant to survive future asset swaps in the
+            // same shape.
             Assert.That(probes.HeroImageSrc, Is.Not.Null.And.Not.Empty,
                 "no image rendered inside .VPHero — hero.image did not take effect");
-            Assert.That(probes.HeroImageSrc, Does.EndWith("/logo.png"),
-                $"hero image src does not point at /logo.png — got '{probes.HeroImageSrc}'");
+            Assert.That(probes.HeroImageSrc, Does.Match(@"/logo[^/]*\.png$"),
+                $"hero image src does not match /logo*.png — got '{probes.HeroImageSrc}'");
 
             // Hero 'Download latest release' CTA — text + canonical link.
             Assert.That(probes.DownloadCtaHref, Is.EqualTo(

--- a/tests/MTConnect.NET-Docs-Tests/RouteCheckTests.cs
+++ b/tests/MTConnect.NET-Docs-Tests/RouteCheckTests.cs
@@ -289,7 +289,7 @@ public class RouteCheckTests
                 ogImage: document.querySelector('meta[property=""og:image""]')?.getAttribute('content') ?? null,
                 twitterCard: document.querySelector('meta[name=""twitter:card""]')?.getAttribute('content') ?? null,
                 twitterImage: document.querySelector('meta[name=""twitter:image""]')?.getAttribute('content') ?? null,
-                heroLogoSrc: document.querySelector('.VPNavBarTitle img.logo')?.getAttribute('src') ?? null,
+                navTitleText: document.querySelector('.VPNavBarTitle')?.textContent?.trim() ?? null,
                 heroImageSrc: (document.querySelector('.VPHero .VPImage')
                     ?? document.querySelector('.VPHero img[src*=""logo""]'))?.getAttribute('src') ?? null,
                 downloadCtaHref: (() => {
@@ -331,14 +331,14 @@ public class RouteCheckTests
             Assert.That(probes.TwitterImage, Does.EndWith("/logo.png"),
                 $"twitter:image does not point at /logo.png — got '{probes.TwitterImage}'");
 
-            // themeConfig.logo — VitePress renders the logo as an <img>
-            // inside .VPNavBarTitle when themeConfig.logo is set. The
-            // text site title is hidden (themeConfig.siteTitle: false)
-            // because the logo PNG already carries the wordmark.
-            Assert.That(probes.HeroLogoSrc, Is.Not.Null.And.Not.Empty,
-                "no <img> rendered inside .VPNavBarTitle — themeConfig.logo did not take effect");
-            Assert.That(probes.HeroLogoSrc, Does.EndWith("/logo.png"),
-                $"nav logo src does not point at /logo.png — got '{probes.HeroLogoSrc}'");
+            // Nav title — text-only (per maintainer decision in commit
+            // c2041cef "Updated Docs Site" 2026-06-26: the logo was
+            // deemed too small to read in the nav bar, so the title
+            // reverted to the plain text "MTConnect.NET"). The nav-bar
+            // no longer contains an <img>; the wordmark rendering lives
+            // in the hero block below.
+            Assert.That(probes.NavTitleText, Is.EqualTo("MTConnect.NET"),
+                $"nav-bar title text does not match 'MTConnect.NET' — got '{probes.NavTitleText}'");
 
             // Hero image — pinned per §1.0d-trigies-semel (the maintainer-supplied
             // logo must render in the landing hero block, not just the nav bar).
@@ -404,8 +404,8 @@ public class RouteCheckTests
         [JsonPropertyName("twitterImage")]
         public string? TwitterImage { get; set; }
 
-        [JsonPropertyName("heroLogoSrc")]
-        public string? HeroLogoSrc { get; set; }
+        [JsonPropertyName("navTitleText")]
+        public string? NavTitleText { get; set; }
 
         [JsonPropertyName("heroImageSrc")]
         public string? HeroImageSrc { get; set; }


### PR DESCRIPTION
## Summary

Unblock master's CI, red since 2026-06-26 on three independent failures in the `Docs site` + `build-test-coverage` DAG. All three fixes land in this PR so a single merge turns the whole DAG green.

- Regenerate `docs/reference/http-api.md` — every route handler's `Source:` line-number reference catches up with the current `MTConnectHttpServer.cs` line positions (shifted 4-22 lines by the 2026-06-26 v7.0-prerelease HTTP Server edits). Line-number metadata only; page content unchanged.
- Bump `Scriban` from `7.2.0` to `7.2.2` in `build/MTConnect.NET-SysML-Import` to clear NU1902/NU1903 CVE errors (GHSA-6q7j-xr26-3h2c, GHSA-7jvp-hj45-2f2m, GHSA-q6rr-fm2g-g5x8) that fail the API-ref build under `<TreatWarningsAsErrors>`. Matches dependabot PR #204; supersedes it.
- Update `RouteCheckTests.Landing_Page_Carries_The_House_Style_Surfaces` to assert the nav-bar renders the plain-text title `MTConnect.NET` (per maintainer commit c2041cef "Updated Docs Site", 2026-06-26: `themeConfig.logo` was removed on the grounds that "logo might be too small to read"). The prior assertion checked for an `<img>` inside `.VPNavBarTitle` that no longer exists. The hero-image assertion, favicon assertion, and social-card assertions remain in force.