### PR TITLE
chore(tests): upgrade NUnit 3 to 4.6.1 across all test projects

### DIFF
--- a/tests/Compliance/MTConnect-Compliance-Tests/MTConnect-Compliance-Tests.csproj
+++ b/tests/Compliance/MTConnect-Compliance-Tests/MTConnect-Compliance-Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Testcontainers" Version="3.10.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />

--- a/tests/Compliance/MTConnect-Compliance-Tests/MTConnect-Compliance-Tests.csproj
+++ b/tests/Compliance/MTConnect-Compliance-Tests/MTConnect-Compliance-Tests.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Testcontainers" Version="3.10.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>

--- a/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/LastSentSequencePersisterTests.cs
+++ b/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/LastSentSequencePersisterTests.cs
@@ -2,6 +2,7 @@
 // TrakHound Inc. licenses this file to you under the MIT license.
 
 using NUnit.Framework;
+using System;
 
 namespace MTConnect.AgentModule.MqttRelay.Tests
 {
@@ -90,7 +91,7 @@ namespace MTConnect.AgentModule.MqttRelay.Tests
             persister.Update(123UL);
 
             Assert.Throws<System.IO.IOException>(
-                () => persister.TryFlush(_ => throw new System.IO.IOException("disk full")));
+                (Action)(() => persister.TryFlush(_ => throw new System.IO.IOException("disk full"))));
 
             Assert.That(persister.IsDirty, Is.True,
                 "A failed write must leave the persister dirty so the next flush retries.");
@@ -135,7 +136,7 @@ namespace MTConnect.AgentModule.MqttRelay.Tests
             // A null writer means the caller has not wired persistence
             // (e.g. DurableRelay disabled at runtime); the persister
             // must not throw.
-            Assert.DoesNotThrow(() => persister.TryFlush(null));
+            Assert.DoesNotThrow((Action)(() => persister.TryFlush(null)));
             // Dirty bit unchanged because no write happened.
             Assert.That(persister.IsDirty, Is.True);
         }

--- a/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MTConnect.NET-AgentModule-MqttRelay-Tests.csproj
+++ b/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MTConnect.NET-AgentModule-MqttRelay-Tests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MTConnect.NET-AgentModule-MqttRelay-Tests.csproj
+++ b/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MTConnect.NET-AgentModule-MqttRelay-Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MqttRelayLifecycleDisconnectTests.cs
+++ b/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MqttRelayLifecycleDisconnectTests.cs
@@ -89,10 +89,10 @@ namespace MTConnect.AgentModule.MqttRelay.Tests
             // and route the exception to the fault logger.
             string loggedFault = null;
 
-            Assert.DoesNotThrow(() => MqttRelayLifecycle.DisconnectWithTimeout(
+            Assert.DoesNotThrow((Action)(() => MqttRelayLifecycle.DisconnectWithTimeout(
                 disconnect: () => throw new InvalidOperationException("sync throw"),
                 timeout: TimeSpan.FromSeconds(1),
-                onFault: ex => loggedFault = ex.Message));
+                onFault: ex => loggedFault = ex.Message)));
 
             Assert.That(loggedFault, Is.EqualTo("sync throw"));
         }
@@ -104,10 +104,10 @@ namespace MTConnect.AgentModule.MqttRelay.Tests
             // The shutdown path must tolerate a null disconnect factory
             // (for example when _mqttClient is null because the worker
             // never ran).
-            Assert.DoesNotThrow(() => MqttRelayLifecycle.DisconnectWithTimeout(
+            Assert.DoesNotThrow((Action)(() => MqttRelayLifecycle.DisconnectWithTimeout(
                 disconnect: null,
                 timeout: TimeSpan.FromSeconds(1),
-                onFault: _ => { }));
+                onFault: _ => { })));
         }
     }
 }

--- a/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MqttRelayLifecycleStopTests.cs
+++ b/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/MqttRelayLifecycleStopTests.cs
@@ -2,6 +2,7 @@
 // TrakHound Inc. licenses this file to you under the MIT license.
 
 using NUnit.Framework;
+using System;
 
 namespace MTConnect.AgentModule.MqttRelay.Tests
 {
@@ -32,7 +33,7 @@ namespace MTConnect.AgentModule.MqttRelay.Tests
             // either server is the worst case; the helper must be a
             // total function over (null, null).
             Assert.DoesNotThrow(
-                () => MqttRelayLifecycle.StopServers(documentStop: null, entityStop: null));
+                (Action)(() => MqttRelayLifecycle.StopServers(documentStop: null, entityStop: null)));
         }
 
         /// <summary>Pins the behaviour expressed by the test name: stop servers invokes document stop when provided.</summary>
@@ -85,9 +86,9 @@ namespace MTConnect.AgentModule.MqttRelay.Tests
             // shutdown leaks live handlers.
             var entityStopped = false;
 
-            Assert.DoesNotThrow(() => MqttRelayLifecycle.StopServers(
+            Assert.DoesNotThrow((Action)(() => MqttRelayLifecycle.StopServers(
                 documentStop: () => throw new System.InvalidOperationException("doc"),
-                entityStop: () => entityStopped = true));
+                entityStop: () => entityStopped = true)));
 
             Assert.That(entityStopped, Is.True);
         }

--- a/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/WorkerLoopExceptionLoggerTests.cs
+++ b/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/WorkerLoopExceptionLoggerTests.cs
@@ -95,9 +95,9 @@ namespace MTConnect.AgentModule.MqttRelay.Tests
             // Defensive: the helper must not throw when the logger is
             // not wired (would defeat the purpose of catching the
             // unexpected exception).
-            Assert.DoesNotThrow(() => WorkerLoopExceptionLogger.Log(
+            Assert.DoesNotThrow((Action)(() => WorkerLoopExceptionLogger.Log(
                 exception: new InvalidOperationException("boom"),
-                onLog: null));
+                onLog: null)));
         }
 
         /// <summary>Pins the behaviour expressed by the test name: log treats subclass of task canceled exception as cancellation.</summary>

--- a/tests/MTConnect.NET-Common-Tests/Agents/AgentMulticastIsolationTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Agents/AgentMulticastIsolationTests.cs
@@ -65,7 +65,7 @@ namespace MTConnect.Tests.Common
             var device = new Device { Name = "device-1", Uuid = "uuid-1" };
             EventHandler<IDevice> handler = (_, _) => throw new InvalidOperationException("DeviceAdded fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, (IDevice)device, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, (IDevice)device, null)));
         }
 
         // -----------------------------------------------------------------------
@@ -96,7 +96,7 @@ namespace MTConnect.Tests.Common
             var obs = new ObservationInput();
             EventHandler<IObservationInput> handler = (_, _) => throw new InvalidOperationException("ObservationReceived fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, (IObservationInput)obs, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, (IObservationInput)obs, null)));
         }
 
         // -----------------------------------------------------------------------
