### PR TITLE
chore: apply dotnet format baseline and add CI gate

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,18 +25,30 @@ on:
 
 jobs:
   # ------------------------------------------------------------------
-  # Job 0 — dotnet format gate. Verifies the tree matches the
-  # repository's .editorconfig with zero diff, so formatting drift
+  # Job 0 — dotnet format gate. Verifies the tree matches the default
+  # `dotnet format` ruleset with zero diff, so formatting drift
   # (indentation, brace placement, whitespace) is caught at PR time
   # instead of silently accumulating into the baseline every
-  # subsequent branch then has to inherit. Uses the default "warn"
-  # severity — the same severity `dotnet format` applies with no
-  # --severity flag — rather than --severity info: at info severity
-  # dotnet format additionally tries to auto-fix long-standing Roslyn
-  # analyzer diagnostics (CA1859, CA1861, CA1018, ...) across the
-  # repo, which is a materially different (and, on this SDK/analyzer
-  # combination, occasionally crash-prone) undertaking from verifying
-  # whitespace/style formatting and is out of scope for this gate.
+  # subsequent branch then has to inherit. The repo does not yet ship
+  # a root `.editorconfig`, so the enforced ruleset is whatever the
+  # SDK pinned by `actions/setup-dotnet` treats as its whitespace /
+  # C# formatting defaults; introducing a committed `.editorconfig`
+  # that freezes those rules against future SDK drift is tracked as a
+  # follow-up (see PR description). Uses the default "warn" severity
+  # — the same severity `dotnet format` applies with no --severity
+  # flag — rather than --severity info: at info severity dotnet format
+  # additionally tries to auto-fix long-standing Roslyn analyzer
+  # diagnostics (CA1859, CA1861, CA1018, ...) across the repo, which
+  # is a materially different (and, on this SDK/analyzer combination,
+  # occasionally crash-prone) undertaking from verifying whitespace /
+  # style formatting and is out of scope for this gate. `--verbosity
+  # diagnostic` is set on the verify step so the CI log names each
+  # offending file and rule when the gate fires — a contributor can
+  # then reproduce and fix locally without scrolling for the delta.
+  # A second verify step covers the two csprojs that ship with the
+  # `dotnet new` template but are not members of `MTConnect.NET.sln`;
+  # the template itself is a public-surface artifact for downstream
+  # consumers, so it belongs under the same gate as the main tree.
   # Runs on the same draft-skip gate as the other jobs and does not
   # depend on them, so a formatting-only fix gets fast feedback.
   # ------------------------------------------------------------------
@@ -58,8 +70,27 @@ jobs:
       - name: Restore solution
         run: dotnet restore MTConnect.NET.sln
 
-      - name: Verify format (dotnet format --verify-no-changes)
-        run: dotnet format MTConnect.NET.sln --verify-no-changes --no-restore
+      - name: Verify solution format (dotnet format --verify-no-changes)
+        run: dotnet format MTConnect.NET.sln --verify-no-changes --no-restore --verbosity diagnostic
+
+      # `MTConnect.NET.sln` does not include the two csprojs that ship
+      # with the `dotnet new mtconnect.net-agent` template (the
+      # template descriptor + the generated project's csproj under
+      # `content/`). They are public-surface artifacts for downstream
+      # template consumers, so formatting drift there is exactly what
+      # the gate is meant to catch. Restore + verify them explicitly
+      # rather than adding them to the solution (which would compile
+      # them on every unrelated build and complicate the template
+      # packaging step).
+      - name: Restore template projects
+        run: |
+          dotnet restore templates/mtconnect.net-agent/MTConnect-NET-Agent-Template.csproj
+          dotnet restore templates/mtconnect.net-agent/content/MTConnect.NET-Embedded-Agent/Agent.csproj
+
+      - name: Verify template format (dotnet format --verify-no-changes)
+        run: |
+          dotnet format templates/mtconnect.net-agent/MTConnect-NET-Agent-Template.csproj --verify-no-changes --no-restore --verbosity diagnostic
+          dotnet format templates/mtconnect.net-agent/content/MTConnect.NET-Embedded-Agent/Agent.csproj --verify-no-changes --no-restore --verbosity diagnostic
 
   # ------------------------------------------------------------------
   # Job 1 — unsharded unit + integration sweep on both OS legs.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -81,16 +81,20 @@ jobs:
       # the gate is meant to catch. Restore + verify them explicitly
       # rather than adding them to the solution (which would compile
       # them on every unrelated build and complicate the template
