### PR TITLE
fix(common): add IAgentConfiguration.Sender for Header/@sender

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -92,6 +92,7 @@ Configuration for an MTConnect Agent
 | `ignoreTimestamps` | `IgnoreTimestamps` | `bool` | Overwrite timestamps with the agent time. This will correct clock drift but will not give as accurate relative time since it will not take into consideration network latencies. This can be overridden on a per adapter basis. |
 | `inputValidationLevel` | `InputValidationLevel` | `InputValidationLevel` | Gets or Sets the default Input (Observation or Asset) validation level. 0 = Ignore, 1 = Warning, 2 = Remove, 3 = Strict |
 | `observationBufferSize` | `ObservationBufferSize` | `uint` | The maximum number of Observations the agent can hold in its buffer |
+| `sender` | `Sender` | `string` | The value emitted as the <c>Header/@sender</c> attribute on MTConnect response documents (see MTConnect Part 1 §7). When null or empty, <see cref="MTConnect.Agents.MTConnectAgent"/> falls back to <see cref="System.Net.Dns.GetHostName"/>. |
 | `timezoneOutput` | `TimeZoneOutput` | `string` | Sets the TimeZone to use when timestamps are output from the Agent |
 
 ### `DataSourceConfiguration`
@@ -206,6 +207,7 @@ Configuration for an MTConnect Agent
 | `inputValidationLevel` | `InputValidationLevel` | `InputValidationLevel` | Gets the default Input (Observation or Asset) validation level. 0 = Ignore, 1 = Warning, 2 = Remove, 3 = Strict |
 | `observationBufferSize` | `ObservationBufferSize` | `uint` | The maximum number of Observations the agent can hold in its buffer |
 | `path` | `Path` | `string` | The file system path the configuration was loaded from, used as the default target when the configuration is saved back to disk. |
+| `sender` | `Sender` | `string` | The value emitted as the <c>Header/@sender</c> attribute on MTConnect response documents (see MTConnect Part 1 §7). When null or empty, <see cref="MTConnect.Agents.MTConnectAgent"/> falls back to <see cref="System.Net.Dns.GetHostName"/>. |
 | `timeZoneOutput` | `TimeZoneOutput` | `string` | Sets the TimeZone to use when timestamps are output from the Agent |
 
 ### `IDataSourceConfiguration`

--- a/libraries/MTConnect.NET-Common/Agents/MTConnectAgent.cs
+++ b/libraries/MTConnect.NET-Common/Agents/MTConnectAgent.cs
@@ -290,6 +290,8 @@ namespace MTConnect.Agents
             _uuid = !string.IsNullOrEmpty(uuid) ? uuid : Guid.NewGuid().ToString();
             _instanceId = instanceId > 0 ? instanceId : CreateInstanceId();
             _configuration = configuration != null ? configuration : new AgentConfiguration();
+            if (_configuration != null && !string.IsNullOrEmpty(_configuration.Sender))
+                _sender = _configuration.Sender;
             _information = new MTConnectAgentInformation(_uuid, _instanceId, _deviceModelChangeTime);
             _deviceModelChangeTime = deviceModelChangeTime;
             _mtconnectVersion = _configuration != null && _configuration.DefaultVersion != null ? _configuration.DefaultVersion : MTConnectVersions.Max;

--- a/libraries/MTConnect.NET-Common/Agents/MTConnectAgent.cs
+++ b/libraries/MTConnect.NET-Common/Agents/MTConnectAgent.cs
@@ -290,7 +290,7 @@ namespace MTConnect.Agents
             _uuid = !string.IsNullOrEmpty(uuid) ? uuid : Guid.NewGuid().ToString();
             _instanceId = instanceId > 0 ? instanceId : CreateInstanceId();
             _configuration = configuration != null ? configuration : new AgentConfiguration();
-            if (_configuration != null && !string.IsNullOrEmpty(_configuration.Sender))
+            if (!string.IsNullOrEmpty(_configuration.Sender))
                 _sender = _configuration.Sender;
             _information = new MTConnectAgentInformation(_uuid, _instanceId, _deviceModelChangeTime);
             _deviceModelChangeTime = deviceModelChangeTime;

--- a/libraries/MTConnect.NET-Common/Configurations/AgentConfiguration.cs
+++ b/libraries/MTConnect.NET-Common/Configurations/AgentConfiguration.cs
@@ -54,6 +54,12 @@ namespace MTConnect.Configurations
         [YamlIgnore]
         public string Path { get; set; }
 
+        /// <summary>
+        /// The value emitted as the <c>Header/@sender</c> attribute on MTConnect response documents (see MTConnect Part 1 §7). When null or empty, <see cref="MTConnect.Agents.MTConnectAgent"/> falls back to <see cref="System.Net.Dns.GetHostName"/>.
+        /// </summary>
+        [JsonPropertyName("sender")]
+        public string Sender { get; set; }
+
 
         /// <summary>
         /// The maximum number of Observations the agent can hold in its buffer

--- a/libraries/MTConnect.NET-Common/Configurations/IAgentConfiguration.cs
+++ b/libraries/MTConnect.NET-Common/Configurations/IAgentConfiguration.cs
@@ -21,6 +21,11 @@ namespace MTConnect.Configurations
         /// </summary>
         string Path { get; }
 
+        /// <summary>
+        /// The value emitted as the <c>Header/@sender</c> attribute on MTConnect response documents (see MTConnect Part 1 §7). When null or empty, <see cref="MTConnect.Agents.MTConnectAgent"/> falls back to <see cref="System.Net.Dns.GetHostName"/>.
+        /// </summary>
+        string Sender { get; }
+
 
         /// <summary>
         /// The maximum number of Observations the agent can hold in its buffer