@@ -127,7 +127,7 @@ namespace MTConnect.Tests.Common
             var obs = new Observation();
             EventHandler<IObservation> handler = (_, _) => throw new InvalidOperationException("ObservationAdded fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, (IObservation)obs, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, (IObservation)obs, null)));
         }
 
         // -----------------------------------------------------------------------
@@ -158,7 +158,7 @@ namespace MTConnect.Tests.Common
             var asset = new Asset { AssetId = "a1", Timestamp = DateTime.UtcNow };
             EventHandler<IAsset> handler = (_, _) => throw new InvalidOperationException("AssetAdded fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, (IAsset)asset, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, (IAsset)asset, null)));
         }
 
         // -----------------------------------------------------------------------
@@ -187,7 +187,7 @@ namespace MTConnect.Tests.Common
         {
             EventHandler handler = (_, _) => throw new InvalidOperationException("StreamsResponseSent fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, EventArgs.Empty, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, EventArgs.Empty, null)));
         }
 
         // -----------------------------------------------------------------------
@@ -201,7 +201,7 @@ namespace MTConnect.Tests.Common
             EventHandler<IDevice>? handler = null;
             var device = new Device { Name = "noop-device", Uuid = "noop-uuid" };
 
-            Assert.DoesNotThrow(() => handler.Raise(this, (IDevice)device, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, (IDevice)device, null)));
         }
 
         /// <summary>Pins the behavior expressed by the test name: Raise with a null non-generic EventHandler is a safe no-op covering the no-subscriber case at runtime.</summary>
@@ -210,7 +210,7 @@ namespace MTConnect.Tests.Common
         {
             EventHandler? handler = null;
 
-            Assert.DoesNotThrow(() => handler.Raise(this, EventArgs.Empty, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, EventArgs.Empty, null)));
         }
 
         // =======================================================================
@@ -246,7 +246,7 @@ namespace MTConnect.Tests.Common
             var result = new ValidationResult(false, "bad device");
             MTConnectDeviceValidationHandler handler = (_, _) => throw new InvalidOperationException("InvalidDeviceAdded fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(device, result)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(device, result))));
         }
 
         // -----------------------------------------------------------------------
@@ -278,7 +278,7 @@ namespace MTConnect.Tests.Common
             var result = new ValidationResult(false, "bad component");
             MTConnectComponentValidationHandler handler = (_, _, _) => throw new InvalidOperationException("InvalidComponentAdded fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h("uuid-1", component, result)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h("uuid-1", component, result))));
         }
 
         // -----------------------------------------------------------------------
@@ -310,7 +310,7 @@ namespace MTConnect.Tests.Common
             var result = new ValidationResult(false, "bad composition");
             MTConnectCompositionValidationHandler handler = (_, _, _) => throw new InvalidOperationException("InvalidCompositionAdded fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h("uuid-1", composition, result)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h("uuid-1", composition, result))));
         }
 
         // -----------------------------------------------------------------------
@@ -342,7 +342,7 @@ namespace MTConnect.Tests.Common
             var result = new ValidationResult(false, "bad data item");
             MTConnectDataItemValidationHandler handler = (_, _, _) => throw new InvalidOperationException("InvalidDataItemAdded fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h("uuid-1", dataItem, result)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h("uuid-1", dataItem, result))));
         }
 
         // -----------------------------------------------------------------------
@@ -372,7 +372,7 @@ namespace MTConnect.Tests.Common
             var result = new ValidationResult(false, "bad observation");
             MTConnectObservationValidationHandler handler = (_, _, _) => throw new InvalidOperationException("InvalidObservationAdded fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h("uuid-1", "key-1", result)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h("uuid-1", "key-1", result))));
         }
 
         // -----------------------------------------------------------------------
@@ -404,7 +404,7 @@ namespace MTConnect.Tests.Common
             var result = new ValidationResult(false, "bad asset");
             MTConnectAssetValidationHandler handler = (_, _) => throw new InvalidOperationException("InvalidAssetAdded fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(asset, result)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(asset, result))));
         }
 
         // =======================================================================