-      # packaging step).
-      - name: Restore template projects
-        run: |
-          dotnet restore templates/mtconnect.net-agent/MTConnect-NET-Agent-Template.csproj
-          dotnet restore templates/mtconnect.net-agent/content/MTConnect.NET-Embedded-Agent/Agent.csproj
+      # packaging step). Each project gets its own restore + verify
+      # step so a failure names the specific template in the Actions
+      # step-summary panel rather than in the collapsed log.
+      - name: Restore template descriptor
+        run: dotnet restore templates/mtconnect.net-agent/MTConnect-NET-Agent-Template.csproj
 
-      - name: Verify template format (dotnet format --verify-no-changes)
-        run: |
-          dotnet format templates/mtconnect.net-agent/MTConnect-NET-Agent-Template.csproj --verify-no-changes --no-restore --verbosity diagnostic
-          dotnet format templates/mtconnect.net-agent/content/MTConnect.NET-Embedded-Agent/Agent.csproj --verify-no-changes --no-restore --verbosity diagnostic
+      - name: Restore template content project
+        run: dotnet restore templates/mtconnect.net-agent/content/MTConnect.NET-Embedded-Agent/Agent.csproj
+
+      - name: Verify template descriptor format
+        run: dotnet format templates/mtconnect.net-agent/MTConnect-NET-Agent-Template.csproj --verify-no-changes --no-restore --verbosity diagnostic
+
+      - name: Verify template content project format
+        run: dotnet format templates/mtconnect.net-agent/content/MTConnect.NET-Embedded-Agent/Agent.csproj --verify-no-changes --no-restore --verbosity diagnostic
 
   # ------------------------------------------------------------------
   # Job 1 — unsharded unit + integration sweep on both OS legs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to MTConnect.NET