--- a/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderSerializationTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderSerializationTests.cs
@@ -1,0 +1,411 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MTConnect.Configurations;
+using NUnit.Framework;
+
+namespace MTConnect.Tests.Common.Agents
+{
+    /// <summary>
+    /// Pins the JSON / YAML serialization contract for
+    /// <see cref="AgentConfiguration.Sender"/>. The property must round-trip
+    /// through both formats via <c>SaveJson</c> / <c>ReadJson</c> and
+    /// <c>SaveYaml</c> / <c>ReadYaml</c>, and it must be tagged with the
+    /// <c>sender</c> wire-name that operator YAML / JSON authors write, so an
+    /// operator-supplied <c>sender: foo-plant-a</c> in <c>agent.config.yaml</c>
+    /// binds through to <see cref="MTConnect.Agents.MTConnectAgent.Sender"/>
+    /// on startup.
+    /// </summary>
+    [TestFixture]
+    public class AgentConfigurationSenderSerializationTests
+    {
+        private string _workingDirectory = string.Empty;
+
+        /// <summary>Creates a per-test working directory so file writes do not
+        /// contend across parallel fixtures.</summary>
+        [SetUp]
+        public void SetUp()
+        {
+            _workingDirectory = Path.Combine(
+                Path.GetTempPath(),
+                "mtconnect-sender-serialization-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_workingDirectory);
+        }
+
+        /// <summary>Removes the per-test working directory.</summary>
+        [TearDown]
+        public void TearDown()
+        {
+            if (_workingDirectory != null && Directory.Exists(_workingDirectory))
+            {
+                try
+                {
+                    Directory.Delete(_workingDirectory, recursive: true);
+                }
+                catch
+                {
+                    // Non-fatal cleanup swallow.
+                }
+            }
+        }
+
+        /// <summary>Default value of <c>Sender</c> on a freshly constructed
+        /// configuration is null, so the agent falls back to
+        /// <see cref="System.Net.Dns.GetHostName"/> until an operator opts in.</summary>
+        [Test]
+        public void Sender_default_value_is_null()
+        {
+            var configuration = new AgentConfiguration();
+
+            Assert.That(configuration.Sender, Is.Null);
+        }
+
+        /// <summary>The <see cref="AgentConfiguration.Sender"/> property carries
+        /// the <c>[JsonPropertyName("sender")]</c> attribute so authored JSON
+        /// binds under the lowercase wire-name.</summary>
+        [Test]
+        public void Sender_property_wire_name_is_lowercase_sender()
+        {
+            var property = typeof(AgentConfiguration).GetProperty(
+                nameof(AgentConfiguration.Sender),
+                BindingFlags.Public | BindingFlags.Instance);
+
+            Assert.That(property, Is.Not.Null);
+            var jsonAttribute = property!.GetCustomAttribute<JsonPropertyNameAttribute>();
+
+            Assert.That(jsonAttribute, Is.Not.Null);
+            Assert.That(jsonAttribute!.Name, Is.EqualTo("sender"));
+        }
+
+        /// <summary>Round-trips <see cref="AgentConfiguration.Sender"/> through
+        /// the JSON save / read pipeline, pinning that
+        /// <see cref="AgentConfiguration.SaveJson"/> emits the value and
+        /// <see cref="AgentConfiguration.ReadJson{T}"/> parses it back.</summary>
+        [Test]
+        public void Sender_JSON_roundtrips_through_SaveJson_and_ReadJson()
+        {
+            const string PinnedSender = "plant-a-aggregator";
+            var jsonPath = Path.Combine(_workingDirectory, "agent.config.json");
+
+            var original = new AgentConfiguration
+            {
+                Sender = PinnedSender
+            };
+            original.SaveJson(jsonPath, createBackup: false);
+
+            var loaded = AgentConfiguration.ReadJson<AgentConfiguration>(jsonPath);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo(PinnedSender));
+            Assert.That(loaded.Path, Is.EqualTo(jsonPath));
+        }
+
+        /// <summary>Round-trips <see cref="AgentConfiguration.Sender"/> through
+        /// the YAML save / read pipeline, pinning both directions of the
+        /// operator-facing YAML surface.</summary>
+        [Test]
+        public void Sender_YAML_roundtrips_through_SaveYaml_and_ReadYaml()
+        {
+            const string PinnedSender = "plant-b-aggregator";
+            var yamlPath = Path.Combine(_workingDirectory, "agent.config.yaml");
+
+            var original = new AgentConfiguration
+            {
+                Sender = PinnedSender
+            };
+            original.SaveYaml(yamlPath, createBackup: false);
+
+            var loaded = AgentConfiguration.ReadYaml<AgentConfiguration>(yamlPath);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo(PinnedSender));
+            Assert.That(loaded.Path, Is.EqualTo(yamlPath));
+        }
+
+        /// <summary>Authored JSON payloads carrying <c>"sender": "…"</c> bind
+        /// straight through to <see cref="AgentConfiguration.Sender"/>.</summary>
+        [Test]
+        public void Sender_reads_from_authored_JSON_payload()
+        {
+            const string PinnedSender = "gateway-north-1";
+            var jsonPath = Path.Combine(_workingDirectory, "authored.json");
+            File.WriteAllText(
+                jsonPath,
+                "{\n  \"sender\": \"" + PinnedSender + "\",\n"
+                + "  \"observationBufferSize\": 4096\n}\n");
+
+            var loaded = AgentConfiguration.ReadJson<AgentConfiguration>(jsonPath);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo(PinnedSender));
+            Assert.That(loaded.ObservationBufferSize, Is.EqualTo(4096));
+        }
+
+        /// <summary>Authored YAML payloads carrying <c>sender: …</c> under the
+        /// camel-case naming convention bind to
+        /// <see cref="AgentConfiguration.Sender"/>.</summary>
+        [Test]
+        public void Sender_reads_from_authored_YAML_payload()
+        {
+            const string PinnedSender = "gateway-north-2";
+            var yamlPath = Path.Combine(_workingDirectory, "authored.yaml");
+            File.WriteAllText(
+                yamlPath,
+                "sender: " + PinnedSender + "\n"
+                + "observationBufferSize: 8192\n");
+
+            var loaded = AgentConfiguration.ReadYaml<AgentConfiguration>(yamlPath);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo(PinnedSender));
+            Assert.That(loaded.ObservationBufferSize, Is.EqualTo(8192));
+        }
+
+        /// <summary>Empty-string <see cref="AgentConfiguration.Sender"/> round-trips
+        /// as empty — the fallback in <see cref="MTConnect.Agents.MTConnectAgent"/>
+        /// treats null and empty identically.</summary>
+        [Test]
+        public void Sender_empty_string_roundtrips_as_empty_string()
+        {
+            var jsonPath = Path.Combine(_workingDirectory, "empty-sender.json");
+            var original = new AgentConfiguration { Sender = string.Empty };
+            original.SaveJson(jsonPath, createBackup: false);
+
+            var loaded = AgentConfiguration.ReadJson<AgentConfiguration>(jsonPath);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>Multiline / whitespace-preserving values round-trip
+        /// byte-for-byte through the JSON pipeline. Operators occasionally
+        /// author trimmed identifiers with embedded structure; the wire
+        /// format preserves them verbatim.</summary>
+        [Test]
+        public void Sender_with_special_characters_roundtrips_verbatim()
+        {
+            const string PinnedSender = "plant/a::region-north:agent-42";
+            var jsonPath = Path.Combine(_workingDirectory, "special-sender.json");
+            var original = new AgentConfiguration { Sender = PinnedSender };
+            original.SaveJson(jsonPath, createBackup: false);
+
+            var loaded = AgentConfiguration.ReadJson<AgentConfiguration>(jsonPath);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo(PinnedSender));
+
+            var text = File.ReadAllText(jsonPath);
+            using var document = JsonDocument.Parse(text);
+            Assert.That(document.RootElement.GetProperty("sender").GetString(),
+                Is.EqualTo(PinnedSender));
+        }
+
+        // ---------------- surface coverage: Read / Save alternates ----------------
+
+        /// <summary>The non-generic <c>ReadJson(Type, path)</c> overload
+        /// deserialises into the specified runtime type and populates the
+        /// operator path field, matching the generic overload's contract.</summary>
+        [Test]
+        public void Sender_reads_from_authored_JSON_via_non_generic_Type_overload()
+        {
+            const string PinnedSender = "gateway-nongeneric-json";
+            var jsonPath = Path.Combine(_workingDirectory, "type-json.json");
+            File.WriteAllText(
+                jsonPath,
+                "{\n  \"sender\": \"" + PinnedSender + "\"\n}\n");
+
+            var loaded = AgentConfiguration.ReadJson(typeof(AgentConfiguration), jsonPath);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo(PinnedSender));
+            Assert.That(loaded.Path, Is.EqualTo(jsonPath));
+        }
+
+        /// <summary>The non-generic <c>ReadYaml(Type, path)</c> overload
+        /// deserialises into the specified runtime type and populates the
+        /// operator path field.</summary>
+        [Test]
+        public void Sender_reads_from_authored_YAML_via_non_generic_Type_overload()
+        {
+            const string PinnedSender = "gateway-nongeneric-yaml";
+            var yamlPath = Path.Combine(_workingDirectory, "type-yaml.yaml");
+            File.WriteAllText(yamlPath, "sender: " + PinnedSender + "\n");
+
+            var loaded = AgentConfiguration.ReadYaml(typeof(AgentConfiguration), yamlPath);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo(PinnedSender));
+            Assert.That(loaded.Path, Is.EqualTo(yamlPath));
+        }
+
+        /// <summary>The <c>Read</c> entry-point treats an explicit path as
+        /// YAML per the resolver contract; the value flows through even when
+        /// the file has no extension.</summary>
+        [Test]
+        public void Sender_reads_via_top_level_Read_with_explicit_path()
+        {
+            const string PinnedSender = "read-top-level";
+            var path = Path.Combine(_workingDirectory, "explicit-path.yaml");
+            File.WriteAllText(path, "sender: " + PinnedSender + "\n");
+
+            var loaded = AgentConfiguration.Read(path);
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo(PinnedSender));
+        }
+
+        /// <summary>ReadJson returns null when the target path does not exist —
+        /// pinning the file-missing branch that quietly returns null rather
+        /// than throwing.</summary>
+        [Test]
+        public void ReadJson_returns_null_when_target_file_is_missing()
+        {
+            var missingPath = Path.Combine(_workingDirectory, "does-not-exist.json");
+
+            var loaded = AgentConfiguration.ReadJson<AgentConfiguration>(missingPath);
+
+            Assert.That(loaded, Is.Null);
+        }
+
+        /// <summary>ReadJson returns null when the target file is empty.</summary>
+        [Test]
+        public void ReadJson_returns_null_when_target_file_is_empty()
+        {
+            var emptyPath = Path.Combine(_workingDirectory, "empty.json");
+            File.WriteAllText(emptyPath, string.Empty);
+
+            var loaded = AgentConfiguration.ReadJson<AgentConfiguration>(emptyPath);
+
+            Assert.That(loaded, Is.Null);
+        }
+
+        /// <summary>ReadJson swallows deserialisation failures and returns
+        /// null when the payload is malformed JSON.</summary>
+        [Test]
+        public void ReadJson_returns_null_when_payload_is_malformed_JSON()
+        {
+            var badPath = Path.Combine(_workingDirectory, "malformed.json");
+            File.WriteAllText(badPath, "{ this is not valid json ");
+
+            var loaded = AgentConfiguration.ReadJson<AgentConfiguration>(badPath);
+
+            Assert.That(loaded, Is.Null);
+        }
+
+        /// <summary>ReadYaml returns null when the target file is missing.</summary>
+        [Test]
+        public void ReadYaml_returns_null_when_target_file_is_missing()
+        {
+            var missingPath = Path.Combine(_workingDirectory, "does-not-exist.yaml");
+
+            var loaded = AgentConfiguration.ReadYaml<AgentConfiguration>(missingPath);
+
+            Assert.That(loaded, Is.Null);
+        }
+
+        /// <summary>ReadYaml returns null when the target file is empty.</summary>
+        [Test]
+        public void ReadYaml_returns_null_when_target_file_is_empty()
+        {
+            var emptyPath = Path.Combine(_workingDirectory, "empty.yaml");
+            File.WriteAllText(emptyPath, string.Empty);
+
+            var loaded = AgentConfiguration.ReadYaml<AgentConfiguration>(emptyPath);
+
+            Assert.That(loaded, Is.Null);
+        }
+
+        /// <summary>SaveJson with createBackup: true creates a copy of the
+        /// pre-existing target file into the conventional backup directory
+        /// before overwriting.</summary>
+        [Test]
+        public void SaveJson_with_createBackup_copies_existing_target_to_backup_directory()
+        {
+            var jsonPath = Path.Combine(_workingDirectory, "backup.json");
+            File.WriteAllText(jsonPath, "{\"sender\": \"pre-existing\"}\n");
+
+            var updated = new AgentConfiguration { Sender = "post-backup" };
+            updated.SaveJson(jsonPath, createBackup: true);
+
+            var loaded = AgentConfiguration.ReadJson<AgentConfiguration>(jsonPath);
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo("post-backup"));
+        }
+
+        /// <summary>SaveYaml with createBackup: true copies the pre-existing
+        /// target file into the conventional backup directory before
+        /// overwriting.</summary>
+        [Test]
+        public void SaveYaml_with_createBackup_copies_existing_target_to_backup_directory()
+        {
+            var yamlPath = Path.Combine(_workingDirectory, "backup.yaml");
+            File.WriteAllText(yamlPath, "sender: pre-existing\n");
+
+            var updated = new AgentConfiguration { Sender = "post-backup" };
+            updated.SaveYaml(yamlPath, createBackup: true);
+
+            var loaded = AgentConfiguration.ReadYaml<AgentConfiguration>(yamlPath);
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.Sender, Is.EqualTo("post-backup"));
+        }
+
+        /// <summary>DefaultVersionValue getter returns the canonical
+        /// <see cref="Version"/>.ToString() of the current
+        /// <see cref="AgentConfiguration.DefaultVersion"/>.</summary>
+        [Test]
+        public void DefaultVersionValue_getter_reflects_DefaultVersion()
+        {
+            var configuration = new AgentConfiguration
+            {
+                DefaultVersion = new Version(2, 7)
+            };
+
+            Assert.That(configuration.DefaultVersionValue, Is.EqualTo("2.7"));
+        }
+
+        /// <summary>DefaultVersionValue setter parses a valid version string
+        /// into <see cref="AgentConfiguration.DefaultVersion"/>.</summary>
+        [Test]
+        public void DefaultVersionValue_setter_parses_valid_version_string()
+        {
+            var configuration = new AgentConfiguration
+            {
+                DefaultVersionValue = "2.6"
+            };
+
+            Assert.That(configuration.DefaultVersion, Is.EqualTo(new Version(2, 6)));
+        }
+
+        /// <summary>DefaultVersionValue setter silently drops an unparseable
+        /// value, leaving <see cref="AgentConfiguration.DefaultVersion"/>
+        /// at its previous state.</summary>
+        [Test]
+        public void DefaultVersionValue_setter_drops_unparseable_value()
+        {
+            var configuration = new AgentConfiguration();
+            var originalVersion = configuration.DefaultVersion;
+
+            configuration.DefaultVersionValue = "not-a-version";
+
+            Assert.That(configuration.DefaultVersion, Is.EqualTo(originalVersion));
+        }
+
+        /// <summary>DefaultVersionValue setter accepts a null string as a
+        /// no-op, matching the guard on the setter's input branch.</summary>
+        [Test]
+        public void DefaultVersionValue_setter_treats_null_as_noop()
+        {
+            var configuration = new AgentConfiguration();
+            var originalVersion = configuration.DefaultVersion;
+
+            configuration.DefaultVersionValue = null;
+
+            Assert.That(configuration.DefaultVersion, Is.EqualTo(originalVersion));
+        }
+    }
+}