@@ -435,7 +435,7 @@ namespace MTConnect.Tests.Common
         {
             MTConnectDevicesRequestedHandler handler = _ => throw new InvalidOperationException("DevicesRequestReceived fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h("uuid-1")));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h("uuid-1"))));
         }
 
         // -----------------------------------------------------------------------
@@ -462,7 +462,7 @@ namespace MTConnect.Tests.Common
         {
             MTConnectDevicesHandler handler = _ => throw new InvalidOperationException("DevicesResponseSent fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(null!)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(null!))));
         }
 
         // -----------------------------------------------------------------------
@@ -489,7 +489,7 @@ namespace MTConnect.Tests.Common
         {
             MTConnectStreamsRequestedHandler handler = _ => throw new InvalidOperationException("StreamsRequestReceived fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h("uuid-1")));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h("uuid-1"))));
         }
 
         // -----------------------------------------------------------------------
@@ -518,7 +518,7 @@ namespace MTConnect.Tests.Common
             var ids = new[] { "asset-1" };
             MTConnectAssetsRequestedHandler handler = _ => throw new InvalidOperationException("AssetsRequestReceived fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(ids)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(ids))));
         }
 
         // -----------------------------------------------------------------------
@@ -545,7 +545,7 @@ namespace MTConnect.Tests.Common
         {
             MTConnectDeviceAssetsRequestedHandler handler = _ => throw new InvalidOperationException("DeviceAssetsRequestReceived fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h("uuid-1")));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h("uuid-1"))));
         }
 
         // -----------------------------------------------------------------------
@@ -572,7 +572,7 @@ namespace MTConnect.Tests.Common
         {
             MTConnectAssetsHandler handler = _ => throw new InvalidOperationException("AssetsResponseSent fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(null!)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(null!))));
         }
 
         // -----------------------------------------------------------------------
@@ -599,7 +599,7 @@ namespace MTConnect.Tests.Common
         {
             MTConnectErrorHandler handler = _ => throw new InvalidOperationException("ErrorResponseSent fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h((IErrorResponseDocument)null!)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h((IErrorResponseDocument)null!))));
         }
     }
 }

--- a/tests/MTConnect.NET-Common-Tests/Agents/AgentUuidDeterministicDefaultTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Agents/AgentUuidDeterministicDefaultTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using MTConnect.Agents;
 using MTConnect.Configurations;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace MTConnect.Tests.Common.Agents
 {
@@ -124,7 +123,7 @@ namespace MTConnect.Tests.Common.Agents
         public void DeriveFromSeed_matches_python_uuid_v5_NAMESPACE_DNS_example_com_vector()
         {
             var derived = DeterministicAgentUuid.DeriveFromSeed("example.com");
-            ClassicAssert.AreEqual("cfbff0d1-9375-5685-968c-48ce8b15ae17", derived,
+            Assert.That(derived, Is.EqualTo("cfbff0d1-9375-5685-968c-48ce8b15ae17"),
                 "DeriveFromSeed must reproduce the canonical UUID v5(NAMESPACE_DNS, 'example.com') vector.");
         }
 

--- a/tests/MTConnect.NET-Common-Tests/Agents/AgentUuidDeterministicDefaultTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Agents/AgentUuidDeterministicDefaultTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using MTConnect.Agents;
 using MTConnect.Configurations;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace MTConnect.Tests.Common.Agents
 {
@@ -123,7 +124,7 @@ namespace MTConnect.Tests.Common.Agents
         public void DeriveFromSeed_matches_python_uuid_v5_NAMESPACE_DNS_example_com_vector()
         {
             var derived = DeterministicAgentUuid.DeriveFromSeed("example.com");
-            Assert.AreEqual("cfbff0d1-9375-5685-968c-48ce8b15ae17", derived,
+            ClassicAssert.AreEqual("cfbff0d1-9375-5685-968c-48ce8b15ae17", derived,
                 "DeriveFromSeed must reproduce the canonical UUID v5(NAMESPACE_DNS, 'example.com') vector.");
         }
 

--- a/tests/MTConnect.NET-Common-Tests/Agents/AgentUuidValidationTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Agents/AgentUuidValidationTests.cs
@@ -601,7 +601,7 @@ namespace MTConnect.Tests.Common.Agents
         [Test]
         public void Null_warn_delegate_does_not_throw_on_either_rejection_path()
         {
-            Assert.DoesNotThrow(() =>
+            Assert.DoesNotThrow((Action)(() =>
             {
                 _ = AgentUuidResolver.Resolve(
                     operatorSuppliedUuid: "not-a-uuid",
@@ -609,7 +609,7 @@ namespace MTConnect.Tests.Common.Agents
                     agentName: "test-agent",
                     hostname: "test-host",
                     warn: null);
-            });
+            }));
         }
 
         /// <summary>
@@ -620,14 +620,14 @@ namespace MTConnect.Tests.Common.Agents
         [Test]
         public void Default_warn_argument_omitted_does_not_throw()
         {
-            Assert.DoesNotThrow(() =>
+            Assert.DoesNotThrow((Action)(() =>
             {
                 _ = AgentUuidResolver.Resolve(
                     operatorSuppliedUuid: "not-a-uuid",
                     persistedUuid: "also-not-a-uuid",
                     agentName: "test-agent",
                     hostname: "test-host");
-            });
+            }));
         }
 
         // ------------------------------------------------------------------
@@ -1056,7 +1056,7 @@ namespace MTConnect.Tests.Common.Agents
         public void Derive_throws_when_both_agent_name_and_hostname_are_empty(string agentName, string hostname)
         {
             Assert.Throws<ArgumentException>(
-                () => DeterministicAgentUuid.Derive(agentName, hostname, port: 0),
+                (Action)(() => DeterministicAgentUuid.Derive(agentName, hostname, port: 0)),
                 "Both seed components empty must not silently derive a fleet-wide collision UUID.");
         }
 

--- a/tests/MTConnect.NET-Common-Tests/DeviceFinderMulticastIsolationTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/DeviceFinderMulticastIsolationTests.cs
@@ -86,7 +86,7 @@ namespace MTConnect.Tests.Common
         {
             TestDeviceHandler handler = (_, _) => throw new InvalidOperationException("DeviceFound fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(this, "device-1")));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(this, "device-1"))));
         }
 
         // -----------------------------------------------------------------------
@@ -113,7 +113,7 @@ namespace MTConnect.Tests.Common
         {
             TestRequestStatusHandler handler = (_, _) => throw new InvalidOperationException("SearchCompleted fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(this, 0L)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(this, 0L))));
         }
 
         // -----------------------------------------------------------------------
@@ -141,7 +141,7 @@ namespace MTConnect.Tests.Common
         {
             TestPingSentHandlerOnFinder handler = (_, _) => throw new InvalidOperationException("PingSent fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(this, IPAddress.Loopback)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(this, IPAddress.Loopback))));
         }
 
         // -----------------------------------------------------------------------
@@ -169,7 +169,7 @@ namespace MTConnect.Tests.Common
         {
             TestPingReceivedHandlerOnFinder handler = (_, _, _) => throw new InvalidOperationException("PingReceived fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(this, IPAddress.Loopback, null!)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(this, IPAddress.Loopback, null!))));
         }
 
         // -----------------------------------------------------------------------
@@ -196,7 +196,7 @@ namespace MTConnect.Tests.Common
         {
             TestPortRequestHandler handler = (_, _, _) => throw new InvalidOperationException("PortRequest fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(this, IPAddress.Loopback, 5000)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(this, IPAddress.Loopback, 5000))));
         }
 
         // -----------------------------------------------------------------------
@@ -223,7 +223,7 @@ namespace MTConnect.Tests.Common
         {
             TestProbeRequestHandler handler = (_, _, _) => throw new InvalidOperationException("ProbeRequest fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(this, IPAddress.Loopback, 5000)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(this, IPAddress.Loopback, 5000))));
         }
 
         // -----------------------------------------------------------------------
@@ -251,7 +251,7 @@ namespace MTConnect.Tests.Common
         {
             TestPingSentHandlerOnQueue handler = _ => throw new InvalidOperationException("PingQueue.PingSent fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(IPAddress.Loopback)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(IPAddress.Loopback))));
         }
 
         // -----------------------------------------------------------------------
@@ -279,7 +279,7 @@ namespace MTConnect.Tests.Common
         {
             TestPingReceivedHandlerOnQueue handler = (_, _) => throw new InvalidOperationException("PingQueue.PingReceived fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(IPAddress.Loopback, null!)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(IPAddress.Loopback, null!))));
         }
 
         // -----------------------------------------------------------------------
@@ -307,7 +307,7 @@ namespace MTConnect.Tests.Common
         {
             TestCompletedHandler handler = _ => throw new InvalidOperationException("PingQueue.Completed fault");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(new List<IPAddress>())));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(new List<IPAddress>()))));
         }
 
         // -----------------------------------------------------------------------
@@ -320,7 +320,7 @@ namespace MTConnect.Tests.Common
         {
             TestDeviceHandler? handler = null;
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler!, h => h(this, "any")));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler!, h => h(this, "any"))));
         }
     }
 }

--- a/tests/MTConnect.NET-Common-Tests/Devices/Configurations/PolymorphicLeafCoverageTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Devices/Configurations/PolymorphicLeafCoverageTests.cs
@@ -114,7 +114,7 @@ namespace MTConnect.NET_Common_Tests.Devices.Configurations
             Type simpleType, Type abstractInterface, Type simpleInterface)
         {
             object? instance = null;
-            Assert.DoesNotThrow(() => instance = Activator.CreateInstance(simpleType),
+            Assert.DoesNotThrow((Action)(() => instance = Activator.CreateInstance(simpleType)),
                 $"{simpleType.Name} must have a public parameterless ctor");
             Assert.That(instance, Is.Not.Null);
         }
@@ -146,7 +146,7 @@ namespace MTConnect.NET_Common_Tests.Devices.Configurations
             Type dataSetType, Type abstractInterface, Type simpleInterface, Type dataSetInterface)
         {
             object? instance = null;
-            Assert.DoesNotThrow(() => instance = Activator.CreateInstance(dataSetType),
+            Assert.DoesNotThrow((Action)(() => instance = Activator.CreateInstance(dataSetType)),
                 $"{dataSetType.Name} must have a public parameterless ctor");
             Assert.That(instance, Is.Not.Null);
         }

--- a/tests/MTConnect.NET-Common-Tests/Headers/HeaderVersionRegressionTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Headers/HeaderVersionRegressionTests.cs
@@ -144,7 +144,7 @@ namespace MTConnect.Tests.Common.Headers
             var assets = broker.GetAssetsResponseDocument();
             var error = broker.GetErrorResponseDocument(ErrorCode.UNSUPPORTED, "test");
 
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)(() =>
             {
                 Assert.That(devices!.Header.Version, Is.Not.EqualTo(libraryVersion),
                     "Devices Header.version must not echo the library assembly version.");
@@ -152,7 +152,7 @@ namespace MTConnect.Tests.Common.Headers
                     "Assets Header.version must not echo the library assembly version.");
                 Assert.That(error!.Header.Version, Is.Not.EqualTo(libraryVersion),
                     "Error Header.version must not echo the library assembly version.");
-            });
+            }));
         }
     }
 }