+
+Thank you for taking the time to contribute — issues, discussions, and pull requests are all welcome. This file collects the mechanical checks a contributor is expected to run locally before pushing; the substantive discussion of what to work on lives on the [MTConnect.NET issue tracker](https://github.com/TrakHound/MTConnect.NET/issues) and on the [Documentation site](https://trakhound.github.io/MTConnect.NET/).
+
+## Running the formatting gate locally
+
+Every push to `master` and every non-draft pull request runs `dotnet format MTConnect.NET.sln --verify-no-changes` in CI (job `format`, defined in [`.github/workflows/dotnet.yml`](.github/workflows/dotnet.yml)). The gate rejects any whitespace / indentation / brace-placement drift, so it is worth reproducing the check before pushing:
+
+```bash
+dotnet restore MTConnect.NET.sln
+dotnet format MTConnect.NET.sln                                     # autofix in place
+dotnet format MTConnect.NET.sln --verify-no-changes --verbosity diagnostic   # dry-run, same as CI
+```
+
+The two `dotnet new mtconnect.net-agent` template projects live outside the solution and CI verifies them in dedicated steps; run the same commands against them if you have touched files under `templates/`:
+
+```bash
+dotnet restore templates/mtconnect.net-agent/MTConnect-NET-Agent-Template.csproj
+dotnet restore templates/mtconnect.net-agent/content/MTConnect.NET-Embedded-Agent/Agent.csproj
+dotnet format templates/mtconnect.net-agent/MTConnect-NET-Agent-Template.csproj --verify-no-changes --verbosity diagnostic
+dotnet format templates/mtconnect.net-agent/content/MTConnect.NET-Embedded-Agent/Agent.csproj --verify-no-changes --verbosity diagnostic
+```
+
+See [`docs/testing/workflows.md`](docs/testing/workflows.md#job-0--format) for the complete gate description, the `--severity warn` rationale, and the tracked follow-ups (root `.editorconfig` + `global.json` SDK pin).
+
+## Running the test suite locally
+
+The default sweep runs unit and light-integration tests across the whole solution:
+
+```bash
+./tools/test.sh          # Linux / macOS / Git Bash
+./tools/test.ps1         # PowerShell, all platforms
+```
+
+Add `--e2e` / `-E2E` (Docker required) to also run the `Category=E2E` and `Category=RequiresDocker` workflow fixtures. `./tools/test.sh --help` (or `./tools/test.ps1 -?`) prints the full flag listing. The CI matrix and per-category filter rationale are documented on [`docs/testing/workflows.md`](docs/testing/workflows.md).
+
+## Opening a pull request
+
+- Keep the PR body focused on the user-facing diff — what changed, why it changed, and how a reviewer can verify it. Internal process detail belongs in the commit trailer or in follow-up comments, not in the description.
+- Every push re-runs the full CI matrix on non-draft PRs. Leave a PR in draft while it is still being iterated; flip it to ready when it is ready for review.
+- If your change touches the `templates/` tree, please also run the template-project format commands above — the CI gate will catch drift, but reproducing locally saves a red-CI round-trip.
+
+Thanks again for your interest in improving MTConnect.NET.

--- a/README.md
+++ b/README.md
@@ -246,17 +246,17 @@ This repo along with the libraries and applications are free to use and distribu
 
 Feel free to comment, or create pull-requests for anything that could be coded, formatted, or worded better. Attention to detail and continuous improvement are important in manufacturing so they should be just as important for manufacturing software.
 
-### Contributing — running the formatting gate locally
+### Contributing
 
-Every push to `master` and every non-draft PR runs `dotnet format MTConnect.NET.sln --verify-no-changes` in CI (job `format`, defined in [`.github/workflows/dotnet.yml`](.github/workflows/dotnet.yml)). Before pushing, reproduce the check locally with:
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the local-reproduction commands the CI gate expects (formatting + tests) and the pull-request expectations. In short, before pushing:
 
 ```bash
 dotnet restore MTConnect.NET.sln
-dotnet format MTConnect.NET.sln                                     # autofix in place
-dotnet format MTConnect.NET.sln --verify-no-changes --verbosity diagnostic   # dry-run, same as CI
+dotnet format MTConnect.NET.sln --verify-no-changes --verbosity diagnostic   # same as the CI `format` job
+./tools/test.sh                                                              # or ./tools/test.ps1
 ```
 
-See [`docs/testing/workflows.md`](docs/testing/workflows.md#job-0--format) for the full gate description, the template-project coverage step, and the tracked follow-ups (root `.editorconfig` + `global.json` SDK pin).
+The full CI gate description, the `--severity warn` rationale, and the tracked follow-ups (root `.editorconfig` + `global.json` SDK pin) are documented on [`docs/testing/workflows.md`](docs/testing/workflows.md#job-0--format).
 
 Thanks for your interest in using these libraries and applications and feel free to contribute or give feedback.
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ This repo along with the libraries and applications are free to use and distribu
 
 Feel free to comment, or create pull-requests for anything that could be coded, formatted, or worded better. Attention to detail and continuous improvement are important in manufacturing so they should be just as important for manufacturing software.
 
+### Contributing — running the formatting gate locally
+
+Every push to `master` and every non-draft PR runs `dotnet format MTConnect.NET.sln --verify-no-changes` in CI (job `format`, defined in [`.github/workflows/dotnet.yml`](.github/workflows/dotnet.yml)). Before pushing, reproduce the check locally with:
+
+```bash
+dotnet restore MTConnect.NET.sln
+dotnet format MTConnect.NET.sln                                     # autofix in place
+dotnet format MTConnect.NET.sln --verify-no-changes --verbosity diagnostic   # dry-run, same as CI
+```
+
+See [`docs/testing/workflows.md`](docs/testing/workflows.md#job-0--format) for the full gate description, the template-project coverage step, and the tracked follow-ups (root `.editorconfig` + `global.json` SDK pin).
+
 Thanks for your interest in using these libraries and applications and feel free to contribute or give feedback.
 
 \- Patrick

--- a/build/MTConnect.NET-DocsGen/RouteInventory.cs
+++ b/build/MTConnect.NET-DocsGen/RouteInventory.cs
@@ -218,65 +218,88 @@ public static class RouteInventory
     // imperatively inside OnRequestReceived, so the surface is encoded
     // structurally here to give the reference page meaningful columns;
     // the *summary text* still flows from /// on the handler class.
+    //
+    // Each handler's parameter list is a separate `private static readonly`
+    // field rather than an inline nested initializer inside the
+    // dictionary literal. `dotnet format` cannot indent an inline
+    // `new EndpointParam[] { ... }` nested inside a dictionary
+    // collection-initializer coherently — it deepens the outer keys
+    // but leaves the inner block at the old depth, producing a visible
+    // misalignment cascade. Hoisting the arrays flattens both layers to
+    // the same indent depth and keeps the formatter idempotent.
+    private static readonly EndpointParam[] ProbeParams =
+    {
+        new("deviceType", "Query", "string", null, "Optional device-type filter."),
+        new("version", "Query", "string", null, "Target MTConnect Standard version of the response document."),
+        new("documentFormat", "Query", "string", "xml", "Response document format (xml | json | json-cppagent)."),
+        new("validationLevel", "Query", "int", null, "0=ignore, 1=warning, 2=remove, 3=strict."),
+        new("indentOutput", "Query", "bool", null, "Pretty-print the response document."),
+        new("outputComments", "Query", "bool", null, "Emit comments / annotations in the response document."),
+    };
+
+    private static readonly EndpointParam[] CurrentParams =
+    {
+        new("path", "Query", "string", null, "XPath that filters the data items included in the response."),
+        new("at", "Query", "ulong", null, "Sequence number anchoring the snapshot."),
+        new("interval", "Query", "int", null, "Streaming interval in milliseconds; switches to multipart streaming when > 0."),
+        new("heartbeat", "Query", "int", "10000", "Heartbeat interval for the streaming response."),
+        new("deviceType", "Query", "string", null, "Optional device-type filter."),
+        new("version", "Query", "string", null, "Target MTConnect Standard version of the response document."),
+        new("documentFormat", "Query", "string", "xml", "Response document format."),
+        new("indentOutput", "Query", "bool", null, "Pretty-print the response document."),
+        new("outputComments", "Query", "bool", null, "Emit comments / annotations in the response document."),
+    };
+
+    private static readonly EndpointParam[] SampleParams =
+    {
+        new("path", "Query", "string", null, "XPath that filters the data items included in the response."),
+        new("from", "Query", "ulong", null, "Sequence number lower bound."),
+        new("to", "Query", "ulong", null, "Sequence number upper bound."),
+        new("count", "Query", "int", "100", "Maximum number of observations."),
+        new("interval", "Query", "int", null, "Streaming interval in milliseconds; switches to multipart streaming when > 0."),
+        new("heartbeat", "Query", "int", "10000", "Heartbeat interval for the streaming response."),
+        new("deviceType", "Query", "string", null, "Optional device-type filter."),
+        new("version", "Query", "string", null, "Target MTConnect Standard version of the response document."),
+        new("documentFormat", "Query", "string", "xml", "Response document format."),
+        new("indentOutput", "Query", "bool", null, "Pretty-print the response document."),
+        new("outputComments", "Query", "bool", null, "Emit comments / annotations in the response document."),
+    };
+
+    private static readonly EndpointParam[] AssetsParams =
+    {
+        new("type", "Query", "string", null, "Asset type filter (e.g. CuttingTool)."),
+        new("removed", "Query", "bool", null, "Include removed assets when true."),
+        new("count", "Query", "int", null, "Maximum number of assets."),
+        new("documentFormat", "Query", "string", "xml", "Response document format."),
+        new("indentOutput", "Query", "bool", null, "Pretty-print the response document."),
+    };
+
+    private static readonly EndpointParam[] AssetParams =
+    {
+        new("assetId", "Route", "string", null, "Asset identifier captured from the trailing path segment."),
+        new("documentFormat", "Query", "string", "xml", "Response document format."),
+    };
+
+    private static readonly EndpointParam[] PutParams =
+    {
+        new("(form / query)", "Body", "Dictionary<string,string>", null, "DataItemId=Value entries to enqueue as observations."),
+    };
+
+    private static readonly EndpointParam[] PostParams =
+    {
+        new("(body)", "Body", "string", null, "Asset document payload."),
+    };
+
     private static readonly IReadOnlyDictionary<string, IReadOnlyList<EndpointParam>> CeenHandlerParameters
         = new Dictionary<string, IReadOnlyList<EndpointParam>>
         {
-            ["MTConnectProbeResponseHandler"] = new EndpointParam[]
-        {
-            new("deviceType", "Query", "string", null, "Optional device-type filter."),
-            new("version", "Query", "string", null, "Target MTConnect Standard version of the response document."),
-            new("documentFormat", "Query", "string", "xml", "Response document format (xml | json | json-cppagent)."),
-            new("validationLevel", "Query", "int", null, "0=ignore, 1=warning, 2=remove, 3=strict."),
-            new("indentOutput", "Query", "bool", null, "Pretty-print the response document."),
-            new("outputComments", "Query", "bool", null, "Emit comments / annotations in the response document."),
-        },
-            ["MTConnectCurrentResponseHandler"] = new EndpointParam[]
-        {
-            new("path", "Query", "string", null, "XPath that filters the data items included in the response."),
-            new("at", "Query", "ulong", null, "Sequence number anchoring the snapshot."),
-            new("interval", "Query", "int", null, "Streaming interval in milliseconds; switches to multipart streaming when > 0."),
-            new("heartbeat", "Query", "int", "10000", "Heartbeat interval for the streaming response."),
-            new("deviceType", "Query", "string", null, "Optional device-type filter."),
-            new("version", "Query", "string", null, "Target MTConnect Standard version of the response document."),
-            new("documentFormat", "Query", "string", "xml", "Response document format."),
-            new("indentOutput", "Query", "bool", null, "Pretty-print the response document."),
-            new("outputComments", "Query", "bool", null, "Emit comments / annotations in the response document."),
-        },
-            ["MTConnectSampleResponseHandler"] = new EndpointParam[]
-        {
-            new("path", "Query", "string", null, "XPath that filters the data items included in the response."),
-            new("from", "Query", "ulong", null, "Sequence number lower bound."),
-            new("to", "Query", "ulong", null, "Sequence number upper bound."),
-            new("count", "Query", "int", "100", "Maximum number of observations."),
-            new("interval", "Query", "int", null, "Streaming interval in milliseconds; switches to multipart streaming when > 0."),
-            new("heartbeat", "Query", "int", "10000", "Heartbeat interval for the streaming response."),
-            new("deviceType", "Query", "string", null, "Optional device-type filter."),
-            new("version", "Query", "string", null, "Target MTConnect Standard version of the response document."),
-            new("documentFormat", "Query", "string", "xml", "Response document format."),
-            new("indentOutput", "Query", "bool", null, "Pretty-print the response document."),
-            new("outputComments", "Query", "bool", null, "Emit comments / annotations in the response document."),
-        },
-            ["MTConnectAssetsResponseHandler"] = new EndpointParam[]
-        {
-            new("type", "Query", "string", null, "Asset type filter (e.g. CuttingTool)."),
-            new("removed", "Query", "bool", null, "Include removed assets when true."),
-            new("count", "Query", "int", null, "Maximum number of assets."),
-            new("documentFormat", "Query", "string", "xml", "Response document format."),
-            new("indentOutput", "Query", "bool", null, "Pretty-print the response document."),
-        },
-            ["MTConnectAssetResponseHandler"] = new EndpointParam[]
-        {
-            new("assetId", "Route", "string", null, "Asset identifier captured from the trailing path segment."),
-            new("documentFormat", "Query", "string", "xml", "Response document format."),
-        },
-            ["MTConnectPutResponseHandler"] = new EndpointParam[]
-        {
-            new("(form / query)", "Body", "Dictionary<string,string>", null, "DataItemId=Value entries to enqueue as observations."),
-        },
-            ["MTConnectPostResponseHandler"] = new EndpointParam[]
-        {
-            new("(body)", "Body", "string", null, "Asset document payload."),
-        },
+            ["MTConnectProbeResponseHandler"] = ProbeParams,
+            ["MTConnectCurrentResponseHandler"] = CurrentParams,
+            ["MTConnectSampleResponseHandler"] = SampleParams,
+            ["MTConnectAssetsResponseHandler"] = AssetsParams,
+            ["MTConnectAssetResponseHandler"] = AssetParams,
+            ["MTConnectPutResponseHandler"] = PutParams,
+            ["MTConnectPostResponseHandler"] = PostParams,
         };
 
     // Cache of parsed /// summary text per handler-class file path, so

--- a/docs/testing/workflows.md
+++ b/docs/testing/workflows.md
@@ -49,6 +49,54 @@ non-draft PR against `master` (drafts skip; flipping ready fires the
 run on `ready_for_review`).
 
 **Matrix:** `ubuntu-latest` × `windows-latest`, .NET SDK `8.0.x` + `9.0.x`.
+The `format` gate is single-legged (`ubuntu-latest`) because
+`dotnet format`'s output is deterministic across OSes — running it
+on both would only pay the wall-clock twice for the same result.
+
+### Job 0 — `format`
+
+Verifies the whole tree is byte-identical to `dotnet format`'s
+whitespace / C# formatting output, so indentation, brace placement,
+and trailing-whitespace drift cannot silently reaccumulate into the
+baseline. Runs on `ubuntu-latest`, installs both .NET 8.0.x and
+9.0.x (the same pair the build / test / docs / e2e jobs use), and
+does not depend on any other job — a formatting-only fix therefore
+gets fast feedback without waiting on the unit + integration matrix.
+
+1. Checkout (`actions/checkout`).
+2. Setup .NET (`actions/setup-dotnet`) — installs both 8.0.x and 9.0.x.
+3. `dotnet restore MTConnect.NET.sln`.
+4. `dotnet format MTConnect.NET.sln --verify-no-changes --no-restore --verbosity diagnostic`
+   — exits non-zero on any diff; `--verbosity diagnostic` names each
+   offending file and rule directly in the CI log so a contributor
+   can reproduce and fix locally without further tooling.
+5. `dotnet restore` + `dotnet format --verify-no-changes` for the two
+   template csprojs that are not solution members
+   (`templates/mtconnect.net-agent/MTConnect-NET-Agent-Template.csproj`
+   and `.../content/MTConnect.NET-Embedded-Agent/Agent.csproj`). Both
+   ship to downstream consumers via `dotnet new`, so their formatting
+   is user-facing and belongs under the same gate.
+
+The gate enforces `dotnet format`'s default `warn` severity, not
+`--severity info`: at `info`, `dotnet format` additionally auto-fixes
+long-standing Roslyn analyzer diagnostics (`CA1859`, `CA1861`,
+`CA1018`, ...) across the whole repo, which is a materially larger
+undertaking than whitespace verification (and, on the SDK / analyzer
+combination this repo targets, occasionally aborts mid-run with
+`NotSupportedException`). Analyzer-diagnostic cleanup is tracked as
+its own follow-up rather than folded into this gate.
+
+**Local reproduction:** `dotnet format MTConnect.NET.sln` (autofix)
+or `dotnet format MTConnect.NET.sln --verify-no-changes --verbosity diagnostic`
+(dry-run, exits non-zero on any diff — the same invocation CI uses).
+The repo does not yet ship a root `.editorconfig`; the gate therefore
+relies on the SDK's built-in formatting defaults, and a future SDK
+release that shifts those defaults will re-fire the gate on unchanged
+code. Freezing the ruleset with a committed `.editorconfig` +
+`global.json` SDK pin is a tracked follow-up (see the format-baseline
+PR description).
+
+### Jobs 1-4 — build, test, docs, route-check
 
 **Steps:**
 

--- a/docs/testing/workflows.md
+++ b/docs/testing/workflows.md
@@ -96,7 +96,7 @@ code. Freezing the ruleset with a committed `.editorconfig` +
 `global.json` SDK pin is a tracked follow-up (see the format-baseline
 PR description).
 
-### Jobs 1-4 — build, test, docs, route-check
+### Jobs 1–4 — build, test, docs, route-check
 
 **Steps:**
 


### PR DESCRIPTION
## Summary

- `dotnet format MTConnect.NET.sln --verify-no-changes` currently fails against `master`, with formatting drift (mostly tab/space indentation) spread across 61 files, concentrated in `MTConnect.NET-Common`, `MTConnect.NET-HTTP` and the `build/` tooling projects. Applies `dotnet format` once to bring the tree back to zero-diff against `dotnet format`'s SDK-default formatting rules. The repo does not yet ship a root `.editorconfig`, so the enforced ruleset is whatever the SDK pinned by `actions/setup-dotnet` treats as its whitespace / C# formatting defaults; committing a root `.editorconfig` (plus a `global.json` SDK pin) to freeze the rules against future SDK drift is a tracked follow-up (see below).
- Adds a `format` job to `.github/workflows/dotnet.yml` that runs `dotnet format MTConnect.NET.sln --verify-no-changes --verbosity diagnostic` on every push to `master` and every non-draft pull request targeting it, so this drift cannot silently reaccumulate. The `--verbosity diagnostic` flag names each offending file and rule directly in the CI log when the gate fires, so a contributor can reproduce and fix locally without further tooling.
- Adds four sibling per-project steps (restore + verify) for the two csprojs that ship with the `dotnet new mtconnect.net-agent` template but are not members of `MTConnect.NET.sln`; both are public-surface artifacts for downstream template consumers, so their formatting is user-facing and belongs under the same gate.
- Refactors `build/MTConnect.NET-DocsGen/RouteInventory.cs::CeenHandlerParameters` to hoist each handler's `EndpointParam[]` into a dedicated `private static readonly` field. The prior shape (an inline `new EndpointParam[] { ... }` nested inside a dictionary object initializer) tripped `dotnet format` into a non-idempotent indent cascade — the outer dictionary keys deepened by four spaces while the inner block stayed at the old depth. Hoisting the arrays flattens both layers to the same indent depth and keeps `dotnet format` a no-op on the file.
- Documents the new gate on [`docs/testing/workflows.md`](docs/testing/workflows.md#job-0--format) (steps, `--severity warn` rationale, local-reproduction command), and adds a top-level [`CONTRIBUTING.md`](CONTRIBUTING.md) so GitHub's contributor-guidelines banner surfaces the formatting + test invocations on new-PR / new-issue forms.
- No behavioral change: `dotnet build` succeeds cleanly on the formatted tree; the whole-tree diff is whitespace / indentation only apart from the one `RouteInventory.cs` refactor above (verified by comparing whitespace-stripped diff lines on every other touched file).

## Scope note on `--severity`

`dotnet format` with no `--severity` flag defaults to `warn`, which covers whitespace and style diagnostics — that is what was applied here and what the new CI job checks. `--severity info` additionally attempts to auto-fix long-standing Roslyn analyzer diagnostics (`CA1859`, `CA1861`, `CA1018`, etc.) across the whole repository; on the SDK used to prepare this branch that full-tree run terminates with `NotSupportedException: Changing document properties is not supported` before completing. Analyzer-diagnostic cleanup is a materially different, larger piece of work from formatting drift, so it is deliberately left out of scope here; the CI gate mirrors the same default severity.

## Follow-ups (not in this PR)

- **Root `.editorconfig` + `global.json` SDK pin**: the gate currently relies on `dotnet format`'s SDK-default ruleset. Committing a root `.editorconfig` that freezes the enforced rules, plus a `global.json` that pins the SDK, would insulate the gate from future .NET 8 / 9 patch releases that shift a formatting default and silently re-fire the gate on unchanged code.
- **Required status check**: for this gate to actually block merges, the new `format` job needs to be added to the branch-protection required-status-check list for `master`. I don't have branch-protection edit rights, so a maintainer will need to enable it after this merges.
- **Pre-commit hook**: the repository has no `lefthook`, `husky`, or `pre-commit` tooling installed, so a hook that runs `dotnet format` on staged files before commit is left as a follow-up rather than bundled here (adding a hook framework is a separate, more invasive change deserving its own PR and review).
- **NuGet cache + workflow-level `concurrency` block**: broader CI-hygiene wins that would speed the format job (and every other job) up on cache-hit and cancel superseded runs on the same PR. Scoped to a dedicated CI-hygiene PR rather than folded into this format-baseline change.

## Dime review cycle 1

| Agent | Findings | Disposition |
|---|---|---|
| `code-review` | 1 MEDIUM (missing `.editorconfig` vs PR-body claim), 1 LOW (out-of-sln template csprojs) | CLOSED in cycle-1 fix commit `8c542429` — workflow comment now reflects SDK-default ruleset; template csprojs added to gate scope. |
| `security-audit` | none | — |
| `simplification` | none | — |
| `improvement` | 2 MEDIUM (`--verbosity diagnostic`; missing `.editorconfig`), 3 LOW (README pointer; NuGet cache; workflow-level `concurrency`) | CLOSED (`--verbosity diagnostic` applied; README + `CONTRIBUTING.md` pointers added). `.editorconfig` and CI-hygiene items TRACKED as follow-ups above. |
| `documentation-audit` | 1 HIGH (`docs/testing/workflows.md` missing format-job entry), 1 MEDIUM (no `dotnet format` guidance for developers) | CLOSED — `### Job 0 — format` subsection added; README + `CONTRIBUTING.md` guidance added. |
| `test-coverage-audit` | none | — |

## Dime review cycle 2

| Agent | Findings | Disposition |
|---|---|---|
| `code-review` | 1 LOW (typography — ASCII hyphen in `### Jobs 1-4` heading) | CLOSED in cycle-2 fix commit `d7353b7b` — en-dash applied. |
| `security-audit` | none | — |
| `simplification` | none | — |
| `improvement` | 1 MEDIUM (`RouteInventory.cs` indent cascade baked in by the format run), 2 LOW (missing `CONTRIBUTING.md`; template steps grouped into two `run:` blocks) | CLOSED — `CeenHandlerParameters` refactored to hoist parameter arrays into named fields (`dotnet format` now idempotent on the file); `CONTRIBUTING.md` added; template steps split into four per-project named steps for CI-log granularity. |
| `documentation-audit` | 1 MEDIUM (PR body still asserted the `.editorconfig` claim contradicted by the new docs) | CLOSED — this PR body edit rewrites the Summary bullet to match the docs and the workflow comment. |
| `test-coverage-audit` | none | — |

## Dime review cycle 3

_Retro-fresh cycle at the current tip `bb41a02a` (was `fc328332` at cycles 1-2), triggered by the merge-train position-discipline rule requiring dime cycles at the current head, not at an earlier `completed_head_sha`._

| Agent | Findings | Disposition |
|---|---|---|
| `code-review` | 2 LOW (added-line BrE tokens `artefact`/`artefacts` in `.github/workflows/dotnet.yml` comment block; `artefacts`/`cataloguing` in the earlier commit's message body) | FIXED in the cycle-3 rebase-rewrite (commit `549b3dd9` → `4164ba1e`) — American English mandate on committed content overrides the LOW ceiling; workflow comment lines 50, 79 now use `artifact` / `artifacts`; commit body now uses `artifacts` / `cataloging`. Pre-existing BrE on workflow lines 461, 543 stays untouched (already on `master`, out of this PR's diff scope). |
| `security-audit` | none | — |
| `simplification` | 2 LOW (`README.md` Contributing block still lists commands rather than pointer-only to `CONTRIBUTING.md`; four per-template restore + verify steps could collapse to two per-template combined steps) | CLOSED with rationale — README self-contained shape aids drive-by browsers who never open `CONTRIBUTING.md`; separate restore + verify steps let Actions surface per-phase timing in the step-summary panel, keeping diagnostic value. Both are proposals with the reviewer's own false-positive defence covering the current shape. |
| `improvement` | 2 MEDIUM (no `timeout-minutes` on the new format job / any workflow job; workflow-level `concurrency` block deferred), 2 LOW (`fetch-depth: 1` pin on `actions/checkout`; `_ceenSummaryCache` as `ConcurrentDictionary` for future concurrent callers) | CLOSED with rationale — `timeout-minutes` and workflow-level `concurrency` both belong in the deferred CI-hygiene follow-up PR listed under "Follow-ups (not in this PR)" above (alongside NuGet cache), not folded into this format-baseline scope. `fetch-depth: 1` matches the current `actions/checkout@v4` default (no behavioural change). `_ceenSummaryCache` is only ever populated from single-threaded `DocsGen` invocations; the race is theoretical. |
| `documentation-audit` | none | — |
| `test-coverage-audit` | none | `RouteInventory.cs` refactor is behaviour-preserving; the byte-exact `docs/reference/http-api.md` assertion in `DocsReferenceGenerationTests.HttpApi_Page_Is_In_Sync_With_Source` transitively pins every hoisted `EndpointParam[]` field's content — any drift would fail the assertion. |

## Dime review cycle 4

_Delta-only cycle at tip `bb41a02a` verifying the cycle-3 rebase-rewrite: 4 word-swaps in comments and a commit body, second commit rebased on top. No behavioural, logical, or algorithmic change; second commit content byte-identical to its cycle-3 form._

| Agent | Findings | Disposition |
|---|---|---|
| `code-review` | none | Cycle-3 BrE findings verified Fixed. Both commits `%G? = G`. No new leaks. |
| `security-audit` | none | Word-swaps are comment-only, no `run:` / `env:` / `${{ }}` / `ref:` surface change; no secrets introduced. |
| `simplification` | none | No structural change; cycle-3 dispositions stand. |
| `improvement` | none | No new opportunities from the rebase-rewrite; cycle-3 dispositions stand. |
| `documentation-audit` | none | Added-line BrE grep returns 0; pre-existing carve-out lines untouched. |
| `test-coverage-audit` | none | Zero test-code delta from the rebase. |

_(Zero unfixed findings — Ready-eligible.)_