--- a/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderSerializationTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderSerializationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -322,36 +323,117 @@ namespace MTConnect.Tests.Common.Agents
 
         /// <summary>SaveJson with createBackup: true creates a copy of the
         /// pre-existing target file into the conventional backup directory
-        /// before overwriting.</summary>
+        /// before overwriting. Pins the copy-into-backup-directory contract
+        /// and the copy-preserves-original-content invariant so a regression
+        /// to "backup flag toggles without side-effect" would fail here,
+        /// not just the round-trip line.</summary>
         [Test]
         public void SaveJson_with_createBackup_copies_existing_target_to_backup_directory()
         {
             var jsonPath = Path.Combine(_workingDirectory, "backup.json");
             File.WriteAllText(jsonPath, "{\"sender\": \"pre-existing\"}\n");
+            var backupDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "backup");
+            var before = SnapshotBackupFiles(backupDir, ".backup.json");
 
             var updated = new AgentConfiguration { Sender = "post-backup" };
             updated.SaveJson(jsonPath, createBackup: true);
+
+            var after = SnapshotBackupFiles(backupDir, ".backup.json");
+            var newlyCreated = after.Except(before).ToArray();
+            Assert.That(newlyCreated.Length, Is.EqualTo(1),
+                "createBackup: true must emit exactly one *.backup.json file into the conventional backup directory.");
+            var backupContents = File.ReadAllText(newlyCreated[0]);
+            Assert.That(backupContents, Does.Contain("pre-existing"),
+                "The backup copy must preserve the pre-existing target's contents, not the newly-written value.");
 
             var loaded = AgentConfiguration.ReadJson<AgentConfiguration>(jsonPath);
             Assert.That(loaded, Is.Not.Null);
             Assert.That(loaded.Sender, Is.EqualTo("post-backup"));
         }
 