--- a/tests/MTConnect.NET-Common-Tests/Http/CA2022ShortReadEdgeCaseTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Http/CA2022ShortReadEdgeCaseTests.cs
@@ -122,7 +122,7 @@ namespace MTConnect.NET_Common_Tests.Http
             cts.Cancel();
 
             Assert.That(
-                async () => await Invoke(scripted, cts.Token),
+                (Func<Task>)(async () => await Invoke(scripted, cts.Token)),
                 Throws.InstanceOf<OperationCanceledException>(),
                 "A pre-cancelled token must surface as OperationCanceledException. "
                 + "Pre-fix, the accumulator ignored the token (signature took only Stream) "
@@ -146,7 +146,7 @@ namespace MTConnect.NET_Common_Tests.Http
             using var cts = new CancellationTokenSource();
 
             Assert.That(
-                async () =>
+                (Func<Task>)(async () =>
                 {
                     var invocation = Invoke(slow, cts.Token);
                     // Give the reader time to start awaiting the first drip,
@@ -154,7 +154,7 @@ namespace MTConnect.NET_Common_Tests.Http
                     // Task.Delay(cancellationToken) throws immediately.
                     cts.CancelAfter(TimeSpan.FromMilliseconds(50));
                     await invocation.WaitAsync(TimeSpan.FromMilliseconds(200));
-                },
+                }),
                 Throws.InstanceOf<OperationCanceledException>(),
                 "A token cancelled mid-drip must surface as OperationCanceledException within "
                 + "the next ReadAsync cycle. Pre-fix, the accumulator ignored the token and "

--- a/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
+++ b/tests/MTConnect.NET-Common-Tests/MTConnect.NET-Common-Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>

--- a/tests/MTConnect.NET-Common-Tests/MqttClientMulticastIsolationTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/MqttClientMulticastIsolationTests.cs
@@ -164,7 +164,7 @@ namespace MTConnect.Tests.Common
             EventHandler<string>? handler = null;
             EventHandler<Exception>? internalError = null;
 
-            Assert.DoesNotThrow(() => handler.Raise(this, "x", internalError));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, "x", internalError)));
         }
 
         /// <summary>Pins the behavior expressed by the test name: Raise non-generic with a null handler is a safe no-op.</summary>
@@ -174,7 +174,7 @@ namespace MTConnect.Tests.Common
             EventHandler? handler = null;
             EventHandler<Exception>? internalError = null;
 
-            Assert.DoesNotThrow(() => handler.Raise(this, EventArgs.Empty, internalError));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, EventArgs.Empty, internalError)));
         }
     }
 }

--- a/tests/MTConnect.NET-Common-Tests/MulticastIsolationTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/MulticastIsolationTests.cs
@@ -75,7 +75,7 @@ namespace MTConnect.Tests.Common
             internalError += (s, ex) => throw new InvalidOperationException("internal-1");
             internalError += (s, ex) => throw new InvalidOperationException("internal-2");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, 0, internalError!));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, 0, internalError!)));
         }
 
         // --- Non-generic overload ---------------------------------------------
@@ -138,7 +138,7 @@ namespace MTConnect.Tests.Common
             internalError += (s, ex) => throw new InvalidOperationException("internal-1");
             internalError += (s, ex) => throw new InvalidOperationException("internal-2");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, EventArgs.Empty, internalError!));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, EventArgs.Empty, internalError!)));
         }
 
         // --- Generic custom-delegate overload ---------------------------------
@@ -204,7 +204,7 @@ namespace MTConnect.Tests.Common
             internalError += (_, _) => throw new InvalidOperationException("internal-1");
             internalError += (_, _) => throw new InvalidOperationException("internal-2");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(0), internalError!));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(0), internalError!)));
         }
 
         /// <summary>Pins the behavior expressed by the test name: the generic-delegate overload accepts a null handler as a safe no-op covering the no-subscriber case.</summary>
@@ -213,7 +213,7 @@ namespace MTConnect.Tests.Common
         {
             CustomDelegate? handler = null;
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler!, h => h(0)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler!, h => h(0))));
         }
 
         /// <summary>Pins the behavior expressed by the test name: the generic-delegate overload swallows subscriber faults at the per-delegate boundary when internalError is left at its default null.</summary>
@@ -222,7 +222,7 @@ namespace MTConnect.Tests.Common
         {
             CustomDelegate handler = _ => throw new InvalidOperationException("boom");
 
-            Assert.DoesNotThrow(() => MulticastIsolation.Raise(handler, h => h(0)));
+            Assert.DoesNotThrow((Action)(() => MulticastIsolation.Raise(handler, h => h(0))));
         }
     }
 }

--- a/tests/MTConnect.NET-Common-Tests/Reflection/RegeneratedAssetsCoverageTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Reflection/RegeneratedAssetsCoverageTests.cs
@@ -93,7 +93,7 @@ namespace MTConnect.NET_Common_Tests.Reflection
         {
             object? instance = null;
             Assert.DoesNotThrow(
-                () => instance = Activator.CreateInstance(type),
+                (Action)(() => instance = Activator.CreateInstance(type)),
                 $"{type.FullName} parameterless ctor threw");
             Assert.That(instance, Is.Not.Null,
                 $"{type.FullName} parameterless ctor returned null");

--- a/tests/MTConnect.NET-Common-Tests/Reflection/RegeneratedConfigurationsCoverageTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Reflection/RegeneratedConfigurationsCoverageTests.cs
@@ -80,7 +80,7 @@ namespace MTConnect.NET_Common_Tests.Reflection
         {
             object? instance = null;
             Assert.DoesNotThrow(
-                () => instance = Activator.CreateInstance(type),
+                (Action)(() => instance = Activator.CreateInstance(type)),
                 $"{type.FullName} parameterless ctor threw");
             Assert.That(instance, Is.Not.Null,
                 $"{type.FullName} parameterless ctor returned null");
@@ -111,7 +111,7 @@ namespace MTConnect.NET_Common_Tests.Reflection
 
                 var sentinel = $"sentinel-{property.Name}";
                 Assert.DoesNotThrow(
-                    () => property.SetValue(instance, sentinel),
+                    (Action)(() => property.SetValue(instance, sentinel)),
                     $"{type.FullName}.{property.Name} setter threw");
                 var readBack = property.GetValue(instance) as string;
                 Assert.That(readBack, Is.EqualTo(sentinel),

--- a/tests/MTConnect.NET-Common-Tests/Reflection/RegeneratedTypesCoverageTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Reflection/RegeneratedTypesCoverageTests.cs
@@ -219,7 +219,7 @@ namespace MTConnect.NET_Common_Tests.Reflection
             // V2_6_V2_7/.
             object? instance = null;
             Assert.DoesNotThrow(
-                () => instance = Activator.CreateInstance(type),
+                (Action)(() => instance = Activator.CreateInstance(type)),
                 $"{type.FullName} parameterless ctor threw");
             Assert.That(instance, Is.Not.Null,
                 $"{type.FullName} parameterless ctor returned null");
@@ -255,12 +255,12 @@ namespace MTConnect.NET_Common_Tests.Reflection
                 object? sentinel = GetDefaultValue(property.PropertyType);
 
                 Assert.DoesNotThrow(
-                    () => property.SetValue(instance, sentinel),
+                    (Action)(() => property.SetValue(instance, sentinel)),
                     $"{key} setter threw for default({property.PropertyType.Name})");
 
                 object? readBack = null;
                 Assert.DoesNotThrow(
-                    () => readBack = property.GetValue(instance),
+                    (Action)(() => readBack = property.GetValue(instance)),
                     $"{key} getter threw after setting default({property.PropertyType.Name})");
 
                 // Read-back equality is only asserted on auto-properties.

--- a/tests/MTConnect.NET-Common-Tests/Regressions/DeviceComponentDefaultsRegressionTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Regressions/DeviceComponentDefaultsRegressionTests.cs
@@ -32,12 +32,12 @@ namespace MTConnect.Tests.Common.Regressions
         public void Device_default_constructor_leaves_identity_fields_null()
         {
             var device = new Device();
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)(() =>
             {
                 Assert.That(device.Id, Is.Null, "Device.Id");
                 Assert.That(device.Name, Is.Null, "Device.Name");
                 Assert.That(device.Uuid, Is.Null, "Device.Uuid");
-            });
+            }));
         }
 
         /// <summary>Pins the behaviour expressed by the test name: agent default constructor leaves identity fields null.</summary>
@@ -45,12 +45,12 @@ namespace MTConnect.Tests.Common.Regressions
         public void Agent_default_constructor_leaves_identity_fields_null()
         {
             var agent = new Agent();
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)(() =>
             {
                 Assert.That(agent.Id, Is.Null, "Agent.Id");
                 Assert.That(agent.Name, Is.Null, "Agent.Name");
                 Assert.That(agent.Uuid, Is.Null, "Agent.Uuid");
-            });
+            }));
         }
 
         /// <summary>Pins the behaviour expressed by the test name: sequential default devices share null uuid.</summary>
@@ -71,12 +71,12 @@ namespace MTConnect.Tests.Common.Regressions
         public void Object_initializer_continues_to_set_Device_identity()
         {
             var device = new Device { Id = "id-A", Name = "name-A", Uuid = "uuid-A" };
-            Assert.Multiple(() =>
+            Assert.Multiple((Action)(() =>
             {
                 Assert.That(device.Id, Is.EqualTo("id-A"));
                 Assert.That(device.Name, Is.EqualTo("name-A"));
                 Assert.That(device.Uuid, Is.EqualTo("uuid-A"));
-            });
+            }));
         }
 
         // ---- Reflection guard --------------------------------------

--- a/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7DataItemTypeTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/V2_6_V2_7/V2_7DataItemTypeTests.cs
@@ -49,7 +49,7 @@ namespace MTConnect.NET_Common_Tests.V2_6_V2_7
             // surfaces as a clear NUnit failure with the offending type name
             // rather than a bare MissingMethodException.
             object? instance = null;
-            Assert.DoesNotThrow(() => instance = Activator.CreateInstance(dataItemType),
+            Assert.DoesNotThrow((Action)(() => instance = Activator.CreateInstance(dataItemType)),
                 $"{dataItemType.Name} should have a public parameterless constructor");
             Assert.That(instance, Is.Not.Null);
             Assert.That(instance, Is.InstanceOf<DataItem>());

--- a/tests/MTConnect.NET-Docs-Tests/MTConnect.NET-Docs-Tests.csproj
+++ b/tests/MTConnect.NET-Docs-Tests/MTConnect.NET-Docs-Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.Playwright" Version="1.60.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>

--- a/tests/MTConnect.NET-Docs-Tests/RouteCheckHelpersTests.cs
+++ b/tests/MTConnect.NET-Docs-Tests/RouteCheckHelpersTests.cs
@@ -115,7 +115,7 @@ public class RouteCheckHelpersTests
     public void MdFileToRoute_NullDocsRoot_Throws()
     {
         var ex = Assert.Throws<ArgumentNullException>(
-            () => RouteCheckHelpers.MdFileToRoute(null!, "/repo/docs/index.md"));
+            (Action)(() => RouteCheckHelpers.MdFileToRoute(null!, "/repo/docs/index.md")));
         Assert.That(ex!.ParamName, Is.EqualTo("docsRoot"));
     }
 
@@ -127,7 +127,7 @@ public class RouteCheckHelpersTests
     public void MdFileToRoute_NullAbsPath_Throws()
     {
         var ex = Assert.Throws<ArgumentNullException>(
-            () => RouteCheckHelpers.MdFileToRoute("/repo/docs", null!));
+            (Action)(() => RouteCheckHelpers.MdFileToRoute("/repo/docs", null!)));
         Assert.That(ex!.ParamName, Is.EqualTo("absPath"));
     }
 
@@ -276,7 +276,7 @@ public class RouteCheckHelpersTests
     {
         var results = new List<string>();
         var ex = Assert.Throws<ArgumentNullException>(
-            () => RouteCheckHelpers.CollectMarkdownFiles(null!, results));
+            (Action)(() => RouteCheckHelpers.CollectMarkdownFiles(null!, results)));
         Assert.That(ex!.ParamName, Is.EqualTo("dir"));
     }
 
@@ -288,7 +288,7 @@ public class RouteCheckHelpersTests
     public void CollectMarkdownFiles_NullResults_Throws()
     {
         var ex = Assert.Throws<ArgumentNullException>(
-            () => RouteCheckHelpers.CollectMarkdownFiles("/tmp", null!));
+            (Action)(() => RouteCheckHelpers.CollectMarkdownFiles("/tmp", null!)));
         Assert.That(ex!.ParamName, Is.EqualTo("results"));
     }
 