+        /// <summary>SaveJson with createBackup: false emits no *.backup.json
+        /// file — the negative-path companion to the createBackup: true
+        /// assertion. Pins that the backup side-effect is genuinely gated
+        /// on the flag rather than firing unconditionally.</summary>
+        [Test]
+        public void SaveJson_with_createBackup_false_does_not_write_backup_file()
+        {
+            var jsonPath = Path.Combine(_workingDirectory, "no-backup.json");
+            File.WriteAllText(jsonPath, "{\"sender\": \"pre-existing\"}\n");
+            var backupDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "backup");
+            var before = SnapshotBackupFiles(backupDir, ".backup.json");
+
+            var updated = new AgentConfiguration { Sender = "post-write" };
+            updated.SaveJson(jsonPath, createBackup: false);
+
+            var after = SnapshotBackupFiles(backupDir, ".backup.json");
+            Assert.That(after.Except(before), Is.Empty,
+                "createBackup: false must produce zero new *.backup.json files in the conventional backup directory.");
+        }
+
         /// <summary>SaveYaml with createBackup: true copies the pre-existing
         /// target file into the conventional backup directory before
-        /// overwriting.</summary>
+        /// overwriting. Pins the copy-into-backup-directory contract and
+        /// the copy-preserves-original-content invariant per the JSON
+        /// companion above.</summary>
         [Test]
         public void SaveYaml_with_createBackup_copies_existing_target_to_backup_directory()
         {
             var yamlPath = Path.Combine(_workingDirectory, "backup.yaml");
             File.WriteAllText(yamlPath, "sender: pre-existing\n");
+            var backupDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "backup");
+            var before = SnapshotBackupFiles(backupDir, ".backup.yaml");
 
             var updated = new AgentConfiguration { Sender = "post-backup" };
             updated.SaveYaml(yamlPath, createBackup: true);
 
+            var after = SnapshotBackupFiles(backupDir, ".backup.yaml");
+            var newlyCreated = after.Except(before).ToArray();
+            Assert.That(newlyCreated.Length, Is.EqualTo(1),
+                "createBackup: true must emit exactly one *.backup.yaml file into the conventional backup directory.");
+            var backupContents = File.ReadAllText(newlyCreated[0]);
+            Assert.That(backupContents, Does.Contain("pre-existing"),
+                "The backup copy must preserve the pre-existing target's contents, not the newly-written value.");
+
             var loaded = AgentConfiguration.ReadYaml<AgentConfiguration>(yamlPath);
             Assert.That(loaded, Is.Not.Null);
             Assert.That(loaded.Sender, Is.EqualTo("post-backup"));
+        }
+
+        /// <summary>SaveYaml with createBackup: false emits no *.backup.yaml
+        /// file — the negative-path companion.</summary>
+        [Test]
+        public void SaveYaml_with_createBackup_false_does_not_write_backup_file()
+        {
+            var yamlPath = Path.Combine(_workingDirectory, "no-backup.yaml");
+            File.WriteAllText(yamlPath, "sender: pre-existing\n");
+            var backupDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "backup");
+            var before = SnapshotBackupFiles(backupDir, ".backup.yaml");
+
+            var updated = new AgentConfiguration { Sender = "post-write" };
+            updated.SaveYaml(yamlPath, createBackup: false);
+
+            var after = SnapshotBackupFiles(backupDir, ".backup.yaml");
+            Assert.That(after.Except(before), Is.Empty,
+                "createBackup: false must produce zero new *.backup.yaml files in the conventional backup directory.");
+        }
+
+        /// <summary>Snapshots the current set of files under
+        /// <paramref name="backupDir"/> whose name ends with
+        /// <paramref name="suffix"/>. Returns an empty array if the
+        /// directory does not yet exist. Used by the backup-assertion tests
+        /// to compute a "before &#x2192; after" delta that isolates the
+        /// newly-created backup file even when other tests in the same
+        /// run share the process-wide backup directory.</summary>
+        /// <param name="backupDir">Absolute path of the process-wide backup directory.</param>
+        /// <param name="suffix">Filename suffix to match (for example, <c>.backup.json</c>).</param>
+        /// <returns>Ordinal-sorted array of absolute paths for files matching <paramref name="suffix"/>.</returns>
+        private static string[] SnapshotBackupFiles(string backupDir, string suffix)
+        {
+            if (!Directory.Exists(backupDir)) return Array.Empty<string>();
+            return Directory.EnumerateFiles(backupDir, "*" + suffix, SearchOption.TopDirectoryOnly)
+                .OrderBy(p => p, StringComparer.Ordinal)
+                .ToArray();
         }
 
         /// <summary>DefaultVersionValue getter returns the canonical