@@ -300,7 +300,7 @@ public class RouteCheckHelpersTests
     public void CollectRoutes_NullDocsRoot_Throws()
     {
         var ex = Assert.Throws<ArgumentNullException>(
-            () => RouteCheckHelpers.CollectRoutes(null!));
+            (Action)(() => RouteCheckHelpers.CollectRoutes(null!)));
         Assert.That(ex!.ParamName, Is.EqualTo("docsRoot"));
     }
 
@@ -405,7 +405,7 @@ public class RouteCheckHelpersTests
     public void ExtractBannerPort_NullLog_Throws()
     {
         var ex = Assert.Throws<ArgumentNullException>(
-            () => RouteCheckHelpers.ExtractBannerPort(null!));
+            (Action)(() => RouteCheckHelpers.ExtractBannerPort(null!)));
         Assert.That(ex!.ParamName, Is.EqualTo("log"));
     }
 
@@ -459,7 +459,7 @@ public class RouteCheckHelpersTests
         // ancestor of the temp directory. The walk will exhaust at
         // the filesystem root.
         var ex = Assert.Throws<InvalidOperationException>(
-            () => RouteCheckHelpers.LocateRepoRoot(fixture.Path, "no-such-marker-12345.txt"));
+            (Action)(() => RouteCheckHelpers.LocateRepoRoot(fixture.Path, "no-such-marker-12345.txt")));
         Assert.That(ex!.Message, Does.Contain(fixture.Path));
         Assert.That(ex.Message, Does.Contain("ancestor"));
     }
@@ -472,7 +472,7 @@ public class RouteCheckHelpersTests
     public void LocateRepoRoot_NullStartDirectory_Throws()
     {
         var ex = Assert.Throws<ArgumentNullException>(
-            () => RouteCheckHelpers.LocateRepoRoot(null!, "marker.txt"));
+            (Action)(() => RouteCheckHelpers.LocateRepoRoot(null!, "marker.txt")));
         Assert.That(ex!.ParamName, Is.EqualTo("startDirectory"));
     }
 
@@ -484,7 +484,7 @@ public class RouteCheckHelpersTests
     public void LocateRepoRoot_NullMarkerFile_Throws()
     {
         var ex = Assert.Throws<ArgumentNullException>(
-            () => RouteCheckHelpers.LocateRepoRoot("/tmp", null!));
+            (Action)(() => RouteCheckHelpers.LocateRepoRoot("/tmp", null!)));
         Assert.That(ex!.ParamName, Is.EqualTo("markerFile"));
     }
 
@@ -715,7 +715,7 @@ public class RouteCheckHelpersTests
     public void ShardRoutes_NullRoutes_Throws()
     {
         var ex = Assert.Throws<ArgumentNullException>(
-            () => RouteCheckHelpers.ShardRoutes(null!, 1, 1));
+            (Action)(() => RouteCheckHelpers.ShardRoutes(null!, 1, 1)));
         Assert.That(ex!.ParamName, Is.EqualTo("routes"));
     }
 
@@ -729,7 +729,7 @@ public class RouteCheckHelpersTests
     public void ShardRoutes_NonPositiveTotal_Throws(int total)
     {
         var ex = Assert.Throws<ArgumentOutOfRangeException>(
-            () => RouteCheckHelpers.ShardRoutes(SampleRoutes, 1, total));
+            (Action)(() => RouteCheckHelpers.ShardRoutes(SampleRoutes, 1, total)));
         Assert.That(ex!.ParamName, Is.EqualTo("total"));
     }
 
@@ -745,7 +745,7 @@ public class RouteCheckHelpersTests
     public void ShardRoutes_IndexOutOfRange_Throws(int index, int total)
     {
         var ex = Assert.Throws<ArgumentOutOfRangeException>(
-            () => RouteCheckHelpers.ShardRoutes(SampleRoutes, index, total));
+            (Action)(() => RouteCheckHelpers.ShardRoutes(SampleRoutes, index, total)));
         Assert.That(ex!.ParamName, Is.EqualTo("index"));
     }
 

--- a/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
+++ b/tests/MTConnect.NET-HTTP-Tests/MTConnect.NET-HTTP-Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>

--- a/tests/MTConnect.NET-HTTP-Tests/Servers/HttpServerMulticastIsolationTests.cs
+++ b/tests/MTConnect.NET-HTTP-Tests/Servers/HttpServerMulticastIsolationTests.cs
@@ -57,7 +57,7 @@ namespace MTConnect.Tests.Http.Servers
             var response = new MTConnectHttpResponse { ContentType = "application/xml" };
             EventHandler<MTConnectHttpResponse> handler = (_, _) => throw new InvalidOperationException("ResponseSent fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, response, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, response, null)));
         }
 
         // -----------------------------------------------------------------------
@@ -147,7 +147,7 @@ namespace MTConnect.Tests.Http.Servers
         {
             EventHandler<string> handler = (_, _) => throw new InvalidOperationException("StreamStopped fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, "stream-id-1", null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, "stream-id-1", null)));
         }
 
         // -----------------------------------------------------------------------
@@ -199,7 +199,7 @@ namespace MTConnect.Tests.Http.Servers
             var args = new MTConnectHttpStreamArgs("stream-id-2", System.IO.Stream.Null, 42.5);
             EventHandler<MTConnectHttpStreamArgs> handler = (_, _) => throw new InvalidOperationException("HeartbeatReceived fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, args, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, args, null)));
         }
 
         // -----------------------------------------------------------------------
@@ -212,7 +212,7 @@ namespace MTConnect.Tests.Http.Servers
         {
             EventHandler<string>? handler = null;
 
-            Assert.DoesNotThrow(() => handler.Raise(this, "x", null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, "x", null)));
         }
     }
 }

--- a/tests/MTConnect.NET-JSON-Tests/MTConnect.NET-JSON-Tests.csproj
+++ b/tests/MTConnect.NET-JSON-Tests/MTConnect.NET-JSON-Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 

--- a/tests/MTConnect.NET-JSON-Tests/MTConnect.NET-JSON-Tests.csproj
+++ b/tests/MTConnect.NET-JSON-Tests/MTConnect.NET-JSON-Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/MTConnect.NET-JSON-cppagent-Tests.csproj
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/MTConnect.NET-JSON-cppagent-Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/MTConnect.NET-JSON-cppagent-Tests.csproj
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/MTConnect.NET-JSON-cppagent-Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Streams/JsonConditionsArrayShapeTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Streams/JsonConditionsArrayShapeTests.cs
@@ -425,8 +425,8 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Streams
                 "\"Normal\":[{\"dataItemId\":\"n1\"}]," +
                 "\"Unavailable\":[{\"dataItemId\":\"u1\"}]}";
 
-            Assert.Throws<JsonException>(() =>
-                JsonSerializer.Deserialize<JsonConditions>(legacyV1));
+            Assert.Throws<JsonException>((Action)(() =>
+                JsonSerializer.Deserialize<JsonConditions>(legacyV1)));
         }
 
         /// <summary>
@@ -495,7 +495,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Streams
         [TestCase("false")]
         public void Deserialize_non_array_root_throws_JsonException(string wire)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<JsonConditions>(wire));
+            Assert.Throws<JsonException>((Action)(() => JsonSerializer.Deserialize<JsonConditions>(wire)));
         }
 
         /// <summary>
@@ -513,7 +513,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Streams
         [TestCase("[[]]")]
         public void Deserialize_scalar_or_array_element_throws_JsonException(string wire)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<JsonConditions>(wire));
+            Assert.Throws<JsonException>((Action)(() => JsonSerializer.Deserialize<JsonConditions>(wire)));
         }
 
         /// <summary>
@@ -527,7 +527,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Streams
         [TestCase("not-json-at-all")]
         public void Deserialize_malformed_wire_throws_JsonException(string wire)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<JsonConditions>(wire));
+            Assert.Throws<JsonException>((Action)(() => JsonSerializer.Deserialize<JsonConditions>(wire)));
         }
 
         /// <summary>

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Streams/JsonSampleValueConverterEdgeCaseTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Streams/JsonSampleValueConverterEdgeCaseTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
 // TrakHound Inc. licenses this file to you under the MIT license.
 
+using System;
 using System.Text.Json;
 using MTConnect.NET_JSON_cppagent.Streams;
 using MTConnect.Streams.Json;
@@ -139,7 +140,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Streams
             options.Converters.Add(converter);
 
             Assert.That(
-                () => JsonSerializer.Deserialize<object>(payload, options),
+                (Action)(() => JsonSerializer.Deserialize<object>(payload, options)),
                 Throws.InstanceOf<JsonException>(),
                 $"Unsupported token payload '{payload}' must surface as a " +
                 "JsonException so feed corruption is visible to callers.");

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Streams/JsonSampleValueToObservationTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Streams/JsonSampleValueToObservationTests.cs
@@ -5,6 +5,7 @@ using MTConnect.Devices;
 using MTConnect.Observations;
 using MTConnect.Streams.Json;
 using NUnit.Framework;
+using System;
 
 namespace MTConnect.NET_JSON_cppagent_Tests.Streams
 {
@@ -35,7 +36,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Streams
 
             ISampleValueObservation? observation = null;
             Assert.That(
-                () => observation = sample.ToObservation("Temperature"),
+                (Action)(() => observation = sample.ToObservation("Temperature")),
                 Throws.Nothing,
                 "ToObservation must null-guard ResetTriggered/Statistic " +
                 "rather than calling ConvertEnum on a null surface.");

--- a/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
+++ b/tests/MTConnect.NET-SHDR-Tests/MTConnect.NET-SHDR-Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/MTConnect.NET-SHDR-Tests/ShdrMulticastIsolationTests.cs
+++ b/tests/MTConnect.NET-SHDR-Tests/ShdrMulticastIsolationTests.cs
@@ -50,7 +50,7 @@ namespace MTConnect.Tests.Shdr
         {
             EventHandler<string> handler = (_, _) => throw new InvalidOperationException("shdr-fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, "x", null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, "x", null)));
         }
 
         /// <summary>Pins the behavior expressed by the test name: multiple string-payload subscribers all fire when no subscriber throws, covering the happy path for AgentConnected and related events.</summary>
@@ -98,7 +98,7 @@ namespace MTConnect.Tests.Shdr
             var payload = new AdapterEventArgs<string>("c1", "data");
             EventHandler<AdapterEventArgs<string>> handler = (_, _) => throw new InvalidOperationException("fault");
 
-            Assert.DoesNotThrow(() => handler.Raise(this, payload, null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, payload, null)));
         }
 
         // -----------------------------------------------------------------------
@@ -156,7 +156,7 @@ namespace MTConnect.Tests.Shdr
         {
             EventHandler<string> handler = null;
 
-            Assert.DoesNotThrow(() => handler.Raise(this, "x", null));
+            Assert.DoesNotThrow((Action)(() => handler.Raise(this, "x", null)));
         }
     }
 }