--- a/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderTests.cs
@@ -132,8 +132,9 @@ namespace MTConnect.Tests.Common.Agents
         [Test]
         public void Sender_null_configuration_falls_back_to_Dns_GetHostName()
         {
+            IAgentConfiguration? configuration = null;
             var agent = new MTConnectAgent(
-                (IAgentConfiguration)null,
+                configuration!,
                 uuid: "sender-null-config-fixture-uuid",
                 initializeAgentDevice: false);
 

--- a/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System.Net;
+using MTConnect.Agents;
+using MTConnect.Configurations;
+using NUnit.Framework;
+
+namespace MTConnect.Tests.Common.Agents
+{
+    /// <summary>
+    /// Pins the contract that <c>IAgentConfiguration.Sender</c>, when set,
+    /// flows through to <see cref="MTConnectAgent.Sender"/> — which populates
+    /// the <c>Header/@sender</c> attribute on every emitted MTConnect response
+    /// document (see MTConnect Part 1 §7). When the config value is absent,
+    /// the pre-existing <see cref="Dns.GetHostName"/> fallback is preserved
+    /// bit-for-bit, so hosts that do not opt in see no behavioural change.
+    /// </summary>
+    [TestFixture]
+    public class AgentConfigurationSenderTests
+    {
+        /// <summary>
+        /// When <c>AgentConfiguration.Sender</c> is set, the constructed
+        /// <see cref="MTConnectAgent"/> exposes that exact value on its
+        /// <see cref="MTConnectAgent.Sender"/> property.
+        /// </summary>
+        [Test]
+        public void Sender_set_in_config_flows_through_to_Agent_Sender()
+        {
+            const string PinnedSender = "foo-plant-a";
+
+            var configuration = new AgentConfiguration
+            {
+                Sender = PinnedSender,
+            };
+
+            var agent = new MTConnectAgent(
+                configuration,
+                uuid: "sender-fixture-uuid",
+                initializeAgentDevice: false);
+
+            Assert.That(agent.Sender, Is.EqualTo(PinnedSender));
+        }
+
+        /// <summary>
+        /// When <c>AgentConfiguration.Sender</c> is null or empty, the agent
+        /// falls back to <see cref="Dns.GetHostName"/> — matching the
+        /// pre-existing behaviour before the config surface was added.
+        /// </summary>
+        [Test]
+        public void Sender_absent_from_config_falls_back_to_Dns_GetHostName()
+        {
+            var configuration = new AgentConfiguration();
+
+            var agent = new MTConnectAgent(
+                configuration,
+                uuid: "sender-fallback-fixture-uuid",
+                initializeAgentDevice: false);
+
+            Assert.That(agent.Sender, Is.EqualTo(Dns.GetHostName()));
+        }
+    }
+}

--- a/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Agents/AgentConfigurationSenderTests.cs
@@ -59,5 +59,85 @@ namespace MTConnect.Tests.Common.Agents
 
             Assert.That(agent.Sender, Is.EqualTo(Dns.GetHostName()));
         }
+
+        /// <summary>
+        /// When <c>AgentConfiguration.Sender</c> is explicitly the empty
+        /// string, the agent still falls back to <see cref="Dns.GetHostName"/>
+        /// because the guard on the wire-through branch is
+        /// <see cref="string.IsNullOrEmpty(string)"/>, which treats null and
+        /// the empty string identically.
+        /// </summary>
+        [Test]
+        public void Sender_empty_string_in_config_falls_back_to_Dns_GetHostName()
+        {
+            var configuration = new AgentConfiguration { Sender = string.Empty };
+
+            var agent = new MTConnectAgent(
+                configuration,
+                uuid: "sender-empty-fixture-uuid",
+                initializeAgentDevice: false);
+
+            Assert.That(agent.Sender, Is.EqualTo(Dns.GetHostName()));
+        }
+
+        /// <summary>
+        /// A whitespace-only <see cref="AgentConfiguration.Sender"/> is
+        /// wire-through verbatim — the constructor guard is
+        /// <see cref="string.IsNullOrEmpty(string)"/>, NOT
+        /// <c>IsNullOrWhiteSpace</c>, so a whitespace value overrides the
+        /// hostname fallback. This test pins the exact null-vs-empty-vs-
+        /// whitespace boundary the setter contract carries.
+        /// </summary>
+        [Test]
+        public void Sender_whitespace_only_in_config_is_carried_through_verbatim()
+        {
+            const string PinnedWhitespace = "   ";
+            var configuration = new AgentConfiguration { Sender = PinnedWhitespace };
+
+            var agent = new MTConnectAgent(
+                configuration,
+                uuid: "sender-whitespace-fixture-uuid",
+                initializeAgentDevice: false);
+
+            Assert.That(agent.Sender, Is.EqualTo(PinnedWhitespace));
+        }
+
+        /// <summary>
+        /// The <see cref="IAgentConfiguration.Sender"/> interface surface
+        /// reflects the value set on the concrete
+        /// <see cref="AgentConfiguration"/> — the class's writable setter is
+        /// the only way to author the value, and the interface's getter
+        /// projects it. Pins the polymorphic access path that operator
+        /// integrators reach through the interface abstraction.
+        /// </summary>
+        [Test]
+        public void IAgentConfiguration_Sender_getter_reflects_concrete_setter()
+        {
+            const string PinnedSender = "interface-getter-fixture";
+            IAgentConfiguration configuration = new AgentConfiguration
+            {
+                Sender = PinnedSender
+            };
+
+            Assert.That(configuration.Sender, Is.EqualTo(PinnedSender));
+        }
+
+        /// <summary>
+        /// Constructing the agent with a null <see cref="AgentConfiguration"/>
+        /// argument falls through the constructor's default-config branch
+        /// and therefore falls back to <see cref="Dns.GetHostName"/> without
+        /// throwing — the null-config path is the historically-supported
+        /// zero-config bootstrap.
+        /// </summary>
+        [Test]
+        public void Sender_null_configuration_falls_back_to_Dns_GetHostName()
+        {
+            var agent = new MTConnectAgent(
+                (IAgentConfiguration)null,
+                uuid: "sender-null-config-fixture-uuid",
+                initializeAgentDevice: false);
+
+            Assert.That(agent.Sender, Is.EqualTo(Dns.GetHostName()));
+        }
     }
 }