--- a/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
+++ b/tests/MTConnect.NET-XML-Tests/MTConnect.NET-XML-Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/MTConnect.NET-XML-Tests/XmlStreamsResponseDocumentTests.cs
+++ b/tests/MTConnect.NET-XML-Tests/XmlStreamsResponseDocumentTests.cs
@@ -7,7 +7,6 @@ using DeepEqual.Syntax;
 using MTConnect.Observations;
 using MTConnect.Streams.Xml;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace MTConnect.Tests.XML
 {
@@ -36,10 +35,10 @@ namespace MTConnect.Tests.XML
             using var xmlStream = XmlReader.Create(new MemoryStream(Encoding.UTF8.GetBytes(text)));
             var doc = XmlStreamsResponseDocument.ReadXml(xmlStream);
 
-            ClassicAssert.AreEqual(1, doc.Streams.Count());
+            Assert.That(doc.Streams.Count(), Is.EqualTo(1));
             var stream = doc.Streams.Single();
             var conditions = stream.Conditions.ToArray();
-            ClassicAssert.AreEqual(2, conditions.Length);
+            Assert.That(conditions.Length, Is.EqualTo(2));
 
             var cond1 = new ConditionObservation()
             {

--- a/tests/MTConnect.NET-XML-Tests/XmlStreamsResponseDocumentTests.cs
+++ b/tests/MTConnect.NET-XML-Tests/XmlStreamsResponseDocumentTests.cs
@@ -7,6 +7,7 @@ using DeepEqual.Syntax;
 using MTConnect.Observations;
 using MTConnect.Streams.Xml;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace MTConnect.Tests.XML
 {
@@ -35,10 +36,10 @@ namespace MTConnect.Tests.XML
             using var xmlStream = XmlReader.Create(new MemoryStream(Encoding.UTF8.GetBytes(text)));
             var doc = XmlStreamsResponseDocument.ReadXml(xmlStream);
 
-            Assert.AreEqual(1, doc.Streams.Count());
+            ClassicAssert.AreEqual(1, doc.Streams.Count());
             var stream = doc.Streams.Single();
             var conditions = stream.Conditions.ToArray();
-            Assert.AreEqual(2, conditions.Length);
+            ClassicAssert.AreEqual(2, conditions.Length);
 
             var cond1 = new ConditionObservation()
             {


### PR DESCRIPTION
## Summary

Upgrade every test project from NUnit 3.14.0 to NUnit 4.6.1 — the current stable line — and normalize the fragmented NUnit / NUnit3TestAdapter versions across the test tree that had drifted onto two different baselines.

## Motivation

NUnit 3's lifetime is now maintenance-only; NUnit 4 is the active stable line and receives new features, .NET 8/9 hardening, and framework-level fixes. Four of the nine test csprojs still sat on NUnit 3.13.3 with NUnit3TestAdapter 4.3.1/4.5.0, while the other five had already moved to 3.14.0 + 4.6.0 — a fragmented baseline that risked masking version-specific behavior. Bringing everything onto NUnit 4.6.1 clears the drift, aligns the runner surface (relevant for the upcoming Stryker.NET adoption in a follow-up PR), and gets ahead of NUnit 3's deprecation curve.

## Approach

Two commits, in the shape [normalize] then [bump]:

1. **`chore(tests): normalize NUnit and NUnit3TestAdapter versions across tests`** — mechanical version alignment across the four lagging csprojs (`MTConnect-Compliance-Tests`, `MTConnect.NET-AgentModule-MqttRelay-Tests`, `MTConnect.NET-JSON-Tests`, `MTConnect.NET-JSON-cppagent-Tests`) so all nine sit on the highest currently-in-use pair before the framework bump. Zero source changes; behavior identical.

2. **`chore(tests): upgrade NUnit 3.14.0 to 4.6.1 across all test projects`** — every test csproj moves to NUnit 4.6.1, and two compiler-driven source migrations follow:

   - **CS0121 delegate-overload ambiguity (84 sites, 20 files).** NUnit 4 added `Action` / `Func<T>` overloads alongside the legacy `TestDelegate` / `ActualValueDelegate` overloads on `Assert.DoesNotThrow`, `Assert.Throws<T>`, `Assert.ThrowsAsync<T>`, `Assert.Multiple`, and `Assert.That`. Lambda arguments are now ambiguous under overload resolution, so each affected site casts the lambda to `(Action)` to unambiguously bind to the new `Action` overload. `Assert.That` sites are cast only when the constraint is a `Throws.*` form (void-lambda variant); the value-returning `Is.*` form is not affected in this corpus. Where the `(Action)` cast introduced a bare `Action` reference in files that only transitively imported `System`, `using System;` was added.

   - **CS9202 `Assert.AreEqual` extension-method dispatch (3 sites, 2 files).** NUnit 4 removed the classic static `Assert.AreEqual` and replaced it with an extension-method shim on `Assert` exposed by `NUnit.Framework.Legacy`. The extension-method shim requires C# 14 (feature `extensions`), which the test projects do not target. The safe migration is `ClassicAssert.AreEqual` from `NUnit.Framework.Legacy` — a plain static method that works under every C# language version. Two files (`AgentUuidDeterministicDefaultTests.cs`, `XmlStreamsResponseDocumentTests.cs`) switch the callers and add `using NUnit.Framework.Legacy;`.

`NUnit3TestAdapter` stays at 4.6.0 — the adapter version tracks the adapter's own release line, not the framework version, and 4.6.0 supports both NUnit 3 and NUnit 4 discovery.

## Depends on

_(no in-flight PR dependencies — merges cleanly against master.)_

## Dime review cycle 1

Six-agent sweep (code-review, security-audit, simplification, improvement, documentation-audit, test-coverage-audit) at head `3a8954cd`. All MEDIUM+ findings closed atomically or tracked with an issue number.

**Atomic fix landed on `5e205e3a`** — swap the 3 `ClassicAssert.AreEqual` sites to `Assert.That(actual, Is.EqualTo(expected))` and drop both `using NUnit.Framework.Legacy;` imports:

- **`[F-CR-001]` MEDIUM** (code-review) — same recommendation.
- **`[F-IMP-002]` MEDIUM** (improvement) — same recommendation.
- **`[F-SIMP-001]` LOW** (simplification, `AgentUuidDeterministicDefaultTests.cs`) — same recommendation.
- **`[F-SIMP-002]` LOW** (simplification, `XmlStreamsResponseDocumentTests.cs`) — same recommendation.

Four agents converged on the same fix — `ClassicAssert.AreEqual` is NUnit's own "temporary expedience", constraint-based `Assert.That` reads uniformly with every other assertion in the diff, and the `Legacy` import is no longer needed. Full-solution build stays at 0 warnings, 0 errors; the two focused suites (`AgentUuidDeterministic*`, `XmlStreamsResponseDocument*`) stay green after the swap.

**MEDIUM tracked via new issue TrakHound/MTConnect.NET#240**:

- **`[F-IMP-001]` MEDIUM** (improvement) — adopt `Directory.Packages.props` (Central Package Management). All 9 test csprojs now duplicate `NUnit@4.6.1`, `NUnit3TestAdapter@4.6.0`, `Microsoft.NET.Test.Sdk@17.14.1`, `coverlet.collector@6.0.4` — the first drift will be silent (and #239 itself was born from precisely that pattern). Sequenced before the follow-up Stryker.NET adoption PR.

**LOW SKIP-rationale** — minimal-diff justifies the mechanical shape; constraint-model migration is legitimate follow-up scope:

- **`[F-CR-002]`** — convert 71 `(Action)(() => …)` casts on `Assert.DoesNotThrow` / `Throws<T>` / `That(delegate, Throws.…)` to `Assert.That(() => …, Throws.Nothing)` / `Throws.TypeOf<T>()`.
- **`[F-CR-004]`** — same tradeoff on `JsonSampleValueToObservationTests.cs` and `JsonSampleValueConverterEdgeCaseTests.cs`.
- **`[F-IMP-003]`** — `(Action)` → `(TestDelegate)` sed sweep. Style call; either reads well.

**LOW TRACK — follow-up-scoped, not blocking:**

- **`[F-CR-003]`** — replace `Assert.Multiple((Action)(() => { … }))` blocks with `using (Assert.EnterMultipleScope()) { … }` (NUnit 4.2+). Cast-free and reads as ambient scope; will be flagged as a nice cleanup in a subsequent quality-pass PR.
- **`[F-IMP-004]`** — benchmark `[assembly: Parallelizable(ParallelScope.Fixtures)]` per test project; suites that bind to fixed HTTP/MQTT ports need per-project audit before flipping. Land under a dedicated performance chore.

**CLOSE — confirmations only, no code change:**

- **`[F-IMP-005]`** — Stryker.NET follow-up unblocked (no `Assert.Throws` weakening in diff).
- **`[F-SEC-001, F-SEC-002, F-SEC-003]`** — no CVE surface introduced; every `Assert.Throws` diff hunk preserves the lambda body verbatim; `XmlReaderSettings` note is pre-existing pattern outside PR scope.
- **`[F-TEST-001, F-TEST-002, F-TEST-003, F-TEST-004]`** — behavior parity spot-checked across all 20 files; `Is.EquivalentTo` sites stay on same-type collections; zero test smells introduced.
- **`[F-TEST-005]`** — Docs-Tests bluefin-flake escape hatch already exists (`--filter "Category!=E2E"`); `RouteCheckHelpersTests.cs` is deliberately Category-free and runs in either mode.

**Documentation audit — CLEAN.** No `///` doc regression on the 25 touched `.cs` files; no stale NUnit 3 references in `docs/**`, root markdown, `.github/workflows/*.yml`, or CHANGELOG (none exists); `MTConnect.NET-Tests-Agents` (fixture-only, no NUnit ref) is not referenced anywhere that would become inconsistent.

Head after cycle 1: `5e205e3a6371feca93b9782e71dd4dce7d61bc79`. Integration branch `integration/up-to-pr-239` at `cfbf89448e221233a157e4dd9098f22995d85fd7`.