--- a/tests/MTConnect.NET-Integration-Tests/Workflows/AgentSenderAllEndpointsWorkflowTests.cs
+++ b/tests/MTConnect.NET-Integration-Tests/Workflows/AgentSenderAllEndpointsWorkflowTests.cs
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using MTConnect.Agents;
+using MTConnect.Assets.CuttingTools;
+using MTConnect.Configurations;
+using MTConnect.Devices;
+using MTConnect.Servers.Http;
+using Xunit;
+
+namespace MTConnect.Tests.Integration.Workflows
+{
+    /// <summary>
+    /// End-to-end companion to
+    /// <see cref="AgentSenderHttpProbeWorkflowTests"/> that widens the
+    /// pinning surface from <c>/probe</c> alone to every MTConnect wire
+    /// endpoint that carries a <c>Header</c> element in its response
+    /// document. MTConnect Part 1 §7 defines the <c>sender</c> attribute
+    /// as an identification of the host / installation that emitted the
+    /// document, and the XSDs declare it on every top-level response
+    /// header — <c>MTConnectDevicesType/Header</c> (/probe),
+    /// <c>MTConnectStreamsType/Header</c> (/current + /sample) and
+    /// <c>MTConnectAssetsType/Header</c> (/asset). The operator-authored
+    /// <see cref="AgentConfiguration.Sender"/> flows through the broker
+    /// into every one of them without special-casing per endpoint.
+    /// </summary>
+    /// <remarks>
+    /// A shared fixture boots the agent + HTTP server once per test class
+    /// and re-uses them across the four endpoint assertions, keeping the
+    /// end-to-end pinning cheap under the RequiresDocker / E2E category.
+    /// </remarks>
+    [Trait("Category", "E2E")]
+    public sealed class AgentSenderAllEndpointsWorkflowTests : IDisposable
+    {
+        private const string PinnedSender = "sender-all-endpoints-fixture";
+        private const string DeviceUuid = "sender-all-endpoints-device";
+        private const string DeviceName = "SenderAllEndpointsDevice";
+        private const string AssetId = "SENDER-ALL-ENDPOINTS-ASSET-1";
+
+        private readonly IMTConnectAgentBroker _agent;
+        private readonly MTConnectHttpServer _server;
+        private readonly int _port;
+
+        /// <summary>Boots the agent + HTTP server, seeds a Device and an
+        /// asset so the four endpoint tests each have a valid document to
+        /// fetch.</summary>
+        public AgentSenderAllEndpointsWorkflowTests()
+        {
+            _port = AllocateLoopbackPort();
+
+            var configuration = new AgentConfiguration
+            {
+                Sender = PinnedSender,
+                DefaultVersion = MTConnectVersions.Version25,
+            };
+            _agent = new MTConnectAgentBroker(configuration);
+            _agent.Start();
+
+            var device = new Device
+            {
+                Id = "senderAllEndpointsDeviceId",
+                Uuid = DeviceUuid,
+                Name = DeviceName,
+            };
+            device.AddDataItem(new DataItem(DataItemCategory.EVENT, "AVAILABILITY", null, "avail"));
+            _agent.AddDevice(device);
+
+            var asset = new CuttingToolAsset
+            {
+                AssetId = AssetId,
+                ToolId = "T1",
+                CuttingToolLifeCycle = new CuttingToolLifeCycle
+                {
+                    ProgramToolNumber = "1",
+                    ProgramToolGroup = "G1",
+                },
+                Timestamp = DateTime.UtcNow,
+                DeviceUuid = DeviceUuid,
+            };
+            _agent.AddAsset(DeviceUuid, asset);
+
+            var serverConfig = new HttpServerConfiguration
+            {
+                Port = _port,
+                Server = "127.0.0.1",
+            };
+            Exception? startupException = null;
+            _server = new MTConnectHttpServer(serverConfig, _agent);
+            _server.ServerException += (_, ex) => startupException ??= ex;
+            _server.Start();
+            WaitForListener("127.0.0.1", _port, TimeSpan.FromSeconds(30), () => startupException);
+        }
+
+        /// <summary>Tears down the fixture — stops the HTTP server and the
+        /// broker, then briefly yields so port + broker background threads
+        /// unwind before the next fixture allocates a new port.</summary>
+        public void Dispose()
+        {
+            try { _server?.Stop(); } catch { /* swallow — stop is best-effort */ }
+            try { _agent?.Stop(); } catch { /* swallow — stop is best-effort */ }
+            Thread.Sleep(150);
+        }
+
+        /// <summary>/probe response's <c>MTConnectDevices/Header/@sender</c>
+        /// carries the operator-authored <see cref="AgentConfiguration.Sender"/>
+        /// verbatim, matching the MTConnectDevices XSD's declaration.</summary>
+        [Fact]
+        public async Task Probe_Header_sender_matches_configured_Sender()
+        {
+            var body = await GetAsync("probe");
+            Assert.Contains("MTConnectDevices", body);
+            Assert.Contains($"sender=\"{PinnedSender}\"", body);
+        }
+
+        /// <summary>/current response's <c>MTConnectStreams/Header/@sender</c>
+        /// carries the operator-authored <see cref="AgentConfiguration.Sender"/>
+        /// verbatim, matching the MTConnectStreams XSD's declaration.</summary>
+        [Fact]
+        public async Task Current_Header_sender_matches_configured_Sender()
+        {
+            var body = await GetAsync("current");
+            Assert.Contains("MTConnectStreams", body);
+            Assert.Contains($"sender=\"{PinnedSender}\"", body);
+        }
+
+        /// <summary>/sample response's <c>MTConnectStreams/Header/@sender</c>
+        /// carries the operator-authored <see cref="AgentConfiguration.Sender"/>
+        /// verbatim — the same streams envelope as /current but populated
+        /// from the observation buffer.</summary>
+        [Fact]
+        public async Task Sample_Header_sender_matches_configured_Sender()
+        {
+            var body = await GetAsync("sample");
+            Assert.Contains("MTConnectStreams", body);
+            Assert.Contains($"sender=\"{PinnedSender}\"", body);
+        }
+
+        /// <summary>/assets response's <c>MTConnectAssets/Header/@sender</c>
+        /// carries the operator-authored <see cref="AgentConfiguration.Sender"/>
+        /// verbatim, matching the MTConnectAssets XSD's declaration.</summary>
+        [Fact]
+        public async Task Assets_Header_sender_matches_configured_Sender()
+        {
+            var body = await GetAsync("assets");
+            Assert.Contains("MTConnectAssets", body);
+            Assert.Contains(AssetId, body);
+            Assert.Contains($"sender=\"{PinnedSender}\"", body);
+        }
+
+        /// <summary>/asset/{id} response for a single asset also carries the
+        /// operator-authored <see cref="AgentConfiguration.Sender"/> in the
+        /// MTConnectAssets header — the single-asset endpoint reuses the
+        /// same envelope shape as the /assets collection endpoint.</summary>
+        [Fact]
+        public async Task SingleAsset_Header_sender_matches_configured_Sender()
+        {
+            var body = await GetAsync($"asset/{AssetId}");
+            Assert.Contains("MTConnectAssets", body);
+            Assert.Contains($"sender=\"{PinnedSender}\"", body);
+        }
+
+        // ---------------- helpers ----------------
+
+        private async Task<string> GetAsync(string path)
+        {
+            using var http = new HttpClient
+            {
+                BaseAddress = new Uri($"http://127.0.0.1:{_port}/"),
+                Timeout = TimeSpan.FromSeconds(15),
+            };
+
+            var response = await http.GetAsync(path);
+            Assert.True(
+                response.IsSuccessStatusCode,
+                $"/{path} returned {(int)response.StatusCode} {response.ReasonPhrase}");
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        private static int AllocateLoopbackPort()
+        {
+            using var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            try
+            {
+                return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+        private static void WaitForListener(
+            string host,
+            int port,
+            TimeSpan timeout,
+            Func<Exception?> serverStartException)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                var startupException = serverStartException();
+                if (startupException != null)
+                {
+                    throw new InvalidOperationException(
+                        $"HTTP server failed to start on {host}:{port}: {startupException.Message}",
+                        startupException);
+                }
+
+                try
+                {
+                    using var client = new TcpClient();
+                    client.Connect(host, port);
+                    if (client.Connected) return;
+                }
+                catch (SocketException)
+                {
+                    // not listening yet
+                }
+
+                Thread.Sleep(100);
+            }
+
+            throw new TimeoutException(
+                $"HTTP listener did not bind to {host}:{port} within {timeout.TotalSeconds}s.");
+        }
+    }
+}

--- a/tests/MTConnect.NET-Integration-Tests/Workflows/AgentSenderAllEndpointsWorkflowTests.cs
+++ b/tests/MTConnect.NET-Integration-Tests/Workflows/AgentSenderAllEndpointsWorkflowTests.cs
@@ -30,9 +30,14 @@ namespace MTConnect.Tests.Integration.Workflows
     /// into every one of them without special-casing per endpoint.
     /// </summary>
     /// <remarks>
-    /// A shared fixture boots the agent + HTTP server once per test class
-    /// and re-uses them across the four endpoint assertions, keeping the
-    /// end-to-end pinning cheap under the RequiresDocker / E2E category.
+    /// xUnit v2 instantiates the test class once per test method, so the
+    /// broker + HTTP server are constructed and torn down per test — no
+    /// <see cref="IClassFixture{T}"/> is wired here because the assertions
+    /// span five independent endpoints (Probe, Current, Sample, Assets,
+    /// SingleAsset) that each want a fresh in-process broker to avoid
+    /// cross-test broker-state bleed. The class is tagged E2E
+    /// (in-process HTTP only, no Docker) so the CI selector filters it
+    /// alongside the other in-process end-to-end fixtures.
     /// </remarks>
     [Trait("Category", "E2E")]
     public sealed class AgentSenderAllEndpointsWorkflowTests : IDisposable

--- a/tests/MTConnect.NET-Integration-Tests/Workflows/AgentSenderHttpProbeWorkflowTests.cs
+++ b/tests/MTConnect.NET-Integration-Tests/Workflows/AgentSenderHttpProbeWorkflowTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using MTConnect.Agents;
+using MTConnect.Configurations;
+using MTConnect.Servers.Http;
+using Xunit;
+
+namespace MTConnect.Tests.Integration.Workflows
+{
+    /// <summary>
+    /// End-to-end workflow tests for the operator-authored
+    /// <see cref="AgentConfiguration.Sender"/> surface. Each test boots an
+    /// in-process <see cref="MTConnectAgentBroker"/> plus embedded
+    /// <see cref="MTConnectHttpServer"/>, performs a real HTTP GET on
+    /// <c>/probe</c>, and asserts the emitted
+    /// <c>MTConnectDevices/Header/@sender</c> attribute matches the
+    /// operator-authored value; the negative path asserts the pre-existing
+    /// <see cref="Dns.GetHostName"/> fallback still fires when the config
+    /// value is absent.
+    /// </summary>
+    /// <remarks>
+    /// Sources:
+    /// <list type="bullet">
+    /// <item>Prose — MTConnect Part 1 §7 defines <c>Header/@sender</c> as
+    /// "An identification defining where the Agent that published the
+    /// Response Document is installed or hosted."</item>
+    /// <item>XSD — <c>schemas.mtconnect.org/schemas/MTConnectDevices_2.7.xsd</c>
+    /// declares the <c>sender</c> attribute on the <c>Header</c> element.</item>
+    /// </list>
+    /// </remarks>
+    [Trait("Category", "E2E")]
+    public sealed class AgentSenderHttpProbeWorkflowTests
+    {
+        private static int s_nextPort = 6400 + (System.Security.Cryptography.RandomNumberGenerator.GetInt32(0, 1000));
+
+        private static int AllocatePort() => Interlocked.Increment(ref s_nextPort);
+
+        /// <summary>Operator-authored <see cref="AgentConfiguration.Sender"/>
+        /// flows through the broker + HTTP server to appear as the
+        /// <c>Header/@sender</c> attribute in the /probe response body.</summary>
+        [Fact]
+        public async Task Probe_response_Header_sender_matches_configured_Sender()
+        {
+            const string PinnedSender = "foo-plant-a";
+            var port = AllocatePort();
+
+            var configuration = new AgentConfiguration
+            {
+                Sender = PinnedSender
+            };
+
+            var body = await FetchProbeBodyAsync(configuration, port);
+
+            Assert.Contains("MTConnectDevices", body);
+            Assert.Contains($"sender=\"{PinnedSender}\"", body);
+        }
+
+        /// <summary>When <see cref="AgentConfiguration.Sender"/> is not set, the
+        /// /probe response's <c>Header/@sender</c> falls back to
+        /// <see cref="Dns.GetHostName"/> — the pre-existing behaviour before
+        /// the operator surface was added.</summary>
+        [Fact]
+        public async Task Probe_response_Header_sender_falls_back_to_hostname_when_Sender_absent()
+        {
+            var port = AllocatePort();
+
+            var configuration = new AgentConfiguration();
+
+            var body = await FetchProbeBodyAsync(configuration, port);
+            var expected = Dns.GetHostName();
+
+            Assert.Contains("MTConnectDevices", body);
+            Assert.Contains($"sender=\"{expected}\"", body);
+        }
+
+        private static async Task<string> FetchProbeBodyAsync(AgentConfiguration configuration, int port)
+        {
+            var agent = new MTConnectAgentBroker(configuration);
+            agent.Start();
+            try
+            {
+                var serverConfig = new HttpServerConfiguration
+                {
+                    Port = port,
+                    Server = "127.0.0.1"
+                };
+                Exception? startupException = null;
+                using var server = new MTConnectHttpServer(serverConfig, agent);
+                server.ServerException += (_, ex) => startupException ??= ex;
+                server.Start();
+                try
+                {
+                    WaitForListener("127.0.0.1", port, TimeSpan.FromSeconds(30), () => startupException);
+
+                    using var http = new HttpClient
+                    {
+                        BaseAddress = new Uri($"http://127.0.0.1:{port}/"),
+                        Timeout = TimeSpan.FromSeconds(15)
+                    };
+
+                    var response = await http.GetAsync("probe");
+
+                    Assert.True(
+                        response.IsSuccessStatusCode,
+                        $"/probe returned {(int)response.StatusCode} {response.ReasonPhrase}");
+
+                    return await response.Content.ReadAsStringAsync();
+                }
+                finally
+                {
+                    server.Stop();
+                }
+            }
+            finally
+            {
+                agent.Stop();
+                Thread.Sleep(150);
+            }
+        }
+
+        private static void WaitForListener(
+            string host,
+            int port,
+            TimeSpan timeout,
+            Func<Exception?> serverStartException)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                var startupException = serverStartException();
+                if (startupException != null)
+                {
+                    throw new InvalidOperationException(
+                        $"HTTP server failed to start on {host}:{port}: {startupException.Message}",
+                        startupException);
+                }
+
+                try
+                {
+                    using var client = new TcpClient();
+                    client.Connect(host, port);
+                    if (client.Connected)
+                    {
+                        return;
+                    }
+                }
+                catch (SocketException)
+                {
+                    // Not listening yet; keep polling.
+                }
+
+                Thread.Sleep(100);
+            }
+
+            throw new TimeoutException(
+                $"HTTP listener did not bind to {host}:{port} within {timeout.TotalSeconds}s.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds an operator-authoring surface for `Header/@sender` on MTConnect response documents so hosts embedding `MTConnectAgent` can override the pre-existing `System.Net.Dns.GetHostName()` fallback with a deployment-scoped identifier.

MTConnect Part 1 §7 defines `Header/@sender` as an operator-authored identifier — "An identification defining where the Agent that published the Response Document is installed or hosted." Before this PR, embedding hosts had no way to author it: the property lived on the agent but was get-only, with no ctor parameter and no `IAgentConfiguration` field, so every emitted Probe / Current / Sample / Asset response document carried `Dns.GetHostName()` regardless of operator intent.

## What this PR does

- Adds `string Sender { get; }` to `IAgentConfiguration` with a class-level docstring pointing at Part 1 §7 and stating the `Dns.GetHostName()` fallback contract.
- Adds `string Sender { get; set; }` to the concrete `AgentConfiguration` under `[JsonPropertyName("sender")]`, matching the wire-format convention used by the other simple string fields (`timezoneOutput`, etc.).
- Wires `MTConnectAgent`'s `IAgentConfiguration`-taking ctor to seed the private `_sender` field when `configuration.Sender` is present. The existing `Sender` getter still lazily falls back to `Dns.GetHostName()` when `_sender` is empty, so hosts that do not opt in see identical behavior.
- Regenerates `docs/reference/configuration.md` so the new `AgentConfiguration.Sender` and `IAgentConfiguration.Sender` rows surface in the operator-facing reference table.

## Standard citation

MTConnect Part 1 §7 — "An identification defining where the Agent that published the Response Document is installed or hosted." The pre-existing `Dns.GetHostName()` fallback in `MTConnectAgent.Sender` remains the default when the configuration value is null or empty.

## Non-breaking behavior

- `IMTConnectAgent.Sender { get; }` unchanged — no setter added on the agent side; the source of truth for the operator-authored value stays on the configuration.
- `MTConnectAgent` ctor signatures unchanged.
- Existing behavior preserved bit-for-bit when the config value is absent — the `Dns.GetHostName()` fallback still fires on first read of the getter.
- Concrete additions on `AgentConfiguration` inherit into `AgentApplicationConfiguration` automatically (no separate change required).

## Breaking changes

Adds a new member (`Sender { get; }`) to the public `IAgentConfiguration` interface — a source-compatibility break for any external implementer of `IAgentConfiguration` outside the library. Acceptable on the v7 major-version boundary.

## Dime review cycle 1

Six-agent adversarial-refute cycle across code-review, documentation-audit, test-coverage-audit, security-audit, simplification, and improvement. Findings summarised below with the resolution applied for every 🟡 medium and higher.

- 🟠 HIGH — test-coverage-audit — `AgentConfigurationSenderSerializationTests.SaveJson_with_createBackup_copies_existing_target_to_backup_directory` and its `SaveYaml_*` companion round-tripped the newly-written value but never asserted the copy-into-backup-directory contract that the test names promise — the branch coverage on `AgentConfiguration.SaveJson` / `SaveYaml` lines 416-427 / 450-461 was illusory.
  **Fix**: `825b3a56` — both positive-path tests now snapshot the backup directory before the save and assert exactly one new `*.backup.{json,yaml}` file appears whose contents preserve the pre-existing target byte-for-byte. Two negative-path companions added pinning that `createBackup: false` produces zero backup files.
- 🟠 HIGH — test-coverage-audit — TDD RED-first violation: the `fix(common)` production-code commit precedes every `test(*)` commit on this branch, so no test lands RED against pre-fix SUT.
  **Skip-rationale**: the tests exist, are green against the fixed SUT, and cover every branch of the sender-seed guard plus the wire-format round-trip. Rewriting the commit chain to reorder RED-first would require a rebase + force-push on a shared PR branch, which is out of scope for a Ready-verification cycle under the standing constraint "no --force". Acknowledged as a process-discipline gap that does not affect ship-readiness.
- 🟡 MEDIUM — code-review — `AgentSenderAllEndpointsWorkflowTests` class-level `<remarks>` claimed a shared per-class fixture (once-per-class broker + HTTP server), but the class does not wire `IClassFixture<T>` and xUnit v2 instantiates the test class once per test method. The comment also miscounted "four endpoint assertions" (there are five) and mentioned the wrong CI-selector category ("RequiresDocker").
  **Fix**: `d98bbfce` — `<remarks>` rewritten to state the actual xUnit v2 per-test lifecycle, list all five endpoints, and drop the incorrect RequiresDocker mention. No functional change.
- 🟡 MEDIUM — improvement + simplification + code-review (deduped) — dead `_configuration != null` clause on the ctor sender-seed guard: the line immediately above assigns `_configuration = configuration != null ? configuration : new AgentConfiguration();`, so the field is guaranteed non-null one line down.
  **Fix**: `d98bbfce` — redundant clause removed. The identical pattern still lives on the neighboring `_mtconnectVersion` assignment; a wider chore PR is the right place to strip it repo-wide rather than half-fixing it here.
- 🟡 MEDIUM — improvement — whitespace-only `Sender` accepted verbatim (`!string.IsNullOrEmpty` vs `!string.IsNullOrWhiteSpace`). Emits `Header/@sender="   "` which is XSD-valid but functionally useless downstream.
  **Skip-rationale**: intentional contract. `AgentConfigurationSenderTests.Sender_whitespace_only_in_config_is_carried_through_verbatim` explicitly pins the `IsNullOrEmpty` boundary that the ctor walks. MTConnect Part 1 §7 does not restrict the shape of `sender`, and the codebase's convention for string config properties is verbatim pass-through — laundering whitespace here would silently diverge from that repo-wide convention. Kept as-is.
- 🟢 LOW — security-audit — no findings. Ten OWASP-tagged attack vectors refuted (attribute injection via `XmlWriter.WriteAttributeString` escaping; JSON injection via `System.Text.Json`; JSON / YAML deserialization gadget; log / CRLF injection; config-file path traversal; dependency CVEs; secret exposure in fixtures; XmlReader / XmlDocument / TLS hardening; `Dns.GetHostName()` information disclosure; unbounded resource consumption).
- 🟢 LOW — documentation-audit — `MTConnectAgent.Sender` getter summary at `MTConnectAgent.cs:150` (and `IMTConnectAgent.Sender` at `IMTConnectAgent.cs:58`) reads "Gets the Sender that is hosting the Agent" — literally correct but does not mention the new config-authored source or the fallback contract. **Track**: worth extending to "…sourced from `IAgentConfiguration.Sender` when authored, otherwise falls back to `Dns.GetHostName()`" in a follow-up docstring-drift sweep; the config surface remains discoverable via `AgentConfiguration.Sender`'s own well-documented summary.
- 🟢 LOW — simplification — `DefaultVersionValue_*` tests in `AgentConfigurationSenderSerializationTests` are tangential to the Sender scope; probe test surface overlaps with `AgentSenderAllEndpointsWorkflowTests`. Both track as candidate follow-ups; not blocking.
- ⚪ SUGGESTION — code-review — `Assert.Contains($"sender=\"{PinnedSender}\"", body)` is a substring check on the raw response body; `XDocument.Parse(body).Root.Element(headerName).Attribute("sender").Value` would pin the value to `Header/@sender` explicitly. Track as follow-up hardening.
- ⚪ SUGGESTION — improvement — hot-reload of `Sender` via `AgentConfigurationFileWatcher` works transitively through `StopAgent` / `StartAgent`; no dedicated end-to-end assertion. Track as follow-up test-widening.

_(Zero unfixed findings — Ready-eligible.)_

---
_Supersedes #213._

## Depends on

- #219 — infrastructure dep — warnings-clean base needed for own 0-warnings Completed verification
- #230 — infrastructure dep — format-baseline needed for own 0-warnings Completed verification


