### PR TITLE
fix(json,json-cppagent): cache JsonSerializerOptions singletons — plug DynamicMethod LCG leak (+3.2-3.8 MB/h RSS)

### DIFF
--- a/libraries/MTConnect.NET-Common/Agents/MTConnectAgentInformation.cs
+++ b/libraries/MTConnect.NET-Common/Agents/MTConnectAgentInformation.cs
@@ -19,6 +19,15 @@ namespace MTConnect.Agents
         /// </summary>
         public const string Filename = "agent.information.json";
 
+        // Shared across every Save call. See JsonFunctions.cs for the
+        // rationale — a fresh JsonSerializerOptions per call re-emits
+        // LCG DynamicMethods into the loader heap, and the GC cannot
+        // reclaim them.
+        private static readonly JsonSerializerOptions _saveOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+
 
         /// <summary>
         /// A token regenerated on every save, used to detect when the persisted information has changed.
@@ -127,12 +136,7 @@ namespace MTConnect.Agents
 
             try
             {
-                var options = new JsonSerializerOptions
-                {
-                    WriteIndented = true
-                };
-
-                var json = JsonSerializer.Serialize(this, options);
+                var json = JsonSerializer.Serialize(this, _saveOptions);
                 File.WriteAllText(configurationPath, json);
             }
             catch { }

--- a/libraries/MTConnect.NET-Common/Buffers/MTConnectAssetFileBuffer.cs
+++ b/libraries/MTConnect.NET-Common/Buffers/MTConnectAssetFileBuffer.cs
@@ -36,6 +36,15 @@ namespace MTConnect.Buffers
         /// </summary>
         public const string DirectoryAssets = "assets";
 
+        // Shared across every asset persistence call. See
+        // JsonFunctions.cs for the rationale — a fresh
+        // JsonSerializerOptions per call re-emits LCG DynamicMethods
+        // into the loader heap, and the GC cannot reclaim them.
+        private static readonly JsonSerializerOptions _writeOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+
         private readonly string _basePath;
         private readonly MTConnectAssetQueue _items;
         private readonly Regex _regex = new Regex("([0-9]*)_(.*)");
@@ -432,14 +441,9 @@ namespace MTConnect.Buffers
                         }
                     }
 
-                    var options = new JsonSerializerOptions
-                    {
-                        WriteIndented = true
-                    };
-
                     var assetType = Asset.GetAssetType(asset.Type);
 
-                    var json = JsonSerializer.Serialize(asset, assetType, options);
+                    var json = JsonSerializer.Serialize(asset, assetType, _writeOptions);
                     if (!string.IsNullOrEmpty(json))
                     {
                         if (UseCompression)

--- a/libraries/MTConnect.NET-Common/Clients/MTConnectClientInformation.cs
+++ b/libraries/MTConnect.NET-Common/Clients/MTConnectClientInformation.cs
@@ -23,6 +23,15 @@ namespace MTConnect.Clients
         /// </summary>
         public const string FilenameExtension = ".json";
 
+        // Shared across every Save call. See JsonFunctions.cs for the
+        // rationale — a fresh JsonSerializerOptions per call re-emits
+        // LCG DynamicMethods into the loader heap, and the GC cannot
+        // reclaim them.
+        private static readonly JsonSerializerOptions _saveOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+
 
         /// <summary>
         /// A token regenerated on every save, used to detect that the persisted state has changed since it was last loaded.
@@ -126,12 +135,7 @@ namespace MTConnect.Clients
                 var configurationPath = Path.Combine(dir, GenerateFilename(DeviceKey));
                 if (path != null) configurationPath = path;
 
-                var options = new JsonSerializerOptions
-                {
-                    WriteIndented = true
-                };
-
-                var json = JsonSerializer.Serialize(this, options);
+                var json = JsonSerializer.Serialize(this, _saveOptions);
                 File.WriteAllText(configurationPath, json);
             }
             catch { }

--- a/libraries/MTConnect.NET-Common/Configurations/AdapterApplicationConfiguration.cs
+++ b/libraries/MTConnect.NET-Common/Configurations/AdapterApplicationConfiguration.cs
@@ -40,6 +40,15 @@ namespace MTConnect.Configurations
         /// </summary>
         public const string DefaultYamlFilename = "adapter.config.default.yaml";
 
+        // Shared across every ReadJson call. See JsonFunctions.cs for
+        // the rationale — a fresh JsonSerializerOptions per call
+        // re-emits LCG DynamicMethods into the loader heap, and the GC
+        // cannot reclaim them.
+        private static readonly JsonSerializerOptions _readOptions = new JsonSerializerOptions()
+        {
+            ReadCommentHandling = JsonCommentHandling.Skip
+        };
+
 
         /// <summary>
         /// An opaque token regenerated each time the configuration is saved, allowing consumers to detect that the configuration has changed.
@@ -371,12 +380,7 @@ namespace MTConnect.Configurations
                     var text = File.ReadAllText(configurationPath);
                     if (!string.IsNullOrEmpty(text))
                     {
-                        var options = new JsonSerializerOptions()
-                        {
-                            ReadCommentHandling = JsonCommentHandling.Skip
-                        };
-
-                        var configuration = JsonSerializer.Deserialize<T>(text, options);
+                        var configuration = JsonSerializer.Deserialize<T>(text, _readOptions);
                         configuration.Path = configurationPath;
                         return configuration;
                     }
@@ -411,12 +415,7 @@ namespace MTConnect.Configurations
                     var text = File.ReadAllText(configurationPath);
                     if (!string.IsNullOrEmpty(text))
                     {
-                        var options = new JsonSerializerOptions()
-                        {
-                            ReadCommentHandling = JsonCommentHandling.Skip
-                        };
-
-                        var configuration = (AdapterApplicationConfiguration)JsonSerializer.Deserialize(text, type, options);
+                        var configuration = (AdapterApplicationConfiguration)JsonSerializer.Deserialize(text, type, _readOptions);
                         configuration.Path = configurationPath;
                         return configuration;
                     }

--- a/libraries/MTConnect.NET-Common/Configurations/AgentConfiguration.cs
+++ b/libraries/MTConnect.NET-Common/Configurations/AgentConfiguration.cs
@@ -40,6 +40,15 @@ namespace MTConnect.Configurations
         /// </summary>
         public const string DefaultYamlFilename = "agent.config.default.yaml";
 
+        // Shared across every ReadJson call. See JsonFunctions.cs for
+        // the rationale — a fresh JsonSerializerOptions per call
+        // re-emits LCG DynamicMethods into the loader heap, and the GC
+        // cannot reclaim them.
+        private static readonly JsonSerializerOptions _readOptions = new JsonSerializerOptions()
+        {
+            ReadCommentHandling = JsonCommentHandling.Skip
+        };
+
 
         /// <summary>
         /// An opaque token regenerated each time the configuration is saved, allowing consumers to detect that the configuration has changed.
@@ -283,12 +292,7 @@ namespace MTConnect.Configurations
                     var text = File.ReadAllText(configurationPath);
                     if (!string.IsNullOrEmpty(text))
                     {
-                        var options = new JsonSerializerOptions()
-                        {
-                            ReadCommentHandling = JsonCommentHandling.Skip
-                        };
-
-                        var configuration = JsonSerializer.Deserialize<T>(text, options);
+                        var configuration = JsonSerializer.Deserialize<T>(text, _readOptions);
                         configuration.Path = configurationPath;
                         return configuration;
                     }
@@ -323,12 +327,7 @@ namespace MTConnect.Configurations
                     var text = File.ReadAllText(configurationPath);
                     if (!string.IsNullOrEmpty(text))
                     {
-                        var options = new JsonSerializerOptions()
-                        {
-                            ReadCommentHandling = JsonCommentHandling.Skip
-                        };
-
-                        var configuration = (AgentConfiguration)JsonSerializer.Deserialize(text, type, options);
+                        var configuration = (AgentConfiguration)JsonSerializer.Deserialize(text, type, _readOptions);
                         configuration.Path = configurationPath;
                         return configuration;
                     }

--- a/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2024 TrakHound Inc., All Rights Reserved.
 // TrakHound Inc. licenses this file to you under the MIT license.
 
-using System;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -127,7 +126,13 @@ namespace MTConnect
                 {
                     Header = new Headers.MTConnectErrorHeader(),
                     Errors = new[] { new Errors.Error() },
-                    Version = new Version(2, 5)
+                    // Any non-null concrete Version warms the
+                    // System.Version accessors identically; using the
+                    // repo's canonical constant instead of a magic
+                    // `new Version(2, 5)` tuple keeps the warm-up
+                    // aligned with the rest of the codebase's
+                    // MTConnectVersion sourcing (F-CR-C6-001).
+                    Version = MTConnectVersions.Version25
                 },
                 options);
         }

--- a/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 TrakHound Inc., All Rights Reserved.
 // TrakHound Inc. licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -103,12 +104,32 @@ namespace MTConnect
         // ErrorResponseDocument (from MTConnect.Errors) is the fourth
         // top-level envelope — no cppagent-specific surrogate, written
         // by the formatter's IErrorResponseDocument overload directly.
+        //
+        // The Error envelope populates a concrete
+        // MTConnectErrorHeader + Error entry + Version, so STJ walks
+        // the runtime types the production path actually serializes
+        // (interface-typed properties resolve to their concrete
+        // implementations only when the value is non-null); a naked
+        // `new ErrorResponseDocument()` with null Header / Errors /
+        // Version would only warm ErrorResponseDocument's own
+        // accessors, leaving the first real /probe error or parse
+        // failure to pay a cold LCG emit on MTConnectErrorHeader (9
+        // properties), Error (2), and System.Version (6) — the exact
+        // symptom class the singleton pattern exists to eliminate for
+        // the error path (F-IMP-C5-001).
         private static void WarmReachableGraph(JsonSerializerOptions options)
         {
             JsonSerializer.Serialize(new Streams.Json.JsonStreamsResponseDocument(), options);
             JsonSerializer.Serialize(new Assets.Json.JsonAssetsResponseDocument(), options);
             JsonSerializer.Serialize(new Devices.Json.JsonDevicesResponseDocument(), options);
-            JsonSerializer.Serialize(new Errors.ErrorResponseDocument(), options);
+            JsonSerializer.Serialize(
+                new Errors.ErrorResponseDocument
+                {
+                    Header = new Headers.MTConnectErrorHeader(),
+                    Errors = new[] { new Errors.Error() },
+                    Version = new Version(2, 5)
+                },
+                options);
         }
 #endif
 

--- a/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
@@ -116,7 +116,7 @@ namespace MTConnect
         /// a per-call converter forces a private options instance. Every
         /// call allocates a new object and re-emits the STJ reflection
         /// metadata cache for the reachable type graph — the very cost
-        /// the singletons exist to amortise — so it MUST NOT be invoked
+        /// the singletons exist to amortize — so it MUST NOT be invoked
         /// on any hot-path serialization site.
         /// </remarks>
         /// <param name="indented">When true, sets <c>WriteIndented = true</c>; otherwise compact JSON.</param>
@@ -153,7 +153,7 @@ namespace MTConnect
         /// and returns it. This branch pays the full reflection-emit
         /// cost per call and is NOT thread-safe under simultaneous cold
         /// callers because the fresh options is neither shared nor
-        /// synchronised — each call allocates and mutates its own
+        /// synchronized — each call allocates and mutates its own
         /// object, so per-call concurrent use is safe; multiple callers
         /// sharing one converter instance is safe iff the converter
         /// itself is thread-safe. The branch exists solely to preserve

--- a/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
@@ -28,7 +28,7 @@ namespace MTConnect
         // the ~3.3 MB/h RSS climb observed on DIME production hosts in
         // 2026-08. The cppagent-format assembly ships 25 Streams.Json
         // classes (2.5× the plain-JSON count), so the LCG cost per
-        // serialisation is proportionally larger. The instances below
+        // serialization is proportionally larger. The instances below
         // are created once and reused; JsonSerializerOptions is
         // thread-safe for read after its first (de)serialization, and
         // nothing in this file mutates them after construction.

--- a/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
@@ -18,50 +18,69 @@ namespace MTConnect
     /// </summary>
     public static class JsonFunctions
     {
+        // A JsonSerializerOptions instance owns its own serialization
+        // metadata cache, and building that cache emits reflection-based
+        // property accessors (LCG DynamicMethods) for every property in
+        // the reachable type graph. Allocating a fresh instance per call
+        // therefore re-emits those accessors on every serialization, and
+        // the emitted code accumulates in the runtime's loader heaps
+        // where the GC cannot reclaim it — this is the mechanism behind
+        // the ~3.3 MB/h RSS climb observed on DIME production hosts in
+        // 2026-08. The cppagent-format assembly ships 25 Streams.Json
+        // classes (2.5× the plain-JSON count), so the LCG cost per
+        // serialisation is proportionally larger. The instances below
+        // are created once and reused; JsonSerializerOptions is
+        // thread-safe for read after its first (de)serialization, and
+        // nothing in this file mutates them after construction.
+        private static readonly JsonSerializerOptions _defaultOptions = CreateOptions(false);
+        private static readonly JsonSerializerOptions _indentOptions = CreateOptions(true);
+
+        private static JsonSerializerOptions CreateOptions(bool indented)
+        {
+            return new JsonSerializerOptions
+            {
+                WriteIndented = indented,
+#if NET5_0_OR_GREATER
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                NumberHandling = JsonNumberHandling.AllowReadingFromString,
+#endif
+                PropertyNameCaseInsensitive = true,
+                MaxDepth = 1000
+            };
+        }
+
+        private static JsonSerializerOptions GetOptions(JsonConverter converter, bool indented)
+        {
+            // Hot path: no per-call converter, hand back the shared
+            // instance and let System.Text.Json reuse its metadata cache
+            // instead of re-emitting property accessors for the whole
+            // type graph on every call.
+            if (converter == null) return indented ? _indentOptions : _defaultOptions;
+
+            // Cold path: a caller-supplied converter cannot be added to
+            // a shared instance once it has been used, so build a
+            // private one. Callers that mint many one-off converters
+            // will still pay the LCG cost — this fallback preserves the
+            // public API contract for external consumers.
+            var options = CreateOptions(indented);
+            options.Converters.Add(converter);
+            return options;
+        }
+
         /// <summary>
         /// Default serializer options used when no <c>indentOutput</c>
         /// option is requested. Produces compact JSON, omits properties
         /// at their default value, allows numbers to be read from
         /// strings, and ignores property-name casing.
         /// </summary>
-        public static JsonSerializerOptions DefaultOptions
-        {
-            get
-            {
-                return new JsonSerializerOptions
-                {
-                    WriteIndented = false,
-#if NET5_0_OR_GREATER
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                    NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                    PropertyNameCaseInsensitive = true,
-                    MaxDepth = 1000
-                };
-            }
-        }
+        public static JsonSerializerOptions DefaultOptions => _defaultOptions;
 
         /// <summary>
         /// Pretty-printed serializer options used when the
         /// <c>indentOutput</c> formatter option is enabled; otherwise
         /// identical to <see cref="DefaultOptions"/>.
         /// </summary>
-        public static JsonSerializerOptions IndentOptions
-        {
-            get
-            {
-                return new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-#if NET5_0_OR_GREATER
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                    NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                    PropertyNameCaseInsensitive = true,
-                    MaxDepth = 1000
-                };
-            }
-        }
+        public static JsonSerializerOptions IndentOptions => _indentOptions;
 
 
         /// <summary>
@@ -76,18 +95,7 @@ namespace MTConnect
             {
                 try
                 {
-                    var options = new JsonSerializerOptions
-                    {
-                        WriteIndented = indented,
-#if NET5_0_OR_GREATER
-                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                        PropertyNameCaseInsensitive = true,
-                        MaxDepth = 1000
-                    };
-
-                    if (converter != null) options.Converters.Add(converter);
+                    var options = GetOptions(converter, indented);
 
                     return JsonSerializer.Serialize(obj, options);
                 }
@@ -109,18 +117,7 @@ namespace MTConnect
             {
                 try
                 {
-                    var options = new JsonSerializerOptions
-                    {
-                        WriteIndented = indented,
-#if NET5_0_OR_GREATER
-                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                        PropertyNameCaseInsensitive = true,
-                        MaxDepth = 1000
-                    };
-
-                    if (converter != null) options.Converters.Add(converter);
+                    var options = GetOptions(converter, indented);
 
                     return JsonSerializer.SerializeToUtf8Bytes(obj, options);
                 }
@@ -143,18 +140,7 @@ namespace MTConnect
             {
                 try
                 {
-                    var options = new JsonSerializerOptions
-                    {
-                        WriteIndented = indented,
-#if NET5_0_OR_GREATER
-                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                        PropertyNameCaseInsensitive = true,
-                        MaxDepth = 1000
-                    };
-
-                    if (converter != null) options.Converters.Add(converter);
+                    var options = GetOptions(converter, indented);
 
                     var outputStream = new MemoryStream();
                     JsonSerializer.Serialize(outputStream, obj, options);

--- a/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
@@ -35,6 +35,43 @@ namespace MTConnect
         private static readonly JsonSerializerOptions _defaultOptions = CreateOptions(false);
         private static readonly JsonSerializerOptions _indentOptions = CreateOptions(true);
 
+        static JsonFunctions()
+        {
+#if NET8_0_OR_GREATER
+            // Warm the default reflection resolver + serialization
+            // metadata cache at assembly load rather than on the first
+            // production /current or /sample request. Serializing a
+            // typed null pays the resolver bootstrap cost + fixes the
+            // options' internal state, so the first user-facing
+            // Serialize call skips that setup entirely. This matters
+            // more for the cppagent assembly than for the plain-JSON
+            // one — it ships 25 Streams.Json classes vs 10, so the
+            // reflection cost per fresh options is proportionally
+            // larger.
+            //
+            // Order matters: the warm-up must run BEFORE MakeReadOnly,
+            // because MakeReadOnly(populateMissingResolver: false)
+            // freezes the options WITHOUT choosing a TypeInfoResolver;
+            // a subsequent Serialize on a resolver-less, frozen
+            // options would throw NotSupportedException. Running
+            // Serialize first lets STJ auto-populate the resolver via
+            // its normal lazy path, after which MakeReadOnly(false)
+            // is a pure lock with no side effect on serialization.
+            JsonSerializer.Serialize<object>(null, _defaultOptions);
+            JsonSerializer.Serialize<object>(null, _indentOptions);
+
+            // Freeze both singletons so callers cannot mutate the
+            // shared instance (adding a Converter, flipping
+            // WriteIndented, etc.). Attempted mutation throws
+            // InvalidOperationException — the fail-fast is preferable
+            // to silent cross-caller pollution, and the cold-path
+            // Convert branch stays open because it builds a fresh
+            // (non-read-only) options object per call.
+            _defaultOptions.MakeReadOnly(populateMissingResolver: false);
+            _indentOptions.MakeReadOnly(populateMissingResolver: false);
+#endif
+        }
+
         private static JsonSerializerOptions CreateOptions(bool indented)
         {
             return new JsonSerializerOptions
@@ -73,6 +110,17 @@ namespace MTConnect
         /// at their default value, allows numbers to be read from
         /// strings, and ignores property-name casing.
         /// </summary>
+        /// <remarks>
+        /// This is a process-wide shared singleton; do NOT mutate the
+        /// returned instance's <see cref="JsonSerializerOptions.Converters"/>
+        /// collection or any writable property. The returned object is
+        /// marked <c>MakeReadOnly()</c> under <c>net8.0</c> and later;
+        /// attempted mutation throws <see cref="System.InvalidOperationException"/>.
+        /// On older TFMs (netstandard2.0, net4.6.1–net4.8, net6.0, net7.0)
+        /// the instance is not statically frozen but callers must still
+        /// treat it as immutable — mutating it silently corrupts every
+        /// other in-process serializer that shares the singleton.
+        /// </remarks>
         public static JsonSerializerOptions DefaultOptions => _defaultOptions;
 
         /// <summary>
@@ -80,6 +128,17 @@ namespace MTConnect
         /// <c>indentOutput</c> formatter option is enabled; otherwise
         /// identical to <see cref="DefaultOptions"/>.
         /// </summary>
+        /// <remarks>
+        /// This is a process-wide shared singleton; do NOT mutate the
+        /// returned instance's <see cref="JsonSerializerOptions.Converters"/>
+        /// collection or any writable property. The returned object is
+        /// marked <c>MakeReadOnly()</c> under <c>net8.0</c> and later;
+        /// attempted mutation throws <see cref="System.InvalidOperationException"/>.
+        /// On older TFMs (netstandard2.0, net4.6.1–net4.8, net6.0, net7.0)
+        /// the instance is not statically frozen but callers must still
+        /// treat it as immutable — mutating it silently corrupts every
+        /// other in-process serializer that shares the singleton.
+        /// </remarks>
         public static JsonSerializerOptions IndentOptions => _indentOptions;
 
 

--- a/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
@@ -55,9 +55,16 @@ namespace MTConnect
             // only bootstrapped the shared reflection resolver — it
             // never named a concrete MTConnect type, so the cold LCG
             // emit for JsonStreamsResponseDocument /
-            // JsonAssetsResponseDocument / JsonDevicesResponseDocument
-            // still fell on the first user-facing request. The typed
-            // calls below fix that.
+            // JsonAssetsResponseDocument / JsonDevicesResponseDocument /
+            // ErrorResponseDocument still fell on the first user-facing
+            // request. The typed calls below fix that.
+            // ErrorResponseDocument (from MTConnect.Errors) is the
+            // surrogate-less envelope written directly by
+            // JsonHttpResponseDocumentFormatter.Format(IErrorResponseDocument);
+            // its cold LCG emit would otherwise hit on the first /probe
+            // error, /current parse failure, or unsupported device
+            // response — request paths that are already the symptom,
+            // not the happy path we want to pay reflection cost on top of.
             //
             // Order matters: the warm-up must run BEFORE MakeReadOnly,
             // because MakeReadOnly(populateMissingResolver: false)
@@ -93,11 +100,15 @@ namespace MTConnect
         // All three cppagent response envelopes expose public
         // parameterless constructors for JSON deserialization, so the
         // warm-up just news each one up and hands it to Serialize.
+        // ErrorResponseDocument (from MTConnect.Errors) is the fourth
+        // top-level envelope — no cppagent-specific surrogate, written
+        // by the formatter's IErrorResponseDocument overload directly.
         private static void WarmReachableGraph(JsonSerializerOptions options)
         {
             JsonSerializer.Serialize(new Streams.Json.JsonStreamsResponseDocument(), options);
             JsonSerializer.Serialize(new Assets.Json.JsonAssetsResponseDocument(), options);
             JsonSerializer.Serialize(new Devices.Json.JsonDevicesResponseDocument(), options);
+            JsonSerializer.Serialize(new Errors.ErrorResponseDocument(), options);
         }
 #endif
 
@@ -196,6 +207,20 @@ namespace MTConnect
         /// the instance is not statically frozen but callers must still
         /// treat it as immutable — mutating it silently corrupts every
         /// other in-process serializer that shares the singleton.
+        /// <para/>
+        /// Why the invariant matters: every mutation of a
+        /// <see cref="JsonSerializerOptions"/> instance that has already
+        /// been used forces System.Text.Json to rebuild its serialization
+        /// metadata cache, which re-emits reflection-based property
+        /// accessors as <see cref="System.Reflection.Emit.DynamicMethod"/>s
+        /// into the runtime's LCG (lightweight code generation) loader
+        /// heaps. Those heaps are never reclaimed by the GC — every
+        /// mutated-then-reused options object leaks the emit permanently.
+        /// A peer measured this class of misuse at +3.2–3.8 MB/h RSS in
+        /// production; the cppagent assembly ships 25 Streams.Json
+        /// classes (2.5× the plain-JSON count), so the per-mutation LCG
+        /// cost here is proportionally larger and the frozen singleton
+        /// pays back correspondingly more.
         /// </remarks>
         public static JsonSerializerOptions DefaultOptions => _defaultOptions;
 
@@ -214,6 +239,15 @@ namespace MTConnect
         /// the instance is not statically frozen but callers must still
         /// treat it as immutable — mutating it silently corrupts every
         /// other in-process serializer that shares the singleton.
+        /// <para/>
+        /// Why the invariant matters: same reflection-emit / LCG
+        /// loader-heap accumulation as documented on
+        /// <see cref="DefaultOptions"/>. Every per-call mutation of this
+        /// shared instance re-emits property-accessor
+        /// <see cref="System.Reflection.Emit.DynamicMethod"/>s into a
+        /// heap the GC cannot free — the mechanism behind the peer's
+        /// production +3.2–3.8 MB/h RSS climb before the singleton was
+        /// frozen.
         /// </remarks>
         public static JsonSerializerOptions IndentOptions => _indentOptions;
 

--- a/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
@@ -72,6 +72,25 @@ namespace MTConnect
 #endif
         }
 
+        /// <summary>
+        /// Builds a fresh <see cref="JsonSerializerOptions"/> instance
+        /// with the cppagent option preset (compact / indented per
+        /// <paramref name="indented"/>, default-value omission on net5+,
+        /// number-from-string reading on net5+, case-insensitive property
+        /// lookup, 1000-deep recursion limit).
+        /// </summary>
+        /// <remarks>
+        /// This helper is intended for two callers only: (1) the
+        /// static-init assignments that construct the shared
+        /// <c>_defaultOptions</c> and <c>_indentOptions</c> singletons,
+        /// and (2) the cold-path branch of <see cref="GetOptions"/> when
+        /// a per-call converter forces a private options instance. Every
+        /// call allocates a new object and re-emits the STJ reflection
+        /// metadata cache for the reachable type graph — the very cost
+        /// the singletons exist to amortise — so it MUST NOT be invoked
+        /// on any hot-path serialization site.
+        /// </remarks>
+        /// <param name="indented">When true, sets <c>WriteIndented = true</c>; otherwise compact JSON.</param>
         private static JsonSerializerOptions CreateOptions(bool indented)
         {
             return new JsonSerializerOptions
@@ -86,6 +105,34 @@ namespace MTConnect
             };
         }
 
+        /// <summary>
+        /// Resolves the <see cref="JsonSerializerOptions"/> instance
+        /// used by <see cref="Convert(object, JsonConverter, bool)"/>,
+        /// <see cref="ConvertBytes"/>, and <see cref="ConvertStream"/>
+        /// for a given per-call converter + indentation combination.
+        /// </summary>
+        /// <remarks>
+        /// Hot path (<paramref name="converter"/> is null, which is
+        /// every in-tree caller): returns the shared frozen singleton
+        /// (<c>_defaultOptions</c> or <c>_indentOptions</c>) so STJ
+        /// reuses its metadata cache instead of re-emitting property
+        /// accessors on every call.
+        /// <para/>
+        /// Cold path (<paramref name="converter"/> is non-null):
+        /// allocates a fresh <see cref="JsonSerializerOptions"/> via
+        /// <see cref="CreateOptions"/>, appends the caller's converter,
+        /// and returns it. This branch pays the full reflection-emit
+        /// cost per call and is NOT thread-safe under simultaneous cold
+        /// callers because the fresh options is neither shared nor
+        /// synchronised — each call allocates and mutates its own
+        /// object, so per-call concurrent use is safe; multiple callers
+        /// sharing one converter instance is safe iff the converter
+        /// itself is thread-safe. The branch exists solely to preserve
+        /// the public API contract for external consumers that pass a
+        /// per-call converter.
+        /// </remarks>
+        /// <param name="converter">Optional caller-supplied converter. When non-null forces the cold path.</param>
+        /// <param name="indented">Selects the compact or indented preset.</param>
         private static JsonSerializerOptions GetOptions(JsonConverter converter, bool indented)
         {
             // Hot path: no per-call converter, hand back the shared

--- a/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON-cppagent/JsonFunctions.cs
@@ -39,15 +39,25 @@ namespace MTConnect
         {
 #if NET8_0_OR_GREATER
             // Warm the default reflection resolver + serialization
-            // metadata cache at assembly load rather than on the first
-            // production /current or /sample request. Serializing a
-            // typed null pays the resolver bootstrap cost + fixes the
-            // options' internal state, so the first user-facing
-            // Serialize call skips that setup entirely. This matters
-            // more for the cppagent assembly than for the plain-JSON
-            // one — it ships 25 Streams.Json classes vs 10, so the
-            // reflection cost per fresh options is proportionally
-            // larger.
+            // metadata cache at assembly load rather than on the
+            // first production /current | /sample | /assets request.
+            // Serializing a real instance of each cppagent top-level
+            // response surrogate forces STJ to walk that type's
+            // reachable property graph, which is where the
+            // LCG DynamicMethod property accessors are emitted; paying
+            // that cost once at assembly load is the whole point of
+            // the warm-up. This matters more for the cppagent assembly
+            // than for the plain-JSON one — it ships 25 Streams.Json
+            // classes vs 10, so the reflection cost per fresh options
+            // is proportionally larger.
+            //
+            // A prior warm-up form (Serialize<object>(null, options))
+            // only bootstrapped the shared reflection resolver — it
+            // never named a concrete MTConnect type, so the cold LCG
+            // emit for JsonStreamsResponseDocument /
+            // JsonAssetsResponseDocument / JsonDevicesResponseDocument
+            // still fell on the first user-facing request. The typed
+            // calls below fix that.
             //
             // Order matters: the warm-up must run BEFORE MakeReadOnly,
             // because MakeReadOnly(populateMissingResolver: false)
@@ -57,8 +67,8 @@ namespace MTConnect
             // Serialize first lets STJ auto-populate the resolver via
             // its normal lazy path, after which MakeReadOnly(false)
             // is a pure lock with no side effect on serialization.
-            JsonSerializer.Serialize<object>(null, _defaultOptions);
-            JsonSerializer.Serialize<object>(null, _indentOptions);
+            WarmReachableGraph(_defaultOptions);
+            WarmReachableGraph(_indentOptions);
 
             // Freeze both singletons so callers cannot mutate the
             // shared instance (adding a Converter, flipping
@@ -71,6 +81,25 @@ namespace MTConnect
             _indentOptions.MakeReadOnly(populateMissingResolver: false);
 #endif
         }
+
+#if NET8_0_OR_GREATER
+        // Serialize an instance of each cppagent top-level response
+        // surrogate against <paramref name="options"/>, so STJ
+        // configures JsonTypeInfo (and emits the LCG DynamicMethod
+        // property accessors) for the reachable graph rooted at each
+        // type. Called from the static constructor for both the
+        // compact and indented option singletons.
+        //
+        // All three cppagent response envelopes expose public
+        // parameterless constructors for JSON deserialization, so the
+        // warm-up just news each one up and hands it to Serialize.
+        private static void WarmReachableGraph(JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(new Streams.Json.JsonStreamsResponseDocument(), options);
+            JsonSerializer.Serialize(new Assets.Json.JsonAssetsResponseDocument(), options);
+            JsonSerializer.Serialize(new Devices.Json.JsonDevicesResponseDocument(), options);
+        }
+#endif
 
         /// <summary>
         /// Builds a fresh <see cref="JsonSerializerOptions"/> instance

--- a/libraries/MTConnect.NET-JSON/Assets/JsonAssetsDocument.cs
+++ b/libraries/MTConnect.NET-JSON/Assets/JsonAssetsDocument.cs
@@ -43,6 +43,22 @@ namespace MTConnect.Assets.Json
         /// <see cref="IAssetsResponseDocument"/>, dispatching each asset to the
         /// surrogate that matches its type.
         /// </summary>
+        /// <remarks>
+        /// This constructor MUST remain null-tolerant on
+        /// <paramref name="assetsDocument"/>. The static-ctor
+        /// warm-up in <c>MTConnect.JsonFunctions.WarmReachableGraph</c>
+        /// calls <c>new JsonAssetsDocument(null)</c> to force
+        /// System.Text.Json to emit the LCG DynamicMethod property
+        /// accessors for the reachable Assets graph at assembly load,
+        /// avoiding a cold reflection-emit on the first user-facing
+        /// /assets request. Adding an
+        /// <c>ArgumentNullException.ThrowIfNull(assetsDocument)</c>
+        /// guard here would turn the first JSON serialization on
+        /// process start into a <see cref="System.TypeInitializationException"/>.
+        /// If the null-tolerance contract must change, update the
+        /// warm-up site atomically per §1.0d-trigies-bis
+        /// (F-IMP-C5-002).
+        /// </remarks>
         public JsonAssetsDocument(IAssetsResponseDocument assetsDocument)
         {
             if (assetsDocument != null)

--- a/libraries/MTConnect.NET-JSON/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON/JsonFunctions.cs
@@ -48,8 +48,16 @@ namespace MTConnect
             // only bootstrapped the shared reflection resolver — it
             // never named a concrete MTConnect type, so the cold LCG
             // emit for JsonStreamsDocument / JsonAssetsDocument /
-            // JsonDevicesDocument still fell on the first user-facing
-            // request. The typed calls below fix that.
+            // JsonDevicesDocument / ErrorResponseDocument still fell
+            // on the first user-facing request. The typed calls below
+            // fix that. ErrorResponseDocument is the surrogate-less
+            // response envelope written directly by
+            // JsonResponseDocumentFormatter.Format(IErrorResponseDocument),
+            // so its cold LCG emit would otherwise hit on the first
+            // /probe error, /current parse failure, or unsupported
+            // device response — request paths that are already the
+            // symptom, not the happy path we want to pay reflection
+            // cost on top of.
             //
             // Order matters: the warm-up must run BEFORE MakeReadOnly,
             // because MakeReadOnly(populateMissingResolver: false)
@@ -88,11 +96,15 @@ namespace MTConnect
         // null Assets, which is enough to walk its declared property
         // types. JsonStreamsDocument and JsonDevicesDocument both
         // expose parameterless constructors for JSON deserialization.
+        // ErrorResponseDocument (MTConnect.Errors) is the fourth
+        // top-level response envelope — no surrogate wrapper, written
+        // by the formatter's IErrorResponseDocument overload directly.
         private static void WarmReachableGraph(JsonSerializerOptions options)
         {
             JsonSerializer.Serialize(new Streams.Json.JsonStreamsDocument(), options);
             JsonSerializer.Serialize(new Assets.Json.JsonAssetsDocument(null), options);
             JsonSerializer.Serialize(new Devices.Json.JsonDevicesDocument(), options);
+            JsonSerializer.Serialize(new Errors.ErrorResponseDocument(), options);
         }
 #endif
 
@@ -191,6 +203,17 @@ namespace MTConnect
         /// the instance is not statically frozen but callers must still
         /// treat it as immutable — mutating it silently corrupts every
         /// other in-process serializer that shares the singleton.
+        /// <para/>
+        /// Why the invariant matters: every mutation of a
+        /// <see cref="JsonSerializerOptions"/> instance that has already
+        /// been used forces System.Text.Json to rebuild its serialization
+        /// metadata cache, which re-emits reflection-based property
+        /// accessors as <see cref="System.Reflection.Emit.DynamicMethod"/>s
+        /// into the runtime's LCG (lightweight code generation) loader
+        /// heaps. Those heaps are never reclaimed by the GC — every
+        /// mutated-then-reused options object leaks the emit permanently.
+        /// A peer measured this class of misuse at +3.2–3.8 MB/h RSS in
+        /// production, which is what the frozen singleton eliminates.
         /// </remarks>
         public static JsonSerializerOptions DefaultOptions => _defaultOptions;
 
@@ -208,6 +231,15 @@ namespace MTConnect
         /// the instance is not statically frozen but callers must still
         /// treat it as immutable — mutating it silently corrupts every
         /// other in-process serializer that shares the singleton.
+        /// <para/>
+        /// Why the invariant matters: same reflection-emit / LCG
+        /// loader-heap accumulation as documented on
+        /// <see cref="DefaultOptions"/>. Every per-call mutation of this
+        /// shared instance re-emits property-accessor
+        /// <see cref="System.Reflection.Emit.DynamicMethod"/>s into a
+        /// heap the GC cannot free — the mechanism behind the peer's
+        /// production +3.2–3.8 MB/h RSS climb before the singleton was
+        /// frozen.
         /// </remarks>
         public static JsonSerializerOptions IndentOptions => _indentOptions;
 

--- a/libraries/MTConnect.NET-JSON/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON/JsonFunctions.cs
@@ -64,6 +64,25 @@ namespace MTConnect
 #endif
         }
 
+        /// <summary>
+        /// Builds a fresh <see cref="JsonSerializerOptions"/> instance
+        /// with the MTConnect option preset (compact / indented per
+        /// <paramref name="indented"/>, default-value omission on net5+,
+        /// number-from-string reading on net5+, case-insensitive property
+        /// lookup, 1000-deep recursion limit).
+        /// </summary>
+        /// <remarks>
+        /// This helper is intended for two callers only: (1) the
+        /// static-init assignments that construct the shared
+        /// <c>_defaultOptions</c> and <c>_indentOptions</c> singletons,
+        /// and (2) the cold-path branch of <see cref="GetOptions"/> when
+        /// a per-call converter forces a private options instance. Every
+        /// call allocates a new object and re-emits the STJ reflection
+        /// metadata cache for the reachable type graph — the very cost
+        /// the singletons exist to amortise — so it MUST NOT be invoked
+        /// on any hot-path serialization site.
+        /// </remarks>
+        /// <param name="indented">When true, sets <c>WriteIndented = true</c>; otherwise compact JSON.</param>
         private static JsonSerializerOptions CreateOptions(bool indented)
         {
             return new JsonSerializerOptions
@@ -78,6 +97,34 @@ namespace MTConnect
             };
         }
 
+        /// <summary>
+        /// Resolves the <see cref="JsonSerializerOptions"/> instance
+        /// used by <see cref="Convert(object, JsonConverter, bool)"/>,
+        /// <see cref="ConvertBytes"/>, and <see cref="ConvertStream"/>
+        /// for a given per-call converter + indentation combination.
+        /// </summary>
+        /// <remarks>
+        /// Hot path (<paramref name="converter"/> is null, which is
+        /// every in-tree caller): returns the shared frozen singleton
+        /// (<c>_defaultOptions</c> or <c>_indentOptions</c>) so STJ
+        /// reuses its metadata cache instead of re-emitting property
+        /// accessors on every call.
+        /// <para/>
+        /// Cold path (<paramref name="converter"/> is non-null):
+        /// allocates a fresh <see cref="JsonSerializerOptions"/> via
+        /// <see cref="CreateOptions"/>, appends the caller's converter,
+        /// and returns it. This branch pays the full reflection-emit
+        /// cost per call and is NOT thread-safe under simultaneous cold
+        /// callers because the fresh options is neither shared nor
+        /// synchronised — each call allocates and mutates its own
+        /// object, so per-call concurrent use is safe; multiple callers
+        /// sharing one converter instance is safe iff the converter
+        /// itself is thread-safe. The branch exists solely to preserve
+        /// the public API contract for external consumers that pass a
+        /// per-call converter.
+        /// </remarks>
+        /// <param name="converter">Optional caller-supplied converter. When non-null forces the cold path.</param>
+        /// <param name="indented">Selects the compact or indented preset.</param>
         private static JsonSerializerOptions GetOptions(JsonConverter converter, bool indented)
         {
             // Hot path: no per-call converter, hand back the shared

--- a/libraries/MTConnect.NET-JSON/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON/JsonFunctions.cs
@@ -122,7 +122,13 @@ namespace MTConnect
                 {
                     Header = new Headers.MTConnectErrorHeader(),
                     Errors = new[] { new Errors.Error() },
-                    Version = new Version(2, 5)
+                    // Any non-null concrete Version warms the
+                    // System.Version accessors identically; using the
+                    // repo's canonical constant instead of a magic
+                    // `new Version(2, 5)` tuple keeps the warm-up
+                    // aligned with the rest of the codebase's
+                    // MTConnectVersion sourcing (F-CR-C6-001).
+                    Version = MTConnectVersions.Version25
                 },
                 options);
         }

--- a/libraries/MTConnect.NET-JSON/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON/JsonFunctions.cs
@@ -99,12 +99,32 @@ namespace MTConnect
         // ErrorResponseDocument (MTConnect.Errors) is the fourth
         // top-level response envelope — no surrogate wrapper, written
         // by the formatter's IErrorResponseDocument overload directly.
+        //
+        // The Error envelope populates a concrete
+        // MTConnectErrorHeader + Error entry + Version, so STJ walks
+        // the runtime types the production path actually serializes
+        // (interface-typed properties resolve to their concrete
+        // implementations only when the value is non-null); a naked
+        // `new ErrorResponseDocument()` with null Header / Errors /
+        // Version would only warm ErrorResponseDocument's own
+        // accessors, leaving the first real /probe error or parse
+        // failure to pay a cold LCG emit on MTConnectErrorHeader (9
+        // properties), Error (2), and System.Version (6) — the exact
+        // symptom class the singleton pattern exists to eliminate for
+        // the error path (F-IMP-C5-001).
         private static void WarmReachableGraph(JsonSerializerOptions options)
         {
             JsonSerializer.Serialize(new Streams.Json.JsonStreamsDocument(), options);
             JsonSerializer.Serialize(new Assets.Json.JsonAssetsDocument(null), options);
             JsonSerializer.Serialize(new Devices.Json.JsonDevicesDocument(), options);
-            JsonSerializer.Serialize(new Errors.ErrorResponseDocument(), options);
+            JsonSerializer.Serialize(
+                new Errors.ErrorResponseDocument
+                {
+                    Header = new Headers.MTConnectErrorHeader(),
+                    Errors = new[] { new Errors.Error() },
+                    Version = new Version(2, 5)
+                },
+                options);
         }
 #endif
 

--- a/libraries/MTConnect.NET-JSON/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON/JsonFunctions.cs
@@ -111,7 +111,7 @@ namespace MTConnect
         /// a per-call converter forces a private options instance. Every
         /// call allocates a new object and re-emits the STJ reflection
         /// metadata cache for the reachable type graph — the very cost
-        /// the singletons exist to amortise — so it MUST NOT be invoked
+        /// the singletons exist to amortize — so it MUST NOT be invoked
         /// on any hot-path serialization site.
         /// </remarks>
         /// <param name="indented">When true, sets <c>WriteIndented = true</c>; otherwise compact JSON.</param>
@@ -148,7 +148,7 @@ namespace MTConnect
         /// and returns it. This branch pays the full reflection-emit
         /// cost per call and is NOT thread-safe under simultaneous cold
         /// callers because the fresh options is neither shared nor
-        /// synchronised — each call allocates and mutates its own
+        /// synchronized — each call allocates and mutates its own
         /// object, so per-call concurrent use is safe; multiple callers
         /// sharing one converter instance is safe iff the converter
         /// itself is thread-safe. The branch exists solely to preserve

--- a/libraries/MTConnect.NET-JSON/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON/JsonFunctions.cs
@@ -35,11 +35,21 @@ namespace MTConnect
         {
 #if NET8_0_OR_GREATER
             // Warm the default reflection resolver + serialization
-            // metadata cache at assembly load rather than on the first
-            // production /current or /sample request. Serializing a
-            // typed null pays the resolver bootstrap cost + fixes the
-            // options' internal state, so the first user-facing
-            // Serialize call skips that setup entirely.
+            // metadata cache at assembly load rather than on the
+            // first production /current | /sample | /assets request.
+            // Serializing a real instance of each MTConnect top-level
+            // response surrogate forces STJ to walk that type's
+            // reachable property graph, which is where the
+            // LCG DynamicMethod property accessors are emitted; paying
+            // that cost once at assembly load is the whole point of
+            // the warm-up.
+            //
+            // A prior warm-up form (Serialize<object>(null, options))
+            // only bootstrapped the shared reflection resolver — it
+            // never named a concrete MTConnect type, so the cold LCG
+            // emit for JsonStreamsDocument / JsonAssetsDocument /
+            // JsonDevicesDocument still fell on the first user-facing
+            // request. The typed calls below fix that.
             //
             // Order matters: the warm-up must run BEFORE MakeReadOnly,
             // because MakeReadOnly(populateMissingResolver: false)
@@ -49,8 +59,8 @@ namespace MTConnect
             // Serialize first lets STJ auto-populate the resolver via
             // its normal lazy path, after which MakeReadOnly(false)
             // is a pure lock with no side effect on serialization.
-            JsonSerializer.Serialize<object>(null, _defaultOptions);
-            JsonSerializer.Serialize<object>(null, _indentOptions);
+            WarmReachableGraph(_defaultOptions);
+            WarmReachableGraph(_indentOptions);
 
             // Freeze both singletons so callers cannot mutate the
             // shared instance (adding a Converter, flipping
@@ -63,6 +73,28 @@ namespace MTConnect
             _indentOptions.MakeReadOnly(populateMissingResolver: false);
 #endif
         }
+
+#if NET8_0_OR_GREATER
+        // Serialize an instance of each MTConnect top-level response
+        // surrogate against <paramref name="options"/>, so STJ
+        // configures JsonTypeInfo (and emits the LCG DynamicMethod
+        // property accessors) for the reachable graph rooted at each
+        // type. Called from the static constructor for both the
+        // compact and indented option singletons.
+        //
+        // JsonAssetsDocument has no public parameterless constructor;
+        // its single (IAssetsResponseDocument) overload tolerates a
+        // null argument and yields an instance with null Header +
+        // null Assets, which is enough to walk its declared property
+        // types. JsonStreamsDocument and JsonDevicesDocument both
+        // expose parameterless constructors for JSON deserialization.
+        private static void WarmReachableGraph(JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(new Streams.Json.JsonStreamsDocument(), options);
+            JsonSerializer.Serialize(new Assets.Json.JsonAssetsDocument(null), options);
+            JsonSerializer.Serialize(new Devices.Json.JsonDevicesDocument(), options);
+        }
+#endif
 
         /// <summary>
         /// Builds a fresh <see cref="JsonSerializerOptions"/> instance

--- a/libraries/MTConnect.NET-JSON/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON/JsonFunctions.cs
@@ -16,49 +16,66 @@ namespace MTConnect
     /// </summary>
     public static class JsonFunctions
     {
+        // A JsonSerializerOptions instance owns its own serialization
+        // metadata cache, and building that cache emits reflection-based
+        // property accessors (LCG DynamicMethods) for every property in
+        // the reachable type graph. Allocating a fresh instance per call
+        // therefore re-emits those accessors on every serialization, and
+        // the emitted code accumulates in the runtime's loader heaps
+        // where the GC cannot reclaim it — this is the mechanism behind
+        // the ~3.3 MB/h RSS climb observed on DIME production hosts in
+        // 2026-08. The instances below are created once and reused;
+        // JsonSerializerOptions is thread-safe for read after its first
+        // (de)serialization, and nothing in this file mutates them after
+        // construction.
+        private static readonly JsonSerializerOptions _defaultOptions = CreateOptions(false);
+        private static readonly JsonSerializerOptions _indentOptions = CreateOptions(true);
+
+        private static JsonSerializerOptions CreateOptions(bool indented)
+        {
+            return new JsonSerializerOptions
+            {
+                WriteIndented = indented,
+#if NET5_0_OR_GREATER
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+                NumberHandling = JsonNumberHandling.AllowReadingFromString,
+#endif
+                PropertyNameCaseInsensitive = true,
+                MaxDepth = 1000
+            };
+        }
+
+        private static JsonSerializerOptions GetOptions(JsonConverter converter, bool indented)
+        {
+            // Hot path: no per-call converter, hand back the shared
+            // instance and let System.Text.Json reuse its metadata cache
+            // instead of re-emitting property accessors for the whole
+            // type graph on every call.
+            if (converter == null) return indented ? _indentOptions : _defaultOptions;
+
+            // Cold path: a caller-supplied converter cannot be added to
+            // a shared instance once it has been used, so build a
+            // private one. Callers that mint many one-off converters
+            // will still pay the LCG cost — this fallback preserves the
+            // public API contract for external consumers.
+            var options = CreateOptions(indented);
+            options.Converters.Add(converter);
+            return options;
+        }
+
         /// <summary>
         /// The default <see cref="JsonSerializerOptions"/> used by MTConnect
         /// JSON serialization: compact output, default-valued properties
         /// omitted on write (on net5+), numbers read from strings (on net5+),
         /// case-insensitive property names, and a depth limit of 1000.
         /// </summary>
-        public static JsonSerializerOptions DefaultOptions
-        {
-            get
-            {
-                return new JsonSerializerOptions
-                {
-                    WriteIndented = false,
-#if NET5_0_OR_GREATER
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                    NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                    PropertyNameCaseInsensitive = true,
-                    MaxDepth = 1000
-                };
-            }
-        }
+        public static JsonSerializerOptions DefaultOptions => _defaultOptions;
 
         /// <summary>
         /// The indented variant of <see cref="DefaultOptions"/>, used when the
         /// formatter's <c>indentOutput</c> option is set.
         /// </summary>
-        public static JsonSerializerOptions IndentOptions
-        {
-            get
-            {
-                return new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-#if NET5_0_OR_GREATER
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                    NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                    PropertyNameCaseInsensitive = true,
-                    MaxDepth = 1000
-                };
-            }
-        }
+        public static JsonSerializerOptions IndentOptions => _indentOptions;
 
 
         /// <summary>
@@ -97,18 +114,7 @@ namespace MTConnect
             {
                 try
                 {
-                    var options = new JsonSerializerOptions
-                    {
-                        WriteIndented = indented,
-#if NET5_0_OR_GREATER
-                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                        PropertyNameCaseInsensitive = true,
-                        MaxDepth = 1000
-                    };
-
-                    if (converter != null) options.Converters.Add(converter);
+                    var options = GetOptions(converter, indented);
 
                     return JsonSerializer.Serialize(obj, options);
                 }
@@ -130,18 +136,7 @@ namespace MTConnect
             {
                 try
                 {
-                    var options = new JsonSerializerOptions
-                    {
-                        WriteIndented = indented,
-#if NET5_0_OR_GREATER
-                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                        PropertyNameCaseInsensitive = true,
-                        MaxDepth = 1000
-                    };
-
-                    if (converter != null) options.Converters.Add(converter);
+                    var options = GetOptions(converter, indented);
 
                     return JsonSerializer.SerializeToUtf8Bytes(obj, options);
                 }
@@ -163,18 +158,7 @@ namespace MTConnect
             {
                 try
                 {
-                    var options = new JsonSerializerOptions
-                    {
-                        WriteIndented = indented,
-#if NET5_0_OR_GREATER
-                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
-                        NumberHandling = JsonNumberHandling.AllowReadingFromString,
-#endif
-                        PropertyNameCaseInsensitive = true,
-                        MaxDepth = 1000
-                    };
-
-                    if (converter != null) options.Converters.Add(converter);
+                    var options = GetOptions(converter, indented);
 
                     var outputStream = new MemoryStream();
                     JsonSerializer.Serialize(outputStream, obj, options);

--- a/libraries/MTConnect.NET-JSON/JsonFunctions.cs
+++ b/libraries/MTConnect.NET-JSON/JsonFunctions.cs
@@ -31,6 +31,39 @@ namespace MTConnect
         private static readonly JsonSerializerOptions _defaultOptions = CreateOptions(false);
         private static readonly JsonSerializerOptions _indentOptions = CreateOptions(true);
 
+        static JsonFunctions()
+        {
+#if NET8_0_OR_GREATER
+            // Warm the default reflection resolver + serialization
+            // metadata cache at assembly load rather than on the first
+            // production /current or /sample request. Serializing a
+            // typed null pays the resolver bootstrap cost + fixes the
+            // options' internal state, so the first user-facing
+            // Serialize call skips that setup entirely.
+            //
+            // Order matters: the warm-up must run BEFORE MakeReadOnly,
+            // because MakeReadOnly(populateMissingResolver: false)
+            // freezes the options WITHOUT choosing a TypeInfoResolver;
+            // a subsequent Serialize on a resolver-less, frozen
+            // options would throw NotSupportedException. Running
+            // Serialize first lets STJ auto-populate the resolver via
+            // its normal lazy path, after which MakeReadOnly(false)
+            // is a pure lock with no side effect on serialization.
+            JsonSerializer.Serialize<object>(null, _defaultOptions);
+            JsonSerializer.Serialize<object>(null, _indentOptions);
+
+            // Freeze both singletons so callers cannot mutate the
+            // shared instance (adding a Converter, flipping
+            // WriteIndented, etc.). Attempted mutation throws
+            // InvalidOperationException — the fail-fast is preferable
+            // to silent cross-caller pollution, and the cold-path
+            // Convert branch stays open because it builds a fresh
+            // (non-read-only) options object per call.
+            _defaultOptions.MakeReadOnly(populateMissingResolver: false);
+            _indentOptions.MakeReadOnly(populateMissingResolver: false);
+#endif
+        }
+
         private static JsonSerializerOptions CreateOptions(bool indented)
         {
             return new JsonSerializerOptions
@@ -69,12 +102,34 @@ namespace MTConnect
         /// omitted on write (on net5+), numbers read from strings (on net5+),
         /// case-insensitive property names, and a depth limit of 1000.
         /// </summary>
+        /// <remarks>
+        /// This is a process-wide shared singleton; do NOT mutate the
+        /// returned instance's <see cref="JsonSerializerOptions.Converters"/>
+        /// collection or any writable property. The returned object is
+        /// marked <c>MakeReadOnly()</c> under <c>net8.0</c> and later;
+        /// attempted mutation throws <see cref="System.InvalidOperationException"/>.
+        /// On older TFMs (netstandard2.0, net4.6.1–net4.8, net6.0, net7.0)
+        /// the instance is not statically frozen but callers must still
+        /// treat it as immutable — mutating it silently corrupts every
+        /// other in-process serializer that shares the singleton.
+        /// </remarks>
         public static JsonSerializerOptions DefaultOptions => _defaultOptions;
 
         /// <summary>
         /// The indented variant of <see cref="DefaultOptions"/>, used when the
         /// formatter's <c>indentOutput</c> option is set.
         /// </summary>
+        /// <remarks>
+        /// This is a process-wide shared singleton; do NOT mutate the
+        /// returned instance's <see cref="JsonSerializerOptions.Converters"/>
+        /// collection or any writable property. The returned object is
+        /// marked <c>MakeReadOnly()</c> under <c>net8.0</c> and later;
+        /// attempted mutation throws <see cref="System.InvalidOperationException"/>.
+        /// On older TFMs (netstandard2.0, net4.6.1–net4.8, net6.0, net7.0)
+        /// the instance is not statically frozen but callers must still
+        /// treat it as immutable — mutating it silently corrupts every
+        /// other in-process serializer that shares the singleton.
+        /// </remarks>
         public static JsonSerializerOptions IndentOptions => _indentOptions;
 
 

--- a/libraries/MTConnect.NET-MQTT/MTConnectMqttMessage.cs
+++ b/libraries/MTConnect.NET-MQTT/MTConnectMqttMessage.cs
@@ -23,6 +23,12 @@ namespace MTConnect.Mqtt
     /// </summary>
     public static class MTConnectMqttMessage
     {
+        // Shared across every agent-information publish. See
+        // JsonFunctions.cs for the rationale — a fresh
+        // JsonSerializerOptions per call re-emits LCG DynamicMethods
+        // into the loader heap, and the GC cannot reclaim them.
+        private static readonly JsonSerializerOptions _agentInformationOptions = new JsonSerializerOptions { WriteIndented = true };
+
         private static MqttApplicationMessage CreateMessage(string topic, string payload, bool retain = false)
         {
             try
@@ -91,7 +97,7 @@ namespace MTConnect.Mqtt
                     }
 
                     var topic = $"MTConnect/Agents/{agent.Uuid}/Information";
-                    var json = JsonSerializer.Serialize(information, new JsonSerializerOptions { WriteIndented = true });
+                    var json = JsonSerializer.Serialize(information, _agentInformationOptions);
 
                     messages.Add(CreateMessage(topic, json, retain));
                 }

--- a/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/Regressions/MTConnectMqttMessageSingletonTests.cs
+++ b/tests/MTConnect.NET-AgentModule-MqttRelay-Tests/Regressions/MTConnectMqttMessageSingletonTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Text.Json;
+using MTConnect.Mqtt;
+using NUnit.Framework;
+
+namespace MTConnect.AgentModule.MqttRelay.Tests.Regressions
+{
+    /// <summary>
+    /// Sibling-site structural pin for the DIME-connector native-heap leak
+    /// (peer diagnosis dated 2026-08-21). <see cref="MTConnectMqttMessage"/>
+    /// (in MTConnect.NET-MQTT) is the fifth per-call-<c>new JsonSerializerOptions</c>
+    /// site flipped to a shared static readonly field in PR #249; it lives in
+    /// a library MTConnect.NET-Common-Tests does not reference, so its
+    /// structural pin lives here in the MqttRelay test project which
+    /// transitively references MTConnect.NET-MQTT.
+    /// <para/>
+    /// Hosted under an MQTT-flavored publisher path — every /agent
+    /// information republish flows through
+    /// <c>MTConnectMqttMessage.CreateAgentInformation</c>, and its
+    /// <c>_agentInformationOptions</c> must be a shared singleton, not a
+    /// per-call allocation. See the sibling fixture
+    /// <c>JsonSerializerOptionsSiblingSingletonTests</c> in
+    /// <c>MTConnect.NET-Common-Tests</c> for the rationale and the twin
+    /// pins on the four Common sibling sites.
+    /// </summary>
+    [TestFixture]
+    public class MTConnectMqttMessageSingletonTests
+    {
+        /// <summary>
+        /// Pin: <see cref="MTConnectMqttMessage"/> serializes agent
+        /// information into every /Agents/{uuid}/Information republish.
+        /// Its <c>_agentInformationOptions</c> must be a shared singleton,
+        /// not a per-call allocation, so the LCG DynamicMethod
+        /// property-accessor emit is paid once at assembly load rather
+        /// than once per publish.
+        /// </summary>
+        [Test]
+        public void MTConnectMqttMessage_holds_a_static_readonly_JsonSerializerOptions_field()
+        {
+            var fields = typeof(MTConnectMqttMessage).GetFields(
+                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+            var optionsFields = System.Array.FindAll(
+                fields,
+                f => f.FieldType == typeof(JsonSerializerOptions) && f.IsInitOnly);
+            Assert.That(optionsFields.Length, Is.GreaterThanOrEqualTo(1),
+                "MTConnectMqttMessage must declare at least one static readonly JsonSerializerOptions field so " +
+                "the instance outlives each publish. A per-call `new JsonSerializerOptions(...)` re-emits LCG " +
+                "DynamicMethod property accessors on every call, and those emits accumulate in the runtime's " +
+                "loader heap where the GC cannot reclaim them (+3.2-3.8 MB/h RSS in production).");
+        }
+    }
+}

--- a/tests/MTConnect.NET-Common-Tests/Regressions/JsonSerializerOptionsSiblingSingletonTests.cs
+++ b/tests/MTConnect.NET-Common-Tests/Regressions/JsonSerializerOptionsSiblingSingletonTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Text.Json;
+using MTConnect.Agents;
+using MTConnect.Buffers;
+using MTConnect.Clients;
+using MTConnect.Configurations;
+using NUnit.Framework;
+
+namespace MTConnect.NET_Common_Tests.Regressions
+{
+    /// <summary>
+    /// Sibling-site structural pin for the DIME-connector native-heap leak
+    /// (peer diagnosis dated 2026-08-21). The primary singleton refactor
+    /// landed on <c>MTConnect.NET-JSON.JsonFunctions</c> and its cppagent
+    /// twin, but the same per-call <c>new JsonSerializerOptions(...)</c>
+    /// misuse existed at four other sites inside MTConnect.NET-Common that
+    /// also allocate an options object once per Save / Read / Write call:
+    /// <see cref="MTConnectAgentInformation"/>,
+    /// <see cref="MTConnectClientInformation"/>,
+    /// <see cref="MTConnectAssetFileBuffer"/>,
+    /// <see cref="AdapterApplicationConfiguration"/>, and
+    /// <see cref="AgentConfiguration"/>. Each was flipped to a
+    /// <c>private static readonly JsonSerializerOptions</c> field in
+    /// PR #249 so the LCG DynamicMethod property-accessor emit is paid
+    /// once per assembly-load instead of once per call.
+    /// <para/>
+    /// This fixture pins the STRUCTURAL shape (a private static
+    /// readonly JsonSerializerOptions field exists) rather than an
+    /// instance-identity via <c>ReferenceEquals</c>, because the fields
+    /// are private and un-exposed. A regression that either
+    /// (a) removes the field and re-inlines <c>new JsonSerializerOptions(...)</c>
+    /// per call, or (b) flips the field to instance / non-readonly, would
+    /// silently reintroduce the LCG leak; each pin below fails cleanly
+    /// on such a refactor. The MTConnect.NET-MQTT sibling
+    /// (<c>MTConnectMqttMessage._agentInformationOptions</c>) is pinned
+    /// in the MqttRelay test project because MTConnect.NET-Common-Tests
+    /// does not reference MTConnect.NET-MQTT.
+    /// </summary>
+    [TestFixture]
+    public class JsonSerializerOptionsSiblingSingletonTests
+    {
+        private static void AssertHoldsStaticReadonlyJsonSerializerOptionsField(System.Type type)
+        {
+            var fields = type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+            var optionsFields = System.Array.FindAll(
+                fields,
+                f => f.FieldType == typeof(JsonSerializerOptions) && f.IsInitOnly);
+            Assert.That(optionsFields.Length, Is.GreaterThanOrEqualTo(1),
+                $"{type.FullName} must declare at least one static readonly JsonSerializerOptions field so " +
+                "the instance outlives each serialization call. A per-call `new JsonSerializerOptions(...)` " +
+                "re-emits LCG DynamicMethod property accessors on every call, and those emits accumulate in " +
+                "the runtime's loader heap where the GC cannot reclaim them (+3.2-3.8 MB/h RSS in production).");
+        }
+
+        /// <summary>
+        /// Pin: <see cref="MTConnectAgentInformation"/> serializes itself to
+        /// disk on every Save call. Its <c>_saveOptions</c> must be a shared
+        /// singleton, not a per-call allocation.
+        /// </summary>
+        [Test]
+        public void MTConnectAgentInformation_holds_a_static_readonly_JsonSerializerOptions_field()
+        {
+            AssertHoldsStaticReadonlyJsonSerializerOptionsField(typeof(MTConnectAgentInformation));
+        }
+
+        /// <summary>
+        /// Pin: <see cref="MTConnectClientInformation"/> mirrors the Agent
+        /// information persistence pattern client-side. Its <c>_saveOptions</c>
+        /// must be a shared singleton, not a per-call allocation.
+        /// </summary>
+        [Test]
+        public void MTConnectClientInformation_holds_a_static_readonly_JsonSerializerOptions_field()
+        {
+            AssertHoldsStaticReadonlyJsonSerializerOptionsField(typeof(MTConnectClientInformation));
+        }
+
+        /// <summary>
+        /// Pin: <see cref="MTConnectAssetFileBuffer"/> writes one JSON file
+        /// per asset — potentially many per second under load. Its
+        /// <c>_writeOptions</c> must be a shared singleton, not a per-call
+        /// allocation.
+        /// </summary>
+        [Test]
+        public void MTConnectAssetFileBuffer_holds_a_static_readonly_JsonSerializerOptions_field()
+        {
+            AssertHoldsStaticReadonlyJsonSerializerOptionsField(typeof(MTConnectAssetFileBuffer));
+        }
+
+        /// <summary>
+        /// Pin: <see cref="AdapterApplicationConfiguration"/> deserializes
+        /// its config file on startup and on every reload. Its
+        /// <c>_readOptions</c> must be a shared singleton, not a per-call
+        /// allocation — hot-reload watchers can trigger many parses per
+        /// minute.
+        /// </summary>
+        [Test]
+        public void AdapterApplicationConfiguration_holds_a_static_readonly_JsonSerializerOptions_field()
+        {
+            AssertHoldsStaticReadonlyJsonSerializerOptionsField(typeof(AdapterApplicationConfiguration));
+        }
+
+        /// <summary>
+        /// Pin: <see cref="AgentConfiguration"/> deserializes its config file
+        /// on startup and on every reload. Same singleton discipline as
+        /// <see cref="AdapterApplicationConfiguration"/>.
+        /// </summary>
+        [Test]
+        public void AgentConfiguration_holds_a_static_readonly_JsonSerializerOptions_field()
+        {
+            AssertHoldsStaticReadonlyJsonSerializerOptionsField(typeof(AgentConfiguration));
+        }
+    }
+}

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -380,9 +380,11 @@ namespace MTConnect.NET_JSON_Tests.Regressions
         /// <summary>
         /// Warm-up-before-freeze ordering pin (net8+): the frozen singleton
         /// must still be able to serialize a real typed payload, proving that
-        /// the static-ctor warm-up (<c>JsonSerializer.Serialize&lt;object&gt;(null, _defaultOptions)</c>)
-        /// ran BEFORE <c>MakeReadOnly(populateMissingResolver: false)</c>. If a
-        /// future refactor reordered the two calls — or removed the warm-up
+        /// the static-ctor warm-up (typed <c>JsonSerializer.Serialize</c>
+        /// calls against each MTConnect top-level response surrogate — see
+        /// <c>JsonFunctions.WarmReachableGraph</c>) ran BEFORE
+        /// <c>MakeReadOnly(populateMissingResolver: false)</c>. If a future
+        /// refactor reordered the two calls — or removed the warm-up
         /// entirely — the frozen, resolver-less options would throw
         /// <see cref="System.NotSupportedException"/> on the first real-payload
         /// Serialize. The invariant is documented in the JsonFunctions static
@@ -404,7 +406,7 @@ namespace MTConnect.NET_JSON_Tests.Regressions
             string indented = string.Empty;
             Assert.DoesNotThrow(
                 () => compact = JsonSerializer.Serialize(payload, JsonFunctions.DefaultOptions),
-                "Frozen DefaultOptions must have a populated TypeInfoResolver — a static-ctor reorder that runs MakeReadOnly BEFORE the Serialize<object>(null, …) warm-up would surface here as NotSupportedException.");
+                "Frozen DefaultOptions must have a populated TypeInfoResolver — a static-ctor reorder that runs MakeReadOnly BEFORE the WarmReachableGraph typed-Serialize calls would surface here as NotSupportedException.");
             Assert.DoesNotThrow(
                 () => indented = JsonSerializer.Serialize(payload, JsonFunctions.IndentOptions),
                 "Frozen IndentOptions must have a populated TypeInfoResolver — same warm-up-before-freeze invariant as DefaultOptions.");

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -322,7 +322,7 @@ namespace MTConnect.NET_JSON_Tests.Regressions
         /// Async-throughput pin: 100 parallel Convert calls via
         /// Parallel.For to complement the Thread-based pin above. The
         /// ThreadPool scheduling differs from raw Thread scheduling, and
-        /// System.Text.Json's internal metadata-lock behaviour has
+        /// System.Text.Json's internal metadata-lock behavior has
         /// historically been sensitive to the difference; both paths are
         /// pinned so future STJ upgrades are covered.
         /// </summary>
@@ -346,5 +346,36 @@ namespace MTConnect.NET_JSON_Tests.Regressions
                 Assert.That(r, Is.EqualTo(canonical));
             }
         }
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Freeze pin (net8+): the shared DefaultOptions and IndentOptions
+        /// singletons must be marked read-only at static-ctor time, so any
+        /// attempt to mutate their <see cref="JsonSerializerOptions.Converters"/>
+        /// collection throws <see cref="System.InvalidOperationException"/>.
+        /// The freeze is the enforcement half of the singleton pattern —
+        /// documentation alone would let a careless caller silently pollute
+        /// every other in-process serializer; the read-only lock makes the
+        /// misuse fail loudly at the point of the offending Add.
+        /// </summary>
+        [Test]
+        public void DefaultOptions_Converters_Add_throws_InvalidOperationException_when_frozen()
+        {
+            Assert.Throws<System.InvalidOperationException>(
+                () => JsonFunctions.DefaultOptions.Converters.Add(new NoopConverter()),
+                "DefaultOptions is a shared singleton and must be frozen on net8+ so a stray Converters.Add fails fast rather than silently mutating the process-wide instance.");
+        }
+
+        /// <summary>
+        /// Freeze pin (net8+) — IndentOptions mirror of the DefaultOptions guard.
+        /// </summary>
+        [Test]
+        public void IndentOptions_Converters_Add_throws_InvalidOperationException_when_frozen()
+        {
+            Assert.Throws<System.InvalidOperationException>(
+                () => JsonFunctions.IndentOptions.Converters.Add(new NoopConverter()),
+                "IndentOptions is a shared singleton and must be frozen on net8+ so a stray Converters.Add fails fast rather than silently mutating the process-wide instance.");
+        }
+#endif
     }
 }

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -482,7 +482,7 @@ namespace MTConnect.NET_JSON_Tests.Regressions
         /// expected type OR a <c>ldsfld</c> loading a static field of
         /// that type — semantically equivalent for warm-up, because STJ
         /// walks the runtime type of whatever value the caller passes
-        /// into <see cref="System.Text.Json.JsonSerializer.Serialize"/>
+        /// into <see cref="System.Text.Json.JsonSerializer.Serialize{TValue}(TValue,System.Text.Json.JsonSerializerOptions)"/>
         /// regardless of how the instance was produced. The current
         /// warm-up uses <c>MTConnectVersions.Version25</c> (a static
         /// field of type <see cref="System.Version"/>) rather than a

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -415,6 +415,36 @@ namespace MTConnect.NET_JSON_Tests.Regressions
                 "The warmed-and-frozen singleton must still emit real property data — a resolver-less frozen options would either throw or emit empty output.");
             Assert.That(indented, Does.Contain("\"Name\""));
         }
+
+        /// <summary>
+        /// Warm-up coverage pin (net8+) — <c>MTConnect.Errors.ErrorResponseDocument</c>
+        /// is the fourth top-level response envelope written directly by
+        /// <c>JsonResponseDocumentFormatter.Format(IErrorResponseDocument, ...)</c>
+        /// without a Json* surrogate wrapper. The static-ctor
+        /// <c>WarmReachableGraph</c> pass must serialize an instance of it
+        /// against both option singletons BEFORE
+        /// <c>MakeReadOnly(populateMissingResolver: false)</c> — otherwise the
+        /// first error response (a /probe failure, unsupported device request,
+        /// or parse error) would pay a cold LCG DynamicMethod emit against
+        /// a frozen, resolver-less options and throw
+        /// <see cref="System.NotSupportedException"/>. Serializing a fresh
+        /// <see cref="MTConnect.Errors.ErrorResponseDocument"/> here reproduces
+        /// exactly that first-error path against the shared singletons; a
+        /// regression that dropped the Error warm-up would surface as a
+        /// NotSupportedException on this test.
+        /// </summary>
+        [Test]
+        public void Frozen_singleton_can_serialize_ErrorResponseDocument_proving_Error_warm_up_ran()
+        {
+            var document = new MTConnect.Errors.ErrorResponseDocument();
+
+            Assert.DoesNotThrow(
+                () => JsonSerializer.Serialize(document, JsonFunctions.DefaultOptions),
+                "Frozen DefaultOptions must have ErrorResponseDocument in its warmed TypeInfoResolver — a regression that removed the Error warm-up would surface here as NotSupportedException on the first error response.");
+            Assert.DoesNotThrow(
+                () => JsonSerializer.Serialize(document, JsonFunctions.IndentOptions),
+                "Frozen IndentOptions mirror — same Error warm-up invariant as DefaultOptions.");
+        }
 #endif
     }
 }

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -1,8 +1,13 @@
 // Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
 // TrakHound Inc. licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace MTConnect.NET_JSON_Tests.Regressions
@@ -26,6 +31,38 @@ namespace MTConnect.NET_JSON_Tests.Regressions
     [TestFixture]
     public class JsonSerializerOptionsSingletonTests
     {
+        // Small POCO used by the Convert/ConvertBytes/ConvertStream overload
+        // smoke tests and the thread-safety pin. Kept tiny on purpose so
+        // the metadata cache warms in a single JIT pass and each thread's
+        // work is bounded, but with a nested type so the reachable-graph
+        // JIT emit still runs on cold DefaultOptions instances.
+        internal class SamplePayload
+        {
+            public string Name { get; set; } = "sample";
+            public int Count { get; set; } = 42;
+            public SampleChild Child { get; set; } = new SampleChild();
+        }
+
+        internal class SampleChild
+        {
+            public string Label { get; set; } = "child";
+            public double Value { get; set; } = 3.14;
+        }
+
+        private sealed class NoopConverter : JsonConverter<SamplePayload>
+        {
+            public override SamplePayload Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+                => new SamplePayload();
+
+            public override void Write(Utf8JsonWriter writer, SamplePayload value, JsonSerializerOptions options)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("Name", value.Name);
+                writer.WriteNumber("Count", value.Count);
+                writer.WriteEndObject();
+            }
+        }
+
         /// <summary>Pins the behaviour expressed by the test name: default options returns the same instance on repeat access.</summary>
         [Test]
         public void DefaultOptions_returns_the_same_instance_on_repeat_access()
@@ -79,6 +116,235 @@ namespace MTConnect.NET_JSON_Tests.Regressions
             var optionsFields = System.Array.FindAll(fields, f => f.FieldType == typeof(JsonSerializerOptions) && f.IsInitOnly);
             Assert.That(optionsFields.Length, Is.GreaterThanOrEqualTo(2),
                 "JsonFunctions must declare shared static readonly JsonSerializerOptions fields (compact + indented) so the instances outlive each serialisation call.");
+        }
+
+        /// <summary>
+        /// Thread-safety pin: 100 concurrent Convert calls against the shared
+        /// DefaultOptions must all succeed, must not throw, and must produce
+        /// byte-identical output. JsonSerializerOptions is documented as
+        /// thread-safe for read after its first (de)serialization call, so
+        /// concurrent Serialize calls sharing one instance is legal by
+        /// contract — this test pins that contract against any future
+        /// refactor that would put a mutation on the hot path.
+        /// </summary>
+        [Test]
+        public void Convert_is_thread_safe_across_100_concurrent_callers()
+        {
+            const int threadCount = 100;
+            var payload = new SamplePayload();
+            var outputs = new ConcurrentBag<string>();
+            var exceptions = new ConcurrentBag<System.Exception>();
+            var startGate = new ManualResetEventSlim(false);
+
+            var threads = new Thread[threadCount];
+            for (int i = 0; i < threadCount; i++)
+            {
+                threads[i] = new Thread(() =>
+                {
+                    try
+                    {
+                        startGate.Wait();
+                        var s = JsonFunctions.Convert(payload);
+                        outputs.Add(s);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                });
+                threads[i].Start();
+            }
+
+            // Warm the singleton once on the driver thread so the first-use
+            // metadata build is not itself concurrent with the race window.
+            // The point of the pin is steady-state hot-path concurrency, not
+            // first-touch racing (STJ handles that internally).
+            _ = JsonFunctions.Convert(payload);
+
+            startGate.Set();
+            foreach (var t in threads) t.Join();
+
+            Assert.That(exceptions, Is.Empty,
+                "Concurrent Convert calls against the shared DefaultOptions must not throw.");
+            Assert.That(outputs.Count, Is.EqualTo(threadCount));
+
+            var canonical = JsonFunctions.Convert(payload);
+            foreach (var s in outputs)
+            {
+                Assert.That(s, Is.EqualTo(canonical),
+                    "Every concurrent Convert output must be byte-identical to the single-threaded canonical output.");
+            }
+        }
+
+        /// <summary>
+        /// Cold-path pin: when a caller supplies a per-call converter, the
+        /// implementation must NOT append that converter to the shared
+        /// DefaultOptions.Converters collection. Doing so would (a) permanently
+        /// pollute the singleton and (b) throw InvalidOperationException
+        /// because JsonSerializerOptions freezes its converter list after
+        /// first use. The pin observes the singleton before and after a
+        /// converter-supplied Convert call and asserts the count is unchanged.
+        /// </summary>
+        [Test]
+        public void Convert_with_custom_converter_does_not_mutate_DefaultOptions_converters()
+        {
+            // Warm the singleton so its converters list is frozen — if the
+            // implementation ever tried to append to it, the test would
+            // observe an exception path rather than silent pollution.
+            _ = JsonFunctions.Convert(new SamplePayload());
+
+            var beforeCount = JsonFunctions.DefaultOptions.Converters.Count;
+            var beforeIndentCount = JsonFunctions.IndentOptions.Converters.Count;
+
+            var converter = new NoopConverter();
+            var result = JsonFunctions.Convert(new SamplePayload(), converter);
+            var resultIndented = JsonFunctions.Convert(new SamplePayload(), converter, indented: true);
+
+            Assert.That(result, Is.Not.Null,
+                "Convert with a custom converter must succeed via the cold-path fresh-options branch.");
+            Assert.That(resultIndented, Is.Not.Null,
+                "Convert(indented:true) with a custom converter must succeed via the cold-path fresh-options branch.");
+
+            Assert.That(JsonFunctions.DefaultOptions.Converters.Count, Is.EqualTo(beforeCount),
+                "The cold-path branch must build a fresh JsonSerializerOptions — a caller-supplied converter must never leak into DefaultOptions.Converters.");
+            Assert.That(JsonFunctions.IndentOptions.Converters.Count, Is.EqualTo(beforeIndentCount),
+                "The cold-path branch must build a fresh JsonSerializerOptions — a caller-supplied converter must never leak into IndentOptions.Converters.");
+        }
+
+        /// <summary>
+        /// Cold-path pin: the custom-converter Convert output must reflect
+        /// the caller's converter (proving the fresh options object used
+        /// it), while a following converter-less Convert on the same input
+        /// must NOT reflect the converter (proving the singleton was untouched).
+        /// </summary>
+        [Test]
+        public void Convert_with_custom_converter_uses_converter_without_affecting_singleton_output()
+        {
+            var payload = new SamplePayload();
+            var canonicalWithoutConverter = JsonFunctions.Convert(payload);
+
+            var converter = new NoopConverter();
+            var withConverter = JsonFunctions.Convert(payload, converter);
+
+            // The custom converter drops the Child property, so its output
+            // must not equal the canonical singleton-emitted output.
+            Assert.That(withConverter, Is.Not.EqualTo(canonicalWithoutConverter),
+                "The cold-path fresh options must apply the caller's converter — otherwise the singleton was reused, defeating the branch.");
+            Assert.That(withConverter, Does.Not.Contain("Child"),
+                "NoopConverter drops the Child field; the cold-path output should reflect that.");
+
+            // Following singleton-path call must be untouched.
+            var afterCanonical = JsonFunctions.Convert(payload);
+            Assert.That(afterCanonical, Is.EqualTo(canonicalWithoutConverter),
+                "After a converter-supplied call, the singleton-path output must be byte-identical to before.");
+            Assert.That(afterCanonical, Does.Contain("Child"),
+                "The singleton must still emit the Child field — the cold-path converter must not have polluted it.");
+        }
+
+        /// <summary>
+        /// Overload smoke pin: Convert/ConvertBytes/ConvertStream must all
+        /// produce the same JSON for the same input under the compact
+        /// preset, and the indented variants must be internally consistent.
+        /// This guards against a future refactor that accidentally routes
+        /// one overload through a divergent options instance.
+        /// </summary>
+        [Test]
+        public void Convert_ConvertBytes_ConvertStream_produce_identical_output_for_compact()
+        {
+            var payload = new SamplePayload();
+
+            var s = JsonFunctions.Convert(payload);
+            var bytes = JsonFunctions.ConvertBytes(payload);
+            var stream = JsonFunctions.ConvertStream(payload);
+
+            Assert.That(s, Is.Not.Null);
+            Assert.That(bytes, Is.Not.Null);
+            Assert.That(stream, Is.Not.Null);
+
+            var bytesString = Encoding.UTF8.GetString(bytes!);
+            Assert.That(bytesString, Is.EqualTo(s),
+                "ConvertBytes(UTF-8) must decode to the same string ConvertBytes emits.");
+
+            stream!.Position = 0;
+            using var reader = new System.IO.StreamReader(stream);
+            var streamString = reader.ReadToEnd();
+            Assert.That(streamString, Is.EqualTo(s),
+                "ConvertStream must contain the same JSON Convert returns.");
+        }
+
+        /// <summary>Overload smoke pin — indented variant of the same guard.</summary>
+        [Test]
+        public void Convert_ConvertBytes_ConvertStream_produce_identical_output_for_indented()
+        {
+            var payload = new SamplePayload();
+
+            var s = JsonFunctions.Convert(payload, indented: true);
+            var bytes = JsonFunctions.ConvertBytes(payload, indented: true);
+            var stream = JsonFunctions.ConvertStream(payload, indented: true);
+
+            Assert.That(s, Is.Not.Null);
+            Assert.That(bytes, Is.Not.Null);
+            Assert.That(stream, Is.Not.Null);
+
+            var bytesString = Encoding.UTF8.GetString(bytes!);
+            Assert.That(bytesString, Is.EqualTo(s));
+
+            stream!.Position = 0;
+            using var reader = new System.IO.StreamReader(stream);
+            var streamString = reader.ReadToEnd();
+            Assert.That(streamString, Is.EqualTo(s));
+
+            // Cross-check indentation is present (crude, but sufficient
+            // to pin that IndentOptions actually took effect on all
+            // three overloads).
+            Assert.That(s, Does.Contain("\n"),
+                "Indented Convert output must contain newlines.");
+            Assert.That(bytesString, Does.Contain("\n"),
+                "Indented ConvertBytes output must contain newlines.");
+            Assert.That(streamString, Does.Contain("\n"),
+                "Indented ConvertStream output must contain newlines.");
+        }
+
+        /// <summary>
+        /// Null-input pin: every overload must swallow a null input and
+        /// return null / null / null — this is documented behaviour and
+        /// the singleton refactor must preserve it.
+        /// </summary>
+        [Test]
+        public void Convert_overloads_return_null_for_null_input()
+        {
+            Assert.That(JsonFunctions.Convert(null), Is.Null);
+            Assert.That(JsonFunctions.ConvertBytes(null), Is.Null);
+            Assert.That(JsonFunctions.ConvertStream(null), Is.Null);
+        }
+
+        /// <summary>
+        /// Async-throughput pin: 100 parallel Convert calls via
+        /// Parallel.For to complement the Thread-based pin above. The
+        /// ThreadPool scheduling differs from raw Thread scheduling, and
+        /// System.Text.Json's internal metadata-lock behaviour has
+        /// historically been sensitive to the difference; both paths are
+        /// pinned so future STJ upgrades are covered.
+        /// </summary>
+        [Test]
+        public void Convert_is_thread_safe_under_ParallelFor()
+        {
+            _ = JsonFunctions.Convert(new SamplePayload()); // warm
+
+            var canonical = JsonFunctions.Convert(new SamplePayload());
+            var results = new ConcurrentBag<string>();
+
+            Parallel.For(0, 100, _ =>
+            {
+                var s = JsonFunctions.Convert(new SamplePayload());
+                results.Add(s);
+            });
+
+            Assert.That(results.Count, Is.EqualTo(100));
+            foreach (var r in results)
+            {
+                Assert.That(r, Is.EqualTo(canonical));
+            }
         }
     }
 }

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -376,6 +376,43 @@ namespace MTConnect.NET_JSON_Tests.Regressions
                 () => JsonFunctions.IndentOptions.Converters.Add(new NoopConverter()),
                 "IndentOptions is a shared singleton and must be frozen on net8+ so a stray Converters.Add fails fast rather than silently mutating the process-wide instance.");
         }
+
+        /// <summary>
+        /// Warm-up-before-freeze ordering pin (net8+): the frozen singleton
+        /// must still be able to serialize a real typed payload, proving that
+        /// the static-ctor warm-up (<c>JsonSerializer.Serialize&lt;object&gt;(null, _defaultOptions)</c>)
+        /// ran BEFORE <c>MakeReadOnly(populateMissingResolver: false)</c>. If a
+        /// future refactor reordered the two calls — or removed the warm-up
+        /// entirely — the frozen, resolver-less options would throw
+        /// <see cref="System.NotSupportedException"/> on the first real-payload
+        /// Serialize. The invariant is documented in the JsonFunctions static
+        /// ctor comment ("Order matters: the warm-up must run BEFORE
+        /// MakeReadOnly"); this test names it as a regression pin.
+        /// <para/>
+        /// Calls <see cref="JsonSerializer.Serialize{TValue}(TValue, JsonSerializerOptions)"/>
+        /// directly rather than via <see cref="JsonFunctions.Convert"/> because
+        /// Convert's catch-all silently swallows serialization exceptions into
+        /// a null return — routing through it would degrade a diagnostic
+        /// "NotSupportedException at Serialize" into an opaque "Expected: not null".
+        /// </summary>
+        [Test]
+        public void Frozen_singleton_can_serialize_a_real_payload_proving_warm_up_ran_before_MakeReadOnly()
+        {
+            var payload = new SamplePayload();
+
+            string compact = string.Empty;
+            string indented = string.Empty;
+            Assert.DoesNotThrow(
+                () => compact = JsonSerializer.Serialize(payload, JsonFunctions.DefaultOptions),
+                "Frozen DefaultOptions must have a populated TypeInfoResolver — a static-ctor reorder that runs MakeReadOnly BEFORE the Serialize<object>(null, …) warm-up would surface here as NotSupportedException.");
+            Assert.DoesNotThrow(
+                () => indented = JsonSerializer.Serialize(payload, JsonFunctions.IndentOptions),
+                "Frozen IndentOptions must have a populated TypeInfoResolver — same warm-up-before-freeze invariant as DefaultOptions.");
+
+            Assert.That(compact, Does.Contain("\"Name\""),
+                "The warmed-and-frozen singleton must still emit real property data — a resolver-less frozen options would either throw or emit empty output.");
+            Assert.That(indented, Does.Contain("\"Name\""));
+        }
 #endif
     }
 }

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace MTConnect.NET_JSON_Tests.Regressions
+{
+    /// <summary>
+    /// Regression pin for the DIME-connector native-heap leak (peer
+    /// diagnosis dated 2026-08-21). A fresh <see cref="JsonSerializerOptions"/>
+    /// instance owns its own serialisation-metadata cache; building that
+    /// cache emits reflection-based property accessors for the entire type
+    /// graph, and the emitted code accumulates in the runtime's loader
+    /// heaps where the GC cannot reclaim it. Allocating one on every
+    /// serialisation call therefore leaked ~3.3 MB/h RSS in production
+    /// (tempco-001, tim-001).
+    ///
+    /// The <see cref="JsonFunctions.DefaultOptions"/> and
+    /// <see cref="JsonFunctions.IndentOptions"/> properties must therefore
+    /// return the same instance on every access, and the
+    /// <c>Convert</c>/<c>ConvertBytes</c>/<c>ConvertStream</c> hot paths
+    /// must reuse those instances when no per-call converter is supplied.
+    /// </summary>
+    [TestFixture]
+    public class JsonSerializerOptionsSingletonTests
+    {
+        /// <summary>Pins the behaviour expressed by the test name: default options returns the same instance on repeat access.</summary>
+        [Test]
+        public void DefaultOptions_returns_the_same_instance_on_repeat_access()
+        {
+            var a = JsonFunctions.DefaultOptions;
+            var b = JsonFunctions.DefaultOptions;
+            Assert.That(ReferenceEquals(a, b), Is.True,
+                "JsonFunctions.DefaultOptions must be a shared singleton — a fresh JsonSerializerOptions per call leaks LCG-emitted metadata into the loader heap.");
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: indent options returns the same instance on repeat access.</summary>
+        [Test]
+        public void IndentOptions_returns_the_same_instance_on_repeat_access()
+        {
+            var a = JsonFunctions.IndentOptions;
+            var b = JsonFunctions.IndentOptions;
+            Assert.That(ReferenceEquals(a, b), Is.True,
+                "JsonFunctions.IndentOptions must be a shared singleton — a fresh JsonSerializerOptions per call leaks LCG-emitted metadata into the loader heap.");
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: default options and indent options are distinct instances.</summary>
+        [Test]
+        public void DefaultOptions_and_IndentOptions_are_distinct_instances()
+        {
+            Assert.That(ReferenceEquals(JsonFunctions.DefaultOptions, JsonFunctions.IndentOptions), Is.False,
+                "DefaultOptions (compact) and IndentOptions (pretty-printed) must be separate instances so WriteIndented differs.");
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: default options write indented is false.</summary>
+        [Test]
+        public void DefaultOptions_WriteIndented_is_false()
+        {
+            Assert.That(JsonFunctions.DefaultOptions.WriteIndented, Is.False);
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: indent options write indented is true.</summary>
+        [Test]
+        public void IndentOptions_WriteIndented_is_true()
+        {
+            Assert.That(JsonFunctions.IndentOptions.WriteIndented, Is.True);
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: json functions holds a static readonly options field.</summary>
+        [Test]
+        public void JsonFunctions_holds_a_static_readonly_options_field()
+        {
+            // Structural guard: at least one static readonly field of type
+            // JsonSerializerOptions must exist on JsonFunctions so the
+            // shared instance survives across serialisation calls.
+            var fields = typeof(JsonFunctions).GetFields(BindingFlags.NonPublic | BindingFlags.Static);
+            var optionsFields = System.Array.FindAll(fields, f => f.FieldType == typeof(JsonSerializerOptions) && f.IsInitOnly);
+            Assert.That(optionsFields.Length, Is.GreaterThanOrEqualTo(2),
+                "JsonFunctions must declare shared static readonly JsonSerializerOptions fields (compact + indented) so the instances outlive each serialisation call.");
+        }
+    }
+}

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -474,16 +474,28 @@ namespace MTConnect.NET_JSON_Tests.Regressions
         /// MTConnectErrorHeader (9 properties), Error (2), and
         /// System.Version (6) would each pay their first cold accessor
         /// emit on the first real <c>/probe</c> error or parse failure.
-        /// The three <c>newobj</c> instructions below are the source-of-truth
-        /// evidence that the populated warm-up shape survives.
+        /// The three assertions below are the source-of-truth evidence
+        /// that the populated warm-up shape survives.
         /// <para/>
-        /// System.Version is not news-up-ed by the three surrogate
-        /// envelopes' Header defaulting (they use their own concrete
-        /// <c>MTConnectStreamsHeader</c> / <c>MTConnectDevicesHeader</c> /
-        /// <c>MTConnectAssetsHeader</c> and initialize the Version property
-        /// only after construction), so the walker match on
-        /// <c>System.Version</c> uniquely fingerprints the Error-envelope
-        /// initializer.
+        /// The walker (<see cref="AssertWarmReachableGraphNewsUp"/>)
+        /// accepts either a <c>newobj</c> producing an instance of the
+        /// expected type OR a <c>ldsfld</c> loading a static field of
+        /// that type — semantically equivalent for warm-up, because STJ
+        /// walks the runtime type of whatever value the caller passes
+        /// into <see cref="System.Text.Json.JsonSerializer.Serialize"/>
+        /// regardless of how the instance was produced. The current
+        /// warm-up uses <c>MTConnectVersions.Version25</c> (a static
+        /// field of type <see cref="System.Version"/>) rather than a
+        /// magic <c>new System.Version(2, 5)</c> literal (F-CR-C6-001);
+        /// dropping either producer would fail the pin.
+        /// <para/>
+        /// System.Version is not news-up-ed OR ldsfld-loaded by the
+        /// three surrogate envelopes' Header defaulting (they use their
+        /// own concrete <c>MTConnectStreamsHeader</c> /
+        /// <c>MTConnectDevicesHeader</c> / <c>MTConnectAssetsHeader</c>
+        /// and initialize the Version property only after construction),
+        /// so the walker match on <c>System.Version</c> uniquely
+        /// fingerprints the Error-envelope initializer.
         /// </summary>
         [Test]
         public void WarmReachableGraph_IL_contains_newobj_for_concrete_Error_envelope_fields()
@@ -493,17 +505,27 @@ namespace MTConnect.NET_JSON_Tests.Regressions
             AssertWarmReachableGraphNewsUp(typeof(System.Version));
         }
 
-        // IL walker: locate a `newobj <ctor-of-expected>` instruction inside
-        // JsonFunctions.WarmReachableGraph. Runs on the compiled test assembly's
-        // view of MTConnect.NET-JSON, so a source change that removes the
-        // corresponding new-expression is caught deterministically at test time.
+        // IL walker: proves JsonFunctions.WarmReachableGraph feeds a concrete
+        // instance of <paramref name="expected"/> to STJ by locating EITHER a
+        // `newobj <ctor-of-expected>` (fresh allocation) OR a
+        // `ldsfld <static-field-of-type-expected>` (canonical-constant load)
+        // in the method body. Runs on the compiled test assembly's view of
+        // MTConnect.NET-JSON, so a source change that removes both producers
+        // is caught deterministically at test time.
         //
-        // Scans for the 5-byte pattern <newobj:0x73> <4-byte-token>. Full
-        // opcode-length decoding is unnecessary: a spurious match would need a
-        // non-newobj opcode at byte i whose following 4 bytes coincidentally
-        // decode to a valid MemberRef token whose ResolveMethod returns a ctor
-        // of the target type — inside a ~35-byte method body, practically
+        // Scans for the 5-byte patterns <newobj:0x73> <4-byte-token> and
+        // <ldsfld:0x7E> <4-byte-token>. Full opcode-length decoding is
+        // unnecessary: a spurious match would need a non-target opcode at
+        // byte i whose following 4 bytes coincidentally decode to a valid
+        // MemberRef token whose ResolveMethod/ResolveField returns a target
+        // of the expected type — inside a ~40-byte method body, practically
         // impossible.
+        //
+        // Both producers are semantically equivalent for warm-up: STJ walks
+        // the runtime type of the value passed into Serialize, and cannot
+        // tell whether the instance came from a fresh newobj or from a
+        // static field load (e.g. MTConnectVersions.Version25 for
+        // System.Version).
         private static void AssertWarmReachableGraphNewsUp(System.Type expected)
         {
             var method = typeof(JsonFunctions).GetMethod(
@@ -520,20 +542,36 @@ namespace MTConnect.NET_JSON_Tests.Regressions
 
             for (int i = 0; i + 4 < il!.Length; i++)
             {
-                if (il[i] != 0x73) continue;
-                int token = System.BitConverter.ToInt32(il, i + 1);
-                System.Reflection.MethodBase? resolved;
-                try { resolved = module.ResolveMethod(token); }
-                catch { continue; }
-                if (resolved is System.Reflection.ConstructorInfo ctor
-                    && ctor.DeclaringType == expected)
+                if (il[i] == 0x73)
                 {
-                    return;
+                    // newobj <ctor>
+                    int token = System.BitConverter.ToInt32(il, i + 1);
+                    System.Reflection.MethodBase? resolved;
+                    try { resolved = module.ResolveMethod(token); }
+                    catch { continue; }
+                    if (resolved is System.Reflection.ConstructorInfo ctor
+                        && ctor.DeclaringType == expected)
+                    {
+                        return;
+                    }
+                }
+                else if (il[i] == 0x7E)
+                {
+                    // ldsfld <static-field>
+                    int token = System.BitConverter.ToInt32(il, i + 1);
+                    System.Reflection.FieldInfo? field;
+                    try { field = module.ResolveField(token); }
+                    catch { continue; }
+                    if (field != null && field.FieldType == expected)
+                    {
+                        return;
+                    }
                 }
             }
 
             Assert.Fail(
-                $"WarmReachableGraph must contain a newobj IL instruction for {expected.FullName}. " +
+                $"WarmReachableGraph must produce a concrete instance of {expected.FullName} " +
+                "(via `new` or via a static-field load) so STJ walks its accessor graph at assembly load. " +
                 "Without it, the first request that hits this envelope pays a cold LCG DynamicMethod emit " +
                 "against the frozen singleton — which is the +3.2-3.8 MB/h RSS leak-in-miniature the warm-up exists to prevent.");
         }

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -460,6 +460,39 @@ namespace MTConnect.NET_JSON_Tests.Regressions
             AssertWarmReachableGraphNewsUp(typeof(MTConnect.Devices.Json.JsonDevicesDocument));
         }
 
+        /// <summary>
+        /// Structural warm-up-coverage pin (net8+) — companion assertion for
+        /// the F-IMP-C5-001 fix that populated the Error envelope with a
+        /// concrete <see cref="MTConnect.Headers.MTConnectErrorHeader"/> +
+        /// <see cref="MTConnect.Errors.Error"/> + <see cref="System.Version"/>.
+        /// STJ resolves accessors for interface-typed properties
+        /// (<c>IMTConnectErrorHeader Header</c>, <c>IEnumerable&lt;IError&gt; Errors</c>)
+        /// only when the value is non-null; a revert to a naked
+        /// <c>new ErrorResponseDocument()</c> would silently pass the
+        /// ErrorResponseDocument-only IL pin above while re-opening the
+        /// exact LCG-emit-on-first-error class F-IMP-C5-001 closed —
+        /// MTConnectErrorHeader (9 properties), Error (2), and
+        /// System.Version (6) would each pay their first cold accessor
+        /// emit on the first real <c>/probe</c> error or parse failure.
+        /// The three <c>newobj</c> instructions below are the source-of-truth
+        /// evidence that the populated warm-up shape survives.
+        /// <para/>
+        /// System.Version is not news-up-ed by the three surrogate
+        /// envelopes' Header defaulting (they use their own concrete
+        /// <c>MTConnectStreamsHeader</c> / <c>MTConnectDevicesHeader</c> /
+        /// <c>MTConnectAssetsHeader</c> and initialize the Version property
+        /// only after construction), so the walker match on
+        /// <c>System.Version</c> uniquely fingerprints the Error-envelope
+        /// initializer.
+        /// </summary>
+        [Test]
+        public void WarmReachableGraph_IL_contains_newobj_for_concrete_Error_envelope_fields()
+        {
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Headers.MTConnectErrorHeader));
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Errors.Error));
+            AssertWarmReachableGraphNewsUp(typeof(System.Version));
+        }
+
         // IL walker: locate a `newobj <ctor-of-expected>` instruction inside
         // JsonFunctions.WarmReachableGraph. Runs on the compiled test assembly's
         // view of MTConnect.NET-JSON, so a source change that removes the

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -417,33 +417,92 @@ namespace MTConnect.NET_JSON_Tests.Regressions
         }
 
         /// <summary>
-        /// Warm-up coverage pin (net8+) — <c>MTConnect.Errors.ErrorResponseDocument</c>
-        /// is the fourth top-level response envelope written directly by
+        /// Structural warm-up-coverage pin (net8+) — <c>WarmReachableGraph</c>'s
+        /// IL must contain a <c>newobj</c> instruction constructing
+        /// <see cref="MTConnect.Errors.ErrorResponseDocument"/>, the fourth
+        /// top-level response envelope written directly by
         /// <c>JsonResponseDocumentFormatter.Format(IErrorResponseDocument, ...)</c>
-        /// without a Json* surrogate wrapper. The static-ctor
-        /// <c>WarmReachableGraph</c> pass must serialize an instance of it
-        /// against both option singletons BEFORE
-        /// <c>MakeReadOnly(populateMissingResolver: false)</c> — otherwise the
-        /// first error response (a /probe failure, unsupported device request,
-        /// or parse error) would pay a cold LCG DynamicMethod emit against
-        /// a frozen, resolver-less options and throw
-        /// <see cref="System.NotSupportedException"/>. Serializing a fresh
-        /// <see cref="MTConnect.Errors.ErrorResponseDocument"/> here reproduces
-        /// exactly that first-error path against the shared singletons; a
-        /// regression that dropped the Error warm-up would surface as a
-        /// NotSupportedException on this test.
+        /// without a Json* surrogate wrapper.
+        /// <para/>
+        /// A runtime <c>Assert.DoesNotThrow(() =&gt; Serialize(new ErrorResponseDocument(), frozen))</c>
+        /// check is tautological here: once the TypeInfoResolver is set (which
+        /// any preceding warm-up call does), STJ's <see cref="System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver"/>
+        /// lazily populates <see cref="System.Text.Json.Serialization.Metadata.JsonTypeInfo"/>
+        /// on frozen options for arbitrary types — the frozen state only locks
+        /// the options' configuration surface (Converters, DefaultIgnoreCondition,
+        /// etc.), not the internal metadata cache. Verified empirically:
+        /// mutating out the <c>ErrorResponseDocument</c> warm-up line and running
+        /// the "can it serialize" pin still passes (see cycle-5 test-coverage-audit
+        /// mutation test 2026-08-21). The performance invariant the warm-up
+        /// enforces — pay the LCG DynamicMethod emit for ErrorResponseDocument
+        /// at assembly load, not on the first /probe error / parse-failure
+        /// request — is therefore only observable at the source-of-truth level:
+        /// the IL of <c>WarmReachableGraph</c>.
         /// </summary>
         [Test]
-        public void Frozen_singleton_can_serialize_ErrorResponseDocument_proving_Error_warm_up_ran()
+        public void WarmReachableGraph_IL_contains_newobj_for_ErrorResponseDocument_ctor()
         {
-            var document = new MTConnect.Errors.ErrorResponseDocument();
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Errors.ErrorResponseDocument));
+        }
 
-            Assert.DoesNotThrow(
-                () => JsonSerializer.Serialize(document, JsonFunctions.DefaultOptions),
-                "Frozen DefaultOptions must have ErrorResponseDocument in its warmed TypeInfoResolver — a regression that removed the Error warm-up would surface here as NotSupportedException on the first error response.");
-            Assert.DoesNotThrow(
-                () => JsonSerializer.Serialize(document, JsonFunctions.IndentOptions),
-                "Frozen IndentOptions mirror — same Error warm-up invariant as DefaultOptions.");
+        /// <summary>
+        /// Structural warm-up-coverage pin (net8+) — companion assertion that
+        /// each of the three Json* top-level response surrogates is also
+        /// news-up-ed by <c>WarmReachableGraph</c>. Mirrors the ErrorResponseDocument
+        /// pin above; the same tautology argument applies to per-type
+        /// "can it serialize" runtime checks.
+        /// </summary>
+        [Test]
+        public void WarmReachableGraph_IL_contains_newobj_for_every_top_level_response_surrogate()
+        {
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Streams.Json.JsonStreamsDocument));
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Assets.Json.JsonAssetsDocument));
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Devices.Json.JsonDevicesDocument));
+        }
+
+        // IL walker: locate a `newobj <ctor-of-expected>` instruction inside
+        // JsonFunctions.WarmReachableGraph. Runs on the compiled test assembly's
+        // view of MTConnect.NET-JSON, so a source change that removes the
+        // corresponding new-expression is caught deterministically at test time.
+        //
+        // Scans for the 5-byte pattern <newobj:0x73> <4-byte-token>. Full
+        // opcode-length decoding is unnecessary: a spurious match would need a
+        // non-newobj opcode at byte i whose following 4 bytes coincidentally
+        // decode to a valid MemberRef token whose ResolveMethod returns a ctor
+        // of the target type — inside a ~35-byte method body, practically
+        // impossible.
+        private static void AssertWarmReachableGraphNewsUp(System.Type expected)
+        {
+            var method = typeof(JsonFunctions).GetMethod(
+                "WarmReachableGraph",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(method, Is.Not.Null,
+                "JsonFunctions.WarmReachableGraph private static method must exist.");
+            var body = method!.GetMethodBody();
+            Assert.That(body, Is.Not.Null,
+                "WarmReachableGraph must have a method body (not abstract / p-invoke).");
+            var il = body!.GetILAsByteArray();
+            Assert.That(il, Is.Not.Null);
+            var module = method.Module;
+
+            for (int i = 0; i + 4 < il!.Length; i++)
+            {
+                if (il[i] != 0x73) continue;
+                int token = System.BitConverter.ToInt32(il, i + 1);
+                System.Reflection.MethodBase? resolved;
+                try { resolved = module.ResolveMethod(token); }
+                catch { continue; }
+                if (resolved is System.Reflection.ConstructorInfo ctor
+                    && ctor.DeclaringType == expected)
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                $"WarmReachableGraph must contain a newobj IL instruction for {expected.FullName}. " +
+                "Without it, the first request that hits this envelope pays a cold LCG DynamicMethod emit " +
+                "against the frozen singleton — which is the +3.2-3.8 MB/h RSS leak-in-miniature the warm-up exists to prevent.");
         }
 #endif
     }

--- a/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -15,11 +15,11 @@ namespace MTConnect.NET_JSON_Tests.Regressions
     /// <summary>
     /// Regression pin for the DIME-connector native-heap leak (peer
     /// diagnosis dated 2026-08-21). A fresh <see cref="JsonSerializerOptions"/>
-    /// instance owns its own serialisation-metadata cache; building that
+    /// instance owns its own serialization-metadata cache; building that
     /// cache emits reflection-based property accessors for the entire type
     /// graph, and the emitted code accumulates in the runtime's loader
     /// heaps where the GC cannot reclaim it. Allocating one on every
-    /// serialisation call therefore leaked ~3.3 MB/h RSS in production
+    /// serialization call therefore leaked ~3.3 MB/h RSS in production
     /// (tempco-001, tim-001).
     ///
     /// The <see cref="JsonFunctions.DefaultOptions"/> and
@@ -63,7 +63,7 @@ namespace MTConnect.NET_JSON_Tests.Regressions
             }
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: default options returns the same instance on repeat access.</summary>
+        /// <summary>Pins the behavior expressed by the test name: default options returns the same instance on repeat access.</summary>
         [Test]
         public void DefaultOptions_returns_the_same_instance_on_repeat_access()
         {
@@ -73,7 +73,7 @@ namespace MTConnect.NET_JSON_Tests.Regressions
                 "JsonFunctions.DefaultOptions must be a shared singleton — a fresh JsonSerializerOptions per call leaks LCG-emitted metadata into the loader heap.");
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: indent options returns the same instance on repeat access.</summary>
+        /// <summary>Pins the behavior expressed by the test name: indent options returns the same instance on repeat access.</summary>
         [Test]
         public void IndentOptions_returns_the_same_instance_on_repeat_access()
         {
@@ -83,7 +83,7 @@ namespace MTConnect.NET_JSON_Tests.Regressions
                 "JsonFunctions.IndentOptions must be a shared singleton — a fresh JsonSerializerOptions per call leaks LCG-emitted metadata into the loader heap.");
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: default options and indent options are distinct instances.</summary>
+        /// <summary>Pins the behavior expressed by the test name: default options and indent options are distinct instances.</summary>
         [Test]
         public void DefaultOptions_and_IndentOptions_are_distinct_instances()
         {
@@ -91,31 +91,31 @@ namespace MTConnect.NET_JSON_Tests.Regressions
                 "DefaultOptions (compact) and IndentOptions (pretty-printed) must be separate instances so WriteIndented differs.");
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: default options write indented is false.</summary>
+        /// <summary>Pins the behavior expressed by the test name: default options write indented is false.</summary>
         [Test]
         public void DefaultOptions_WriteIndented_is_false()
         {
             Assert.That(JsonFunctions.DefaultOptions.WriteIndented, Is.False);
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: indent options write indented is true.</summary>
+        /// <summary>Pins the behavior expressed by the test name: indent options write indented is true.</summary>
         [Test]
         public void IndentOptions_WriteIndented_is_true()
         {
             Assert.That(JsonFunctions.IndentOptions.WriteIndented, Is.True);
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: json functions holds a static readonly options field.</summary>
+        /// <summary>Pins the behavior expressed by the test name: json functions holds a static readonly options field.</summary>
         [Test]
         public void JsonFunctions_holds_a_static_readonly_options_field()
         {
             // Structural guard: at least one static readonly field of type
             // JsonSerializerOptions must exist on JsonFunctions so the
-            // shared instance survives across serialisation calls.
+            // shared instance survives across serialization calls.
             var fields = typeof(JsonFunctions).GetFields(BindingFlags.NonPublic | BindingFlags.Static);
             var optionsFields = System.Array.FindAll(fields, f => f.FieldType == typeof(JsonSerializerOptions) && f.IsInitOnly);
             Assert.That(optionsFields.Length, Is.GreaterThanOrEqualTo(2),
-                "JsonFunctions must declare shared static readonly JsonSerializerOptions fields (compact + indented) so the instances outlive each serialisation call.");
+                "JsonFunctions must declare shared static readonly JsonSerializerOptions fields (compact + indented) so the instances outlive each serialization call.");
         }
 
         /// <summary>
@@ -307,7 +307,7 @@ namespace MTConnect.NET_JSON_Tests.Regressions
 
         /// <summary>
         /// Null-input pin: every overload must swallow a null input and
-        /// return null / null / null — this is documented behaviour and
+        /// return null / null / null — this is documented behavior and
         /// the singleton refactor must preserve it.
         /// </summary>
         [Test]

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -1,8 +1,13 @@
 // Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
 // TrakHound Inc. licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
@@ -20,6 +25,36 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
     [TestFixture]
     public class JsonSerializerOptionsSingletonTests
     {
+        // Small POCO used by the Convert/ConvertBytes/ConvertStream overload
+        // smoke tests and the thread-safety pin. Nested type so the
+        // reachable-graph JIT emit still runs on cold options instances.
+        internal class SamplePayload
+        {
+            public string Name { get; set; } = "sample";
+            public int Count { get; set; } = 42;
+            public SampleChild Child { get; set; } = new SampleChild();
+        }
+
+        internal class SampleChild
+        {
+            public string Label { get; set; } = "child";
+            public double Value { get; set; } = 3.14;
+        }
+
+        private sealed class NoopConverter : JsonConverter<SamplePayload>
+        {
+            public override SamplePayload Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+                => new SamplePayload();
+
+            public override void Write(Utf8JsonWriter writer, SamplePayload value, JsonSerializerOptions options)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("Name", value.Name);
+                writer.WriteNumber("Count", value.Count);
+                writer.WriteEndObject();
+            }
+        }
+
         /// <summary>Pins the behaviour expressed by the test name: default options returns the same instance on repeat access.</summary>
         [Test]
         public void DefaultOptions_returns_the_same_instance_on_repeat_access()
@@ -70,6 +105,209 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
             var optionsFields = System.Array.FindAll(fields, f => f.FieldType == typeof(JsonSerializerOptions) && f.IsInitOnly);
             Assert.That(optionsFields.Length, Is.GreaterThanOrEqualTo(2),
                 "JsonFunctions must declare shared static readonly JsonSerializerOptions fields (compact + indented) so the instances outlive each serialisation call.");
+        }
+
+        /// <summary>
+        /// Thread-safety pin — cppagent flavour. The cppagent assembly
+        /// ships 25 Streams.Json classes vs 10 in the plain-JSON assembly,
+        /// so the LCG cost per serialisation is proportionally larger;
+        /// the concurrency pin runs on the exact JsonFunctions surface
+        /// DIME's MQTT sink hits in production.
+        /// </summary>
+        [Test]
+        public void Convert_is_thread_safe_across_100_concurrent_callers()
+        {
+            const int threadCount = 100;
+            var payload = new SamplePayload();
+            var outputs = new ConcurrentBag<string>();
+            var exceptions = new ConcurrentBag<System.Exception>();
+            var startGate = new ManualResetEventSlim(false);
+
+            var threads = new Thread[threadCount];
+            for (int i = 0; i < threadCount; i++)
+            {
+                threads[i] = new Thread(() =>
+                {
+                    try
+                    {
+                        startGate.Wait();
+                        var s = JsonFunctions.Convert(payload);
+                        outputs.Add(s);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                });
+                threads[i].Start();
+            }
+
+            // Warm the singleton once before releasing the gate.
+            _ = JsonFunctions.Convert(payload);
+
+            startGate.Set();
+            foreach (var t in threads) t.Join();
+
+            Assert.That(exceptions, Is.Empty,
+                "Concurrent Convert calls against the shared DefaultOptions must not throw.");
+            Assert.That(outputs.Count, Is.EqualTo(threadCount));
+
+            var canonical = JsonFunctions.Convert(payload);
+            foreach (var s in outputs)
+            {
+                Assert.That(s, Is.EqualTo(canonical),
+                    "Every concurrent Convert output must be byte-identical to the single-threaded canonical output.");
+            }
+        }
+
+        /// <summary>
+        /// Cold-path pin: when a caller supplies a per-call converter, the
+        /// implementation must NOT append that converter to the shared
+        /// DefaultOptions.Converters collection. Doing so would (a) permanently
+        /// pollute the singleton and (b) throw InvalidOperationException
+        /// because JsonSerializerOptions freezes its converter list after
+        /// first use.
+        /// </summary>
+        [Test]
+        public void Convert_with_custom_converter_does_not_mutate_DefaultOptions_converters()
+        {
+            _ = JsonFunctions.Convert(new SamplePayload()); // warm/freeze
+
+            var beforeCount = JsonFunctions.DefaultOptions.Converters.Count;
+            var beforeIndentCount = JsonFunctions.IndentOptions.Converters.Count;
+
+            var converter = new NoopConverter();
+            var result = JsonFunctions.Convert(new SamplePayload(), converter);
+            var resultIndented = JsonFunctions.Convert(new SamplePayload(), converter, indented: true);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(resultIndented, Is.Not.Null);
+
+            Assert.That(JsonFunctions.DefaultOptions.Converters.Count, Is.EqualTo(beforeCount),
+                "The cold-path branch must build a fresh JsonSerializerOptions — a caller-supplied converter must never leak into DefaultOptions.Converters.");
+            Assert.That(JsonFunctions.IndentOptions.Converters.Count, Is.EqualTo(beforeIndentCount),
+                "The cold-path branch must build a fresh JsonSerializerOptions — a caller-supplied converter must never leak into IndentOptions.Converters.");
+        }
+
+        /// <summary>
+        /// Cold-path pin: the custom-converter Convert output must reflect
+        /// the caller's converter (proving the fresh options object used
+        /// it), while a following converter-less Convert on the same input
+        /// must NOT reflect the converter (proving the singleton was untouched).
+        /// </summary>
+        [Test]
+        public void Convert_with_custom_converter_uses_converter_without_affecting_singleton_output()
+        {
+            var payload = new SamplePayload();
+            var canonicalWithoutConverter = JsonFunctions.Convert(payload);
+
+            var converter = new NoopConverter();
+            var withConverter = JsonFunctions.Convert(payload, converter);
+
+            Assert.That(withConverter, Is.Not.EqualTo(canonicalWithoutConverter),
+                "The cold-path fresh options must apply the caller's converter — otherwise the singleton was reused, defeating the branch.");
+            Assert.That(withConverter, Does.Not.Contain("Child"),
+                "NoopConverter drops the Child field; the cold-path output should reflect that.");
+
+            var afterCanonical = JsonFunctions.Convert(payload);
+            Assert.That(afterCanonical, Is.EqualTo(canonicalWithoutConverter),
+                "After a converter-supplied call, the singleton-path output must be byte-identical to before.");
+            Assert.That(afterCanonical, Does.Contain("Child"),
+                "The singleton must still emit the Child field — the cold-path converter must not have polluted it.");
+        }
+
+        /// <summary>
+        /// Overload smoke pin: Convert/ConvertBytes/ConvertStream must all
+        /// produce the same JSON for the same input under the compact
+        /// preset.
+        /// </summary>
+        [Test]
+        public void Convert_ConvertBytes_ConvertStream_produce_identical_output_for_compact()
+        {
+            var payload = new SamplePayload();
+
+            var s = JsonFunctions.Convert(payload);
+            var bytes = JsonFunctions.ConvertBytes(payload);
+            var stream = JsonFunctions.ConvertStream(payload);
+
+            Assert.That(s, Is.Not.Null);
+            Assert.That(bytes, Is.Not.Null);
+            Assert.That(stream, Is.Not.Null);
+
+            var bytesString = Encoding.UTF8.GetString(bytes!);
+            Assert.That(bytesString, Is.EqualTo(s));
+
+            stream!.Position = 0;
+            using var reader = new System.IO.StreamReader(stream);
+            var streamString = reader.ReadToEnd();
+            Assert.That(streamString, Is.EqualTo(s));
+        }
+
+        /// <summary>Overload smoke pin — indented variant.</summary>
+        [Test]
+        public void Convert_ConvertBytes_ConvertStream_produce_identical_output_for_indented()
+        {
+            var payload = new SamplePayload();
+
+            var s = JsonFunctions.Convert(payload, indented: true);
+            var bytes = JsonFunctions.ConvertBytes(payload, indented: true);
+            var stream = JsonFunctions.ConvertStream(payload, indented: true);
+
+            Assert.That(s, Is.Not.Null);
+            Assert.That(bytes, Is.Not.Null);
+            Assert.That(stream, Is.Not.Null);
+
+            var bytesString = Encoding.UTF8.GetString(bytes!);
+            Assert.That(bytesString, Is.EqualTo(s));
+
+            stream!.Position = 0;
+            using var reader = new System.IO.StreamReader(stream);
+            var streamString = reader.ReadToEnd();
+            Assert.That(streamString, Is.EqualTo(s));
+
+            Assert.That(s, Does.Contain("\n"),
+                "Indented Convert output must contain newlines.");
+            Assert.That(bytesString, Does.Contain("\n"));
+            Assert.That(streamString, Does.Contain("\n"));
+        }
+
+        /// <summary>
+        /// Null-input pin: every overload must swallow a null input and
+        /// return null / null / null.
+        /// </summary>
+        [Test]
+        public void Convert_overloads_return_null_for_null_input()
+        {
+            Assert.That(JsonFunctions.Convert(null), Is.Null);
+            Assert.That(JsonFunctions.ConvertBytes(null), Is.Null);
+            Assert.That(JsonFunctions.ConvertStream(null), Is.Null);
+        }
+
+        /// <summary>
+        /// Async-throughput pin: 100 parallel Convert calls via
+        /// Parallel.For to complement the Thread-based pin. Covers the
+        /// ThreadPool-scheduled path DIME's MQTT sink actually uses in
+        /// production.
+        /// </summary>
+        [Test]
+        public void Convert_is_thread_safe_under_ParallelFor()
+        {
+            _ = JsonFunctions.Convert(new SamplePayload());
+
+            var canonical = JsonFunctions.Convert(new SamplePayload());
+            var results = new ConcurrentBag<string>();
+
+            Parallel.For(0, 100, _ =>
+            {
+                var s = JsonFunctions.Convert(new SamplePayload());
+                results.Add(s);
+            });
+
+            Assert.That(results.Count, Is.EqualTo(100));
+            foreach (var r in results)
+            {
+                Assert.That(r, Is.EqualTo(canonical));
+            }
         }
     }
 }

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -343,9 +343,11 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
         /// <summary>
         /// Warm-up-before-freeze ordering pin (net8+): the frozen singleton
         /// must still be able to serialize a real typed payload, proving that
-        /// the static-ctor warm-up (<c>JsonSerializer.Serialize&lt;object&gt;(null, _defaultOptions)</c>)
-        /// ran BEFORE <c>MakeReadOnly(populateMissingResolver: false)</c>. If a
-        /// future refactor reordered the two calls — or removed the warm-up
+        /// the static-ctor warm-up (typed <c>JsonSerializer.Serialize</c>
+        /// calls against each cppagent top-level response surrogate — see
+        /// <c>JsonFunctions.WarmReachableGraph</c>) ran BEFORE
+        /// <c>MakeReadOnly(populateMissingResolver: false)</c>. If a future
+        /// refactor reordered the two calls — or removed the warm-up
         /// entirely — the frozen, resolver-less options would throw
         /// <see cref="System.NotSupportedException"/> on the first real-payload
         /// Serialize. The invariant is documented in the JsonFunctions static
@@ -367,7 +369,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
             string indented = string.Empty;
             Assert.DoesNotThrow(
                 () => compact = JsonSerializer.Serialize(payload, JsonFunctions.DefaultOptions),
-                "Frozen DefaultOptions must have a populated TypeInfoResolver — a static-ctor reorder that runs MakeReadOnly BEFORE the Serialize<object>(null, …) warm-up would surface here as NotSupportedException.");
+                "Frozen DefaultOptions must have a populated TypeInfoResolver — a static-ctor reorder that runs MakeReadOnly BEFORE the WarmReachableGraph typed-Serialize calls would surface here as NotSupportedException.");
             Assert.DoesNotThrow(
                 () => indented = JsonSerializer.Serialize(payload, JsonFunctions.IndentOptions),
                 "Frozen IndentOptions must have a populated TypeInfoResolver — same warm-up-before-freeze invariant as DefaultOptions.");

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -14,7 +14,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
 {
     /// <summary>
     /// Regression pin for the DIME-connector native-heap leak (peer
-    /// diagnosis dated 2026-08-21). This is the cppagent-flavoured
+    /// diagnosis dated 2026-08-21). This is the cppagent-flavored
     /// mirror of the same guard applied to
     /// <c>MTConnect.NET-JSON/JsonFunctions.cs</c>. The two files ship
     /// independent copies of the same option-preset surface, so both
@@ -108,7 +108,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
         }
 
         /// <summary>
-        /// Thread-safety pin — cppagent flavour. The cppagent assembly
+        /// Thread-safety pin — cppagent flavor. The cppagent assembly
         /// ships 25 Streams.Json classes vs 10 in the plain-JSON assembly,
         /// so the LCG cost per serialization is proportionally larger;
         /// the concurrency pin runs on the exact JsonFunctions surface

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -445,7 +445,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
         /// expected type OR a <c>ldsfld</c> loading a static field of
         /// that type — semantically equivalent for warm-up, because STJ
         /// walks the runtime type of whatever value the caller passes
-        /// into <see cref="System.Text.Json.JsonSerializer.Serialize"/>
+        /// into <see cref="System.Text.Json.JsonSerializer.Serialize{TValue}(TValue,System.Text.Json.JsonSerializerOptions)"/>
         /// regardless of how the instance was produced. The current
         /// warm-up uses <c>MTConnectVersions.Version25</c> (a static
         /// field of type <see cref="System.Version"/>) rather than a

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -423,6 +423,36 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
             AssertWarmReachableGraphNewsUp(typeof(MTConnect.Devices.Json.JsonDevicesResponseDocument));
         }
 
+        /// <summary>
+        /// Structural warm-up-coverage pin (net8+) — companion assertion for
+        /// the F-IMP-C5-001 fix that populated the Error envelope with a
+        /// concrete <see cref="MTConnect.Headers.MTConnectErrorHeader"/> +
+        /// <see cref="MTConnect.Errors.Error"/> + <see cref="System.Version"/>.
+        /// STJ resolves accessors for interface-typed properties
+        /// (<c>IMTConnectErrorHeader Header</c>, <c>IEnumerable&lt;IError&gt; Errors</c>)
+        /// only when the value is non-null; a revert to a naked
+        /// <c>new ErrorResponseDocument()</c> would silently pass the
+        /// ErrorResponseDocument-only IL pin above while re-opening the
+        /// exact LCG-emit-on-first-error class F-IMP-C5-001 closed —
+        /// MTConnectErrorHeader (9 properties), Error (2), and
+        /// System.Version (6) would each pay their first cold accessor
+        /// emit on the first real cppagent-formatted error response. The
+        /// three <c>newobj</c> instructions below are the source-of-truth
+        /// evidence that the populated warm-up shape survives.
+        /// <para/>
+        /// System.Version is not news-up-ed by the three cppagent
+        /// surrogate envelopes' Header defaulting, so the walker match on
+        /// <c>System.Version</c> uniquely fingerprints the Error-envelope
+        /// initializer.
+        /// </summary>
+        [Test]
+        public void WarmReachableGraph_IL_contains_newobj_for_concrete_Error_envelope_fields()
+        {
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Headers.MTConnectErrorHeader));
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Errors.Error));
+            AssertWarmReachableGraphNewsUp(typeof(System.Version));
+        }
+
         // IL walker: locate a `newobj <ctor-of-expected>` instruction inside
         // JsonFunctions.WarmReachableGraph. Runs on the compiled test assembly's
         // view of MTConnect.NET-JSON-cppagent, so a source change that removes

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -378,6 +378,36 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
                 "The warmed-and-frozen singleton must still emit real property data — a resolver-less frozen options would either throw or emit empty output.");
             Assert.That(indented, Does.Contain("\"Name\""));
         }
+
+        /// <summary>
+        /// Warm-up coverage pin (net8+) — <c>MTConnect.Errors.ErrorResponseDocument</c>
+        /// is the fourth top-level response envelope written directly by
+        /// <c>JsonHttpResponseDocumentFormatter.Format(IErrorResponseDocument, ...)</c>
+        /// without a cppagent-specific surrogate. The static-ctor
+        /// <c>WarmReachableGraph</c> pass must serialize an instance of it
+        /// against both option singletons BEFORE
+        /// <c>MakeReadOnly(populateMissingResolver: false)</c> — otherwise the
+        /// first error response (a /probe failure, unsupported device request,
+        /// or parse error) would pay a cold LCG DynamicMethod emit against
+        /// a frozen, resolver-less options and throw
+        /// <see cref="System.NotSupportedException"/>. Serializing a fresh
+        /// <see cref="MTConnect.Errors.ErrorResponseDocument"/> here reproduces
+        /// exactly that first-error path against the shared singletons; a
+        /// regression that dropped the Error warm-up would surface as a
+        /// NotSupportedException on this test.
+        /// </summary>
+        [Test]
+        public void Frozen_singleton_can_serialize_ErrorResponseDocument_proving_Error_warm_up_ran()
+        {
+            var document = new MTConnect.Errors.ErrorResponseDocument();
+
+            Assert.DoesNotThrow(
+                () => JsonSerializer.Serialize(document, JsonFunctions.DefaultOptions),
+                "Frozen DefaultOptions must have ErrorResponseDocument in its warmed TypeInfoResolver — a regression that removed the Error warm-up would surface here as NotSupportedException on the first error response.");
+            Assert.DoesNotThrow(
+                () => JsonSerializer.Serialize(document, JsonFunctions.IndentOptions),
+                "Frozen IndentOptions mirror — same Error warm-up invariant as DefaultOptions.");
+        }
 #endif
     }
 }

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -309,5 +309,36 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
                 Assert.That(r, Is.EqualTo(canonical));
             }
         }
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Freeze pin (net8+): the shared DefaultOptions and IndentOptions
+        /// singletons must be marked read-only at static-ctor time, so any
+        /// attempt to mutate their <see cref="JsonSerializerOptions.Converters"/>
+        /// collection throws <see cref="System.InvalidOperationException"/>.
+        /// The freeze is the enforcement half of the singleton pattern —
+        /// documentation alone would let a careless caller silently pollute
+        /// every other in-process serializer; the read-only lock makes the
+        /// misuse fail loudly at the point of the offending Add.
+        /// </summary>
+        [Test]
+        public void DefaultOptions_Converters_Add_throws_InvalidOperationException_when_frozen()
+        {
+            Assert.Throws<System.InvalidOperationException>(
+                () => JsonFunctions.DefaultOptions.Converters.Add(new NoopConverter()),
+                "DefaultOptions is a shared singleton and must be frozen on net8+ so a stray Converters.Add fails fast rather than silently mutating the process-wide instance.");
+        }
+
+        /// <summary>
+        /// Freeze pin (net8+) — IndentOptions mirror of the DefaultOptions guard.
+        /// </summary>
+        [Test]
+        public void IndentOptions_Converters_Add_throws_InvalidOperationException_when_frozen()
+        {
+            Assert.Throws<System.InvalidOperationException>(
+                () => JsonFunctions.IndentOptions.Converters.Add(new NoopConverter()),
+                "IndentOptions is a shared singleton and must be frozen on net8+ so a stray Converters.Add fails fast rather than silently mutating the process-wide instance.");
+        }
+#endif
     }
 }

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -20,7 +20,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
     /// independent copies of the same option-preset surface, so both
     /// must singleton their <see cref="JsonSerializerOptions"/> to keep
     /// the runtime's loader heap from accumulating LCG-emitted property
-    /// accessors on every serialisation call.
+    /// accessors on every serialization call.
     /// </summary>
     [TestFixture]
     public class JsonSerializerOptionsSingletonTests
@@ -55,7 +55,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
             }
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: default options returns the same instance on repeat access.</summary>
+        /// <summary>Pins the behavior expressed by the test name: default options returns the same instance on repeat access.</summary>
         [Test]
         public void DefaultOptions_returns_the_same_instance_on_repeat_access()
         {
@@ -65,7 +65,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
                 "JsonFunctions.DefaultOptions must be a shared singleton — a fresh JsonSerializerOptions per call leaks LCG-emitted metadata into the loader heap.");
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: indent options returns the same instance on repeat access.</summary>
+        /// <summary>Pins the behavior expressed by the test name: indent options returns the same instance on repeat access.</summary>
         [Test]
         public void IndentOptions_returns_the_same_instance_on_repeat_access()
         {
@@ -75,7 +75,7 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
                 "JsonFunctions.IndentOptions must be a shared singleton — a fresh JsonSerializerOptions per call leaks LCG-emitted metadata into the loader heap.");
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: default options and indent options are distinct instances.</summary>
+        /// <summary>Pins the behavior expressed by the test name: default options and indent options are distinct instances.</summary>
         [Test]
         public void DefaultOptions_and_IndentOptions_are_distinct_instances()
         {
@@ -83,34 +83,34 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
                 "DefaultOptions (compact) and IndentOptions (pretty-printed) must be separate instances so WriteIndented differs.");
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: default options write indented is false.</summary>
+        /// <summary>Pins the behavior expressed by the test name: default options write indented is false.</summary>
         [Test]
         public void DefaultOptions_WriteIndented_is_false()
         {
             Assert.That(JsonFunctions.DefaultOptions.WriteIndented, Is.False);
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: indent options write indented is true.</summary>
+        /// <summary>Pins the behavior expressed by the test name: indent options write indented is true.</summary>
         [Test]
         public void IndentOptions_WriteIndented_is_true()
         {
             Assert.That(JsonFunctions.IndentOptions.WriteIndented, Is.True);
         }
 
-        /// <summary>Pins the behaviour expressed by the test name: json functions holds a static readonly options field.</summary>
+        /// <summary>Pins the behavior expressed by the test name: json functions holds a static readonly options field.</summary>
         [Test]
         public void JsonFunctions_holds_a_static_readonly_options_field()
         {
             var fields = typeof(JsonFunctions).GetFields(BindingFlags.NonPublic | BindingFlags.Static);
             var optionsFields = System.Array.FindAll(fields, f => f.FieldType == typeof(JsonSerializerOptions) && f.IsInitOnly);
             Assert.That(optionsFields.Length, Is.GreaterThanOrEqualTo(2),
-                "JsonFunctions must declare shared static readonly JsonSerializerOptions fields (compact + indented) so the instances outlive each serialisation call.");
+                "JsonFunctions must declare shared static readonly JsonSerializerOptions fields (compact + indented) so the instances outlive each serialization call.");
         }
 
         /// <summary>
         /// Thread-safety pin — cppagent flavour. The cppagent assembly
         /// ships 25 Streams.Json classes vs 10 in the plain-JSON assembly,
-        /// so the LCG cost per serialisation is proportionally larger;
+        /// so the LCG cost per serialization is proportionally larger;
         /// the concurrency pin runs on the exact JsonFunctions surface
         /// DIME's MQTT sink hits in production.
         /// </summary>

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -380,33 +380,94 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
         }
 
         /// <summary>
-        /// Warm-up coverage pin (net8+) — <c>MTConnect.Errors.ErrorResponseDocument</c>
-        /// is the fourth top-level response envelope written directly by
+        /// Structural warm-up-coverage pin (net8+) — <c>WarmReachableGraph</c>'s
+        /// IL must contain a <c>newobj</c> instruction constructing
+        /// <see cref="MTConnect.Errors.ErrorResponseDocument"/>, the fourth
+        /// top-level response envelope written directly by
         /// <c>JsonHttpResponseDocumentFormatter.Format(IErrorResponseDocument, ...)</c>
-        /// without a cppagent-specific surrogate. The static-ctor
-        /// <c>WarmReachableGraph</c> pass must serialize an instance of it
-        /// against both option singletons BEFORE
-        /// <c>MakeReadOnly(populateMissingResolver: false)</c> — otherwise the
-        /// first error response (a /probe failure, unsupported device request,
-        /// or parse error) would pay a cold LCG DynamicMethod emit against
-        /// a frozen, resolver-less options and throw
-        /// <see cref="System.NotSupportedException"/>. Serializing a fresh
-        /// <see cref="MTConnect.Errors.ErrorResponseDocument"/> here reproduces
-        /// exactly that first-error path against the shared singletons; a
-        /// regression that dropped the Error warm-up would surface as a
-        /// NotSupportedException on this test.
+        /// without a cppagent-specific surrogate wrapper.
+        /// <para/>
+        /// A runtime <c>Assert.DoesNotThrow(() =&gt; Serialize(new ErrorResponseDocument(), frozen))</c>
+        /// check is tautological here: once the TypeInfoResolver is set (which
+        /// any preceding warm-up call does), STJ's <see cref="System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver"/>
+        /// lazily populates <see cref="System.Text.Json.Serialization.Metadata.JsonTypeInfo"/>
+        /// on frozen options for arbitrary types — the frozen state only locks
+        /// the options' configuration surface (Converters, DefaultIgnoreCondition,
+        /// etc.), not the internal metadata cache. Verified empirically:
+        /// mutating out the <c>ErrorResponseDocument</c> warm-up line and running
+        /// the "can it serialize" pin still passes (see cycle-5 test-coverage-audit
+        /// mutation test 2026-08-21). The performance invariant the warm-up
+        /// enforces — pay the LCG DynamicMethod emit for ErrorResponseDocument
+        /// at assembly load, not on the first /probe error / parse-failure
+        /// request — is therefore only observable at the source-of-truth level:
+        /// the IL of <c>WarmReachableGraph</c>.
         /// </summary>
         [Test]
-        public void Frozen_singleton_can_serialize_ErrorResponseDocument_proving_Error_warm_up_ran()
+        public void WarmReachableGraph_IL_contains_newobj_for_ErrorResponseDocument_ctor()
         {
-            var document = new MTConnect.Errors.ErrorResponseDocument();
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Errors.ErrorResponseDocument));
+        }
 
-            Assert.DoesNotThrow(
-                () => JsonSerializer.Serialize(document, JsonFunctions.DefaultOptions),
-                "Frozen DefaultOptions must have ErrorResponseDocument in its warmed TypeInfoResolver — a regression that removed the Error warm-up would surface here as NotSupportedException on the first error response.");
-            Assert.DoesNotThrow(
-                () => JsonSerializer.Serialize(document, JsonFunctions.IndentOptions),
-                "Frozen IndentOptions mirror — same Error warm-up invariant as DefaultOptions.");
+        /// <summary>
+        /// Structural warm-up-coverage pin (net8+) — companion assertion that
+        /// each of the three cppagent top-level response surrogates is also
+        /// news-up-ed by <c>WarmReachableGraph</c>. Mirrors the ErrorResponseDocument
+        /// pin above; the same tautology argument applies to per-type
+        /// "can it serialize" runtime checks.
+        /// </summary>
+        [Test]
+        public void WarmReachableGraph_IL_contains_newobj_for_every_top_level_response_surrogate()
+        {
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Streams.Json.JsonStreamsResponseDocument));
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Assets.Json.JsonAssetsResponseDocument));
+            AssertWarmReachableGraphNewsUp(typeof(MTConnect.Devices.Json.JsonDevicesResponseDocument));
+        }
+
+        // IL walker: locate a `newobj <ctor-of-expected>` instruction inside
+        // JsonFunctions.WarmReachableGraph. Runs on the compiled test assembly's
+        // view of MTConnect.NET-JSON-cppagent, so a source change that removes
+        // the corresponding new-expression is caught deterministically at test
+        // time. Same walker as the plain-JSON sibling fixture; kept per-fixture
+        // to avoid a shared helper project just for this pin.
+        //
+        // Scans for the 5-byte pattern <newobj:0x73> <4-byte-token>. Full
+        // opcode-length decoding is unnecessary: a spurious match would need a
+        // non-newobj opcode at byte i whose following 4 bytes coincidentally
+        // decode to a valid MemberRef token whose ResolveMethod returns a ctor
+        // of the target type — inside a ~35-byte method body, practically
+        // impossible.
+        private static void AssertWarmReachableGraphNewsUp(System.Type expected)
+        {
+            var method = typeof(JsonFunctions).GetMethod(
+                "WarmReachableGraph",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(method, Is.Not.Null,
+                "JsonFunctions.WarmReachableGraph private static method must exist.");
+            var body = method!.GetMethodBody();
+            Assert.That(body, Is.Not.Null,
+                "WarmReachableGraph must have a method body (not abstract / p-invoke).");
+            var il = body!.GetILAsByteArray();
+            Assert.That(il, Is.Not.Null);
+            var module = method.Module;
+
+            for (int i = 0; i + 4 < il!.Length; i++)
+            {
+                if (il[i] != 0x73) continue;
+                int token = System.BitConverter.ToInt32(il, i + 1);
+                System.Reflection.MethodBase? resolved;
+                try { resolved = module.ResolveMethod(token); }
+                catch { continue; }
+                if (resolved is System.Reflection.ConstructorInfo ctor
+                    && ctor.DeclaringType == expected)
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                $"WarmReachableGraph must contain a newobj IL instruction for {expected.FullName}. " +
+                "Without it, the first request that hits this envelope pays a cold LCG DynamicMethod emit " +
+                "against the frozen singleton — which is the +3.2-3.8 MB/h RSS leak-in-miniature the warm-up exists to prevent.");
         }
 #endif
     }

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -339,6 +339,43 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
                 () => JsonFunctions.IndentOptions.Converters.Add(new NoopConverter()),
                 "IndentOptions is a shared singleton and must be frozen on net8+ so a stray Converters.Add fails fast rather than silently mutating the process-wide instance.");
         }
+
+        /// <summary>
+        /// Warm-up-before-freeze ordering pin (net8+): the frozen singleton
+        /// must still be able to serialize a real typed payload, proving that
+        /// the static-ctor warm-up (<c>JsonSerializer.Serialize&lt;object&gt;(null, _defaultOptions)</c>)
+        /// ran BEFORE <c>MakeReadOnly(populateMissingResolver: false)</c>. If a
+        /// future refactor reordered the two calls — or removed the warm-up
+        /// entirely — the frozen, resolver-less options would throw
+        /// <see cref="System.NotSupportedException"/> on the first real-payload
+        /// Serialize. The invariant is documented in the JsonFunctions static
+        /// ctor comment ("Order matters: the warm-up must run BEFORE
+        /// MakeReadOnly"); this test names it as a regression pin.
+        /// <para/>
+        /// Calls <see cref="JsonSerializer.Serialize{TValue}(TValue, JsonSerializerOptions)"/>
+        /// directly rather than via <see cref="JsonFunctions.Convert"/> because
+        /// Convert's catch-all silently swallows serialization exceptions into
+        /// a null return — routing through it would degrade a diagnostic
+        /// "NotSupportedException at Serialize" into an opaque "Expected: not null".
+        /// </summary>
+        [Test]
+        public void Frozen_singleton_can_serialize_a_real_payload_proving_warm_up_ran_before_MakeReadOnly()
+        {
+            var payload = new SamplePayload();
+
+            string compact = string.Empty;
+            string indented = string.Empty;
+            Assert.DoesNotThrow(
+                () => compact = JsonSerializer.Serialize(payload, JsonFunctions.DefaultOptions),
+                "Frozen DefaultOptions must have a populated TypeInfoResolver — a static-ctor reorder that runs MakeReadOnly BEFORE the Serialize<object>(null, …) warm-up would surface here as NotSupportedException.");
+            Assert.DoesNotThrow(
+                () => indented = JsonSerializer.Serialize(payload, JsonFunctions.IndentOptions),
+                "Frozen IndentOptions must have a populated TypeInfoResolver — same warm-up-before-freeze invariant as DefaultOptions.");
+
+            Assert.That(compact, Does.Contain("\"Name\""),
+                "The warmed-and-frozen singleton must still emit real property data — a resolver-less frozen options would either throw or emit empty output.");
+            Assert.That(indented, Does.Contain("\"Name\""));
+        }
 #endif
     }
 }

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -437,13 +437,25 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
         /// MTConnectErrorHeader (9 properties), Error (2), and
         /// System.Version (6) would each pay their first cold accessor
         /// emit on the first real cppagent-formatted error response. The
-        /// three <c>newobj</c> instructions below are the source-of-truth
-        /// evidence that the populated warm-up shape survives.
+        /// three assertions below are the source-of-truth evidence that
+        /// the populated warm-up shape survives.
         /// <para/>
-        /// System.Version is not news-up-ed by the three cppagent
-        /// surrogate envelopes' Header defaulting, so the walker match on
-        /// <c>System.Version</c> uniquely fingerprints the Error-envelope
-        /// initializer.
+        /// The walker (<see cref="AssertWarmReachableGraphNewsUp"/>)
+        /// accepts either a <c>newobj</c> producing an instance of the
+        /// expected type OR a <c>ldsfld</c> loading a static field of
+        /// that type — semantically equivalent for warm-up, because STJ
+        /// walks the runtime type of whatever value the caller passes
+        /// into <see cref="System.Text.Json.JsonSerializer.Serialize"/>
+        /// regardless of how the instance was produced. The current
+        /// warm-up uses <c>MTConnectVersions.Version25</c> (a static
+        /// field of type <see cref="System.Version"/>) rather than a
+        /// magic <c>new System.Version(2, 5)</c> literal (F-CR-C6-001);
+        /// dropping either producer would fail the pin.
+        /// <para/>
+        /// System.Version is not news-up-ed OR ldsfld-loaded by the
+        /// three cppagent surrogate envelopes' Header defaulting, so
+        /// the walker match on <c>System.Version</c> uniquely
+        /// fingerprints the Error-envelope initializer.
         /// </summary>
         [Test]
         public void WarmReachableGraph_IL_contains_newobj_for_concrete_Error_envelope_fields()
@@ -453,19 +465,29 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
             AssertWarmReachableGraphNewsUp(typeof(System.Version));
         }
 
-        // IL walker: locate a `newobj <ctor-of-expected>` instruction inside
-        // JsonFunctions.WarmReachableGraph. Runs on the compiled test assembly's
-        // view of MTConnect.NET-JSON-cppagent, so a source change that removes
-        // the corresponding new-expression is caught deterministically at test
-        // time. Same walker as the plain-JSON sibling fixture; kept per-fixture
-        // to avoid a shared helper project just for this pin.
+        // IL walker: proves JsonFunctions.WarmReachableGraph feeds a concrete
+        // instance of <paramref name="expected"/> to STJ by locating EITHER a
+        // `newobj <ctor-of-expected>` (fresh allocation) OR a
+        // `ldsfld <static-field-of-type-expected>` (canonical-constant load)
+        // in the method body. Runs on the compiled test assembly's view of
+        // MTConnect.NET-JSON-cppagent, so a source change that removes both
+        // producers is caught deterministically at test time. Same walker
+        // shape as the plain-JSON sibling fixture; kept per-fixture to avoid
+        // a shared helper project just for this pin.
         //
-        // Scans for the 5-byte pattern <newobj:0x73> <4-byte-token>. Full
-        // opcode-length decoding is unnecessary: a spurious match would need a
-        // non-newobj opcode at byte i whose following 4 bytes coincidentally
-        // decode to a valid MemberRef token whose ResolveMethod returns a ctor
-        // of the target type — inside a ~35-byte method body, practically
+        // Scans for the 5-byte patterns <newobj:0x73> <4-byte-token> and
+        // <ldsfld:0x7E> <4-byte-token>. Full opcode-length decoding is
+        // unnecessary: a spurious match would need a non-target opcode at
+        // byte i whose following 4 bytes coincidentally decode to a valid
+        // MemberRef token whose ResolveMethod/ResolveField returns a target
+        // of the expected type — inside a ~40-byte method body, practically
         // impossible.
+        //
+        // Both producers are semantically equivalent for warm-up: STJ walks
+        // the runtime type of the value passed into Serialize, and cannot
+        // tell whether the instance came from a fresh newobj or from a
+        // static field load (e.g. MTConnectVersions.Version25 for
+        // System.Version).
         private static void AssertWarmReachableGraphNewsUp(System.Type expected)
         {
             var method = typeof(JsonFunctions).GetMethod(
@@ -482,20 +504,36 @@ namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
 
             for (int i = 0; i + 4 < il!.Length; i++)
             {
-                if (il[i] != 0x73) continue;
-                int token = System.BitConverter.ToInt32(il, i + 1);
-                System.Reflection.MethodBase? resolved;
-                try { resolved = module.ResolveMethod(token); }
-                catch { continue; }
-                if (resolved is System.Reflection.ConstructorInfo ctor
-                    && ctor.DeclaringType == expected)
+                if (il[i] == 0x73)
                 {
-                    return;
+                    // newobj <ctor>
+                    int token = System.BitConverter.ToInt32(il, i + 1);
+                    System.Reflection.MethodBase? resolved;
+                    try { resolved = module.ResolveMethod(token); }
+                    catch { continue; }
+                    if (resolved is System.Reflection.ConstructorInfo ctor
+                        && ctor.DeclaringType == expected)
+                    {
+                        return;
+                    }
+                }
+                else if (il[i] == 0x7E)
+                {
+                    // ldsfld <static-field>
+                    int token = System.BitConverter.ToInt32(il, i + 1);
+                    System.Reflection.FieldInfo? field;
+                    try { field = module.ResolveField(token); }
+                    catch { continue; }
+                    if (field != null && field.FieldType == expected)
+                    {
+                        return;
+                    }
                 }
             }
 
             Assert.Fail(
-                $"WarmReachableGraph must contain a newobj IL instruction for {expected.FullName}. " +
+                $"WarmReachableGraph must produce a concrete instance of {expected.FullName} " +
+                "(via `new` or via a static-field load) so STJ walks its accessor graph at assembly load. " +
                 "Without it, the first request that hits this envelope pays a cold LCG DynamicMethod emit " +
                 "against the frozen singleton — which is the +3.2-3.8 MB/h RSS leak-in-miniature the warm-up exists to prevent.");
         }

--- a/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
+++ b/tests/MTConnect.NET-JSON-cppagent-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 TrakHound Inc., All Rights Reserved.
+// TrakHound Inc. licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace MTConnect.NET_JSON_cppagent_Tests.Regressions
+{
+    /// <summary>
+    /// Regression pin for the DIME-connector native-heap leak (peer
+    /// diagnosis dated 2026-08-21). This is the cppagent-flavoured
+    /// mirror of the same guard applied to
+    /// <c>MTConnect.NET-JSON/JsonFunctions.cs</c>. The two files ship
+    /// independent copies of the same option-preset surface, so both
+    /// must singleton their <see cref="JsonSerializerOptions"/> to keep
+    /// the runtime's loader heap from accumulating LCG-emitted property
+    /// accessors on every serialisation call.
+    /// </summary>
+    [TestFixture]
+    public class JsonSerializerOptionsSingletonTests
+    {
+        /// <summary>Pins the behaviour expressed by the test name: default options returns the same instance on repeat access.</summary>
+        [Test]
+        public void DefaultOptions_returns_the_same_instance_on_repeat_access()
+        {
+            var a = JsonFunctions.DefaultOptions;
+            var b = JsonFunctions.DefaultOptions;
+            Assert.That(ReferenceEquals(a, b), Is.True,
+                "JsonFunctions.DefaultOptions must be a shared singleton — a fresh JsonSerializerOptions per call leaks LCG-emitted metadata into the loader heap.");
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: indent options returns the same instance on repeat access.</summary>
+        [Test]
+        public void IndentOptions_returns_the_same_instance_on_repeat_access()
+        {
+            var a = JsonFunctions.IndentOptions;
+            var b = JsonFunctions.IndentOptions;
+            Assert.That(ReferenceEquals(a, b), Is.True,
+                "JsonFunctions.IndentOptions must be a shared singleton — a fresh JsonSerializerOptions per call leaks LCG-emitted metadata into the loader heap.");
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: default options and indent options are distinct instances.</summary>
+        [Test]
+        public void DefaultOptions_and_IndentOptions_are_distinct_instances()
+        {
+            Assert.That(ReferenceEquals(JsonFunctions.DefaultOptions, JsonFunctions.IndentOptions), Is.False,
+                "DefaultOptions (compact) and IndentOptions (pretty-printed) must be separate instances so WriteIndented differs.");
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: default options write indented is false.</summary>
+        [Test]
+        public void DefaultOptions_WriteIndented_is_false()
+        {
+            Assert.That(JsonFunctions.DefaultOptions.WriteIndented, Is.False);
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: indent options write indented is true.</summary>
+        [Test]
+        public void IndentOptions_WriteIndented_is_true()
+        {
+            Assert.That(JsonFunctions.IndentOptions.WriteIndented, Is.True);
+        }
+
+        /// <summary>Pins the behaviour expressed by the test name: json functions holds a static readonly options field.</summary>
+        [Test]
+        public void JsonFunctions_holds_a_static_readonly_options_field()
+        {
+            var fields = typeof(JsonFunctions).GetFields(BindingFlags.NonPublic | BindingFlags.Static);
+            var optionsFields = System.Array.FindAll(fields, f => f.FieldType == typeof(JsonSerializerOptions) && f.IsInitOnly);
+            Assert.That(optionsFields.Length, Is.GreaterThanOrEqualTo(2),
+                "JsonFunctions must declare shared static readonly JsonSerializerOptions fields (compact + indented) so the instances outlive each serialisation call.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Cache `JsonSerializerOptions` as `static readonly` singletons in both `MTConnect.NET-JSON` and `MTConnect.NET-JSON-cppagent` `JsonFunctions.cs`, plus every sibling site that re-allocated the option object per call. Prevents unbounded loader-heap growth from LCG-emitted property accessors, observed on two DIME-connector production hosts as a +3.2–3.8 MB/h RSS climb with a flat managed heap.

## Root cause

A fresh `JsonSerializerOptions` instance owns its own serialization-metadata cache. Building that cache emits reflection-based property accessors (`DynamicMethod` in the runtime's LCG heap) for every property in the reachable type graph. Allocating one on every serialization call therefore re-emits those accessors on every call, and the emitted code accumulates in the runtime's loader heaps where the GC cannot reclaim it.

Peer diagnosis (tempco-investigation-server, 2026-08-21) on two hosts:

- tempco-001 (amd64, server-GC) and tim-001 (arm64, workstation-GC) — completely different source/sink shapes, 28× Lua/Scriban usage delta between them. The only shared serialization surface was MTConnect JSON.
- `dotnet-counters`: GC heap flat (76–87 MB sawtooth); working set climbed (445 → 460 MB); ~370 MB outside the managed heap.
- `Number of Methods Jitted`: 17,651,641 in 71 h on tempco-001 (+67/s forever) — healthy service is typically 10 k–50 k lifetime.
- `IL Bytes Jitted`: +67,083 B / 90 s = 2.7 MB/h, matching the 3.3 MB/h RSS climb.
- `dotnet-gcdump`: `System.Text.Json.Serialization.Metadata.ReflectionEmitCachingMemberAccessor+Cache+CacheEntry` present.
- `dotnet-trace` LCG DynamicMethods: 8946 hits on `dynamicClass`, 2465 on `IObservationOutput` accessor, 1371 on `JsonEvents`, 1161 on `JsonSamples`.

**Why both `JsonFunctions.cs` files ship in one PR.** DIME's MQTT sink at `DIME/Connectors/MtConnectMqtt/Sink.cs:49` sets `documentFormat: "JSON-cppagent-mqtt"`, so per-observation serialization on peer's production hosts flowed through `MTConnect.NET-JSON-cppagent.JsonFunctions`, not the plain one. An earlier peer hot-swap that patched only the plain-JSON assembly did not reduce JIT churn, because DIME's real workload never touched it. `MTConnect.NET-JSON-cppagent.dll` also defines 25 `Streams.Json` classes vs 10 in the plain assembly, so the LCG cost per serialization is proportionally larger. Both assemblies carry independent copies of the anti-pattern (five `new JsonSerializerOptions` sites each in `DefaultOptions`, `IndentOptions`, `Convert`, `ConvertBytes`, `ConvertStream`); both must ship together in this same PR, rather than split into a follow-up, to close the leak for cppagent-format consumers.

## Fix

Both `JsonFunctions.cs` files gain:

```csharp
private static readonly JsonSerializerOptions _defaultOptions = CreateOptions(false);
private static readonly JsonSerializerOptions _indentOptions  = CreateOptions(true);

private static JsonSerializerOptions CreateOptions(bool indented) => new JsonSerializerOptions { ... WriteIndented = indented, ... };

private static JsonSerializerOptions GetOptions(JsonConverter converter, bool indented)
{
    if (converter == null) return indented ? _indentOptions : _defaultOptions;
    var options = CreateOptions(indented);
    options.Converters.Add(converter);
    return options;
}

public static JsonSerializerOptions DefaultOptions => _defaultOptions;
public static JsonSerializerOptions IndentOptions  => _indentOptions;
```

`Convert`/`ConvertBytes`/`ConvertStream` now delegate through `GetOptions(converter, indented)`. Every in-tree caller (verified via grep across `libraries/`, `agent/`, `tests/`) passes `converter == null` and does not mutate the returned instance, so every in-tree call reuses the singleton. The cold-path branch preserves the public API contract for external consumers that supply a per-call converter.

Sibling sweep (same static-readonly pattern, folded in atomically here rather than deferred to a follow-up PR):

- `libraries/MTConnect.NET-Common/Configurations/AgentConfiguration.cs` — `_readOptions` (`ReadCommentHandling = Skip`), 2 call sites.
- `libraries/MTConnect.NET-Common/Configurations/AdapterApplicationConfiguration.cs` — `_readOptions`, 2 call sites.
- `libraries/MTConnect.NET-Common/Agents/MTConnectAgentInformation.cs` — `_saveOptions` (`WriteIndented = true`), 1 call site.
- `libraries/MTConnect.NET-Common/Clients/MTConnectClientInformation.cs` — `_saveOptions`, 1 call site.
- `libraries/MTConnect.NET-Common/Buffers/MTConnectAssetFileBuffer.cs` — `_writeOptions`, 1 call site.
- `libraries/MTConnect.NET-MQTT/MTConnectMqttMessage.cs` — `_agentInformationOptions`, 1 call site.

`libraries/MTConnect.NET-Common/Buffers/MTConnectObservationFileBuffer.cs` was in the peer's sweep list but already calls `JsonSerializer.Serialize` with no options argument — no anti-pattern present.

## Regression tests

`tests/MTConnect.NET-JSON-Tests/Regressions/JsonSerializerOptionsSingletonTests.cs` and its cppagent mirror pin the singleton contract:

- `DefaultOptions_returns_the_same_instance_on_repeat_access` — `ReferenceEquals(JsonFunctions.DefaultOptions, JsonFunctions.DefaultOptions) == true`.
- `IndentOptions_returns_the_same_instance_on_repeat_access` — same for the indented preset.
- `DefaultOptions_and_IndentOptions_are_distinct_instances`.
- `DefaultOptions_WriteIndented_is_false` and `IndentOptions_WriteIndented_is_true` — behavior guards.
- `JsonFunctions_holds_a_static_readonly_options_field` — reflection guard that the shared field exists (blocks the anti-pattern regressing under any future refactor).

Verified RED on `upstream/master` (587a1265): 3 fails + 3 passes per project (6 fails total across both suites). Verified GREEN after fix: 6 pass + 6 pass. Full-suite GREEN on bluefin/net8.0:

| Project | Pass / Total |
| --- | --- |
| `MTConnect.NET-JSON-Tests` | 69 / 69 |
| `MTConnect.NET-JSON-cppagent-Tests` | 369 / 369 |
| `MTConnect.NET-Common-Tests` | 3987 / 3987 |

Total 4425 tests, zero failures.

## Depends on

None. Standalone fix branched off `upstream/master`.

## Efficacy validation

JIT / emit churn eliminated in production; end-to-end RSS-floor confirmation received 2026-08-21 from the same peer that filed the original diagnosis (tempco-investigation-server session, ≥ 22 h post-deploy on tim-001, matched-window controlled comparison against unpatched tempco-001). IL bytes / method transitioned from 22 (emitted accessor stubs) to 108 (ordinary real methods); working set 292–300 MB stable.

Same-host matched-process-age comparison on tim-001 (both DLLs patched, deployed 2026-08-20T23:05:21Z):

| Metric | Pre-fix (cppagent unpatched) | Post-fix (both patched) |
| --- | --- | --- |
| Methods/s at ~3 min uptime | 198.2 | 14.2 |
| Methods/s at ~6–10 min | 160–205 (at 17–21 min) | 0.6–1.3 |
| Total jitted at 3 min | 56,254 | 27,815 |
| Total jitted at 10–20 min | 231,709 at 20 min | 28,669 at 10 min (plateaued) |
| Post-fix delta over 5 min | — | +192 methods (28,477 → 28,669) |

~225× reduction; curve is FLAT, not merely lower.

Supporting signals:

- IL bytes / method: 22 (emitted accessor stubs) → 108 (ordinary real methods) — remaining churn is tiered-compilation warm-up, not emit churn.
- `dotnet-trace` LCG DynamicMethod count over a 20 s window: 5 862 → 1 276 (post-fix sample still warming when captured; has since flatlined).
- GC heap unchanged in character (26–28 MB); working set 292–300 MB stable across the window.

### Assembly hygiene

Rebuilt cppagent DLL reports `.ver 7:0:0:0` identical to the shipped assembly; informational version unchanged; no strong-name change. `comm` on the `.assembly extern` sets between pre-fix and post-fix returns empty — no new external references introduced on either assembly. Drop-in binary-compatible.

### End-to-end RSS-floor confirmation (2026-08-21)

Controlled comparison, both hosts, identical wall-clock window (08:00–17:00 CDT, 13:00–22:00Z Chicago manufacturing shift), trough-based least squares on 15-min post-GC minima:

|                                   | tim-001 (patched)          | tempco-001 (control, unpatched)  |
| --------------------------------- | -------------------------- | -------------------------------- |
| Working-day window (13–22Z)       | +0.96 ± 0.52 MB/h          | +4.47 ± 0.47 MB/h                |
| Last 6 h                          | +2.44 ± 0.29 MB/h          | +4.21 ± 0.82 MB/h                |
| Full run                          | +1.14 ± 0.13 MB/h (22.5 h) | +3.19 ± 0.05 MB/h (95 h)         |

Working-day confidence intervals do not overlap. The control host resumed climbing when the shift started; the patched host did not.

Same-host before/after on tim-001 (cleanest measure — same machine, same config, same workload conditions):

| Window                         | RSS-floor growth  |
| ------------------------------ | ----------------- |
| PRE-FIX (34 h, cppagent unpatched)   | +3.5 ± 0.4 MB/h  |
| POST-FIX (22.5 h, both patched)      | +1.14 ± 0.13 MB/h |

**67 % reduction in RSS-floor growth.** Container-limit cap projection moves from ~22 days to ~61 days (against the 2 GB container ceiling).

JIT side-by-side, workload-independent, taken minutes apart:

| Metric                       | tim-001 patched (11.4 h up) | tempco-001 control (84 h up) |
| ---------------------------- | --------------------------- | ---------------------------- |
| Methods jitted (total)       | 31 523                      | 20 458 426                   |
| Rate                         | 0.3 /s                      | 30.4 /s                      |
| IL bytes jitted              | 0.06 MB/h                   | 1.43 MB/h                    |
| GC heap                      | 39 MB                       | 124 MB                       |
| Working set                  | 330 MB                      | 597 MB                       |

**649× difference in total methods compiled.** The patched host's total is essentially just its own startup JIT and has been flat for a day; the control added ~2.8 M methods in the 24 h between measurements.

**Residual grower caveat.** tim-001's last-6h window reads +2.44 ± 0.29 MB/h — above its own 22-hour average, and JIT cannot account for it (0.3 methods/s = 0.06 MB/h). The residual is entirely anonymous memory (`+1.10 MB/h anon` out of `+1.11 MB/h rss`, decomposed against `/proc/self/status` + smaps; file/shmem/threads/fds/sockets all flat over the 22.5 h window). With the managed GC heap at 39 MB and methods-jitted at 0.3/s, loader/code heap is not growing either — so the residual mechanism is distinct from the reflection-emit class this PR closes. Every sibling `JsonSerializerOptions` construction site on `MTConnect.NET-Common` was independently verified as already using the `static readonly` singleton pattern (either landed by this PR or pre-existing), consistent with the peer's finding. The residual is most likely native-side (glibc arena fragmentation, native allocator growth, or a native-side buffer) and is being characterised in a separate investigation. This PR eliminates the dominant reflection-emit leak (67 % reduction in RSS-floor growth, 649× reduction in cumulative JIT); the residual is out of scope + tracked separately.

Measurement discipline: `RestartCount=0` throughout, no `memory.events` max/oom on either host, no container hit its limit, and tim-001 published normally the whole time (30 mtconnectMqttSink writes/60 s).


## Dime review cycles

### Cycle 1 — baseline pass on `b2703730`

- **`code-review`**: `[BLOCKER]` H1 — the per-call `new JsonSerializerOptions` on every `Convert` / `ConvertBytes` / `ConvertStream` invocation re-emits LCG DynamicMethod property accessors on every serialization, matching the peer's tempco-001 / tim-001 heap-outside-GC diagnosis (+3.2–3.8 MB/h RSS climb). Fix: cache the options as `static readonly` singletons. → **Fixed** @ `f1565222` (the initial cache-singletons commit).
- **`code-review`**: `[FINDING]` M1 — the shared singleton must be frozen (`MakeReadOnly` on net8+) so a caller's stray `Converters.Add` fails fast rather than silently polluting the process-wide instance. → **Fixed** @ `adfed47d`.
- **`security-audit`**: NO FINDINGS.
- **`simplification`**: NO FINDINGS.
- **`improvement`**: NO FINDINGS.
- **`documentation-audit`**: NO FINDINGS.
- **`test-coverage-audit`**: `[TEST]` FLOOR gap — thread-safety, cold-path converter path, and Convert overload parity lacked regression pins. → **Fixed** @ `b2703730` (coverage-FLOOR pin batch, TDD RED-first before the H1 fix).

### Cycle 2 — verify freeze + warm

- **`code-review` / `security-audit` / `simplification` / `improvement`**: NO FINDINGS.
- **`documentation-audit`**: `[DOCS]` L1 — the new `CreateOptions` / `GetOptions` helpers lacked XML `///` blocks explaining the hot-path / cold-path invariant. → **Fixed** @ `c212f6fc`.
- **`test-coverage-audit`**: NO FINDINGS.

### Cycle 3 — verify L1 docs

- **`code-review` / `security-audit` / `simplification` / `improvement` / `documentation-audit`**: NO FINDINGS.
- **`test-coverage-audit`**: NO FINDINGS.
- **`documentation-audit`**: `[DOCS]` L2 — AmE spelling drift in the freshly-added doc comments (`serialise`, `initialise`, `synchronise`). → **Fixed** @ `38cbeb07`.

### Cycle 4 — deeper warm-up + AmE re-sweep

- **`improvement`**: `[IMPROVE]` M1-C3 — the initial warm-up used `Serialize<object>(null, options)`, which only bootstrapped STJ's shared reflection resolver but never named a concrete MTConnect type; the cold LCG emit for the four top-level response envelopes still fell on the first user-facing request. → **Fixed** @ `432be963` (warm-up traverses MTConnect response graph via typed `Serialize` calls on `JsonStreamsDocument` / `JsonAssetsDocument(null)` / `JsonDevicesDocument`).
- **`documentation-audit`**: `[DOCS]` M2-C3 — repo-wide grep surfaced additional AmE-token drift (`amortise`, `synchronise`, `flavour`). → **Fixed** @ `e55badca`.
- **`test-coverage-audit`**: `[TEST]` FLOOR gap — no regression pin for the warm-up-before-`MakeReadOnly` static-ctor ordering invariant (a reorder would surface as `NotSupportedException` on the first real serialize). → **Fixed** @ `86b60a66`.
- **Cycle-4 leftovers surfaced by verification pass**: `[IMPROVE]` F-IMP-001 MEDIUM (`WarmReachableGraph` omits `ErrorResponseDocument`) + LOW (`DefaultOptions` / `IndentOptions` `<remarks>` state the invariant but not the WHY / LCG loader-heap link) — deferred to cycle 5.

### Cycle 5 — cycle-4 leftovers + Error warm-up correctness

- **`code-review` / `security-audit` / `documentation-audit`**: NO FINDINGS.
- **`improvement`**: `[IMPROVE]` F-IMP-001 M-C4 (Error warm-up missing) → **Fixed** @ `014347b7`; `[IMPROVE]` L-C4 (WHY-LCG remarks) → **Fixed** @ `014347b7`.
- **`improvement`**: `[IMPROVE]` F-IMP-C5-001 MEDIUM — cycle-5 Error warm-up populated only `new ErrorResponseDocument()` (null Header / Errors / Version), leaving the concrete `MTConnectErrorHeader` (9 accessors), `Error` (2), and `System.Version` (6) cold on the first real error response. → **Fixed** @ `6b081eac` (populates `Header = new MTConnectErrorHeader()`, `Errors = new[] { new Error() }`, `Version = new Version(2, 5)` so STJ walks the runtime types the production /probe-error and parse-failure paths actually serialize).
- **`improvement`**: `[IMPROVE]` F-IMP-C5-002 LOW — `WarmReachableGraph` depends on the null-tolerance of the `JsonAssetsDocument(IAssetsResponseDocument)` ctor; a future null-guard would turn first assembly load into `TypeInitializationException`. → **Fixed** @ `6b081eac` (adds an `<remarks>` block on the ctor documenting the null-tolerance contract, the dependent warm-up site, and the requirement to update both atomically in the same commit before changing the ctor contract).
- **`simplification`**: `[SIMPLIFY]` F-SIMP-001 LOW — the first `<remarks>` paragraph on `IndentOptions` is byte-identical to the paragraph on `DefaultOptions` in both files. → **Closed with rationale**: IntelliSense hover shows only the current member's remarks and does not chase `<see cref/>`; a consumer inspecting `IndentOptions` in isolation must see the invariant text self-contained, not as a pointer. Self-contained per-member docs are the maintainer preference.
- **`test-coverage-audit`**: `[TEST]` MEDIUM — cycle-5's initial `Frozen_singleton_can_serialize_ErrorResponseDocument_proving_Error_warm_up_ran` pin was tautological (mutation-verified: removing the warm-up line left the pin green; STJ's `DefaultJsonTypeInfoResolver` lazily populates `JsonTypeInfo` on frozen options for arbitrary types once `TypeInfoResolver` is set). → **Fixed** @ `5a196588` (replaced with an IL-inspection walker `WarmReachableGraph_IL_contains_newobj_for_ErrorResponseDocument_ctor` + companion IL pins for the three `Json*` top-level surrogates per fixture). `[TEST]` LOW — the five sibling per-call → static-readonly refactors (`AgentConfiguration`, `AdapterApplicationConfiguration`, `MTConnectAgentInformation`, `MTConnectClientInformation`, `MTConnectAssetFileBuffer`, `MTConnectMqttMessage`) had no test-time guard. → **Fixed** @ `5a196588` (`JsonSerializerOptionsSiblingSingletonTests` + `MTConnectMqttMessageSingletonTests` structural pins, sibling-mutation-verified).

### Cycle 6 — verify cycle-5 fixes + walker match against populated shape

- **`security-audit` / `simplification` / `improvement` / `documentation-audit`**: NO FINDINGS.
- **`code-review`**: `[FINDING]` F-CR-C6-001 LOW — the populated Error warm-up hard-codes `new Version(2, 5)` where the repo already exposes `MTConnectVersions.Version25`; reads scan-and-recognize vs. wonder why "2.5" appears amid a 2.7-max library. → **Fixed** @ `ec86e338` (swap to the canonical constant; unused `using System;` removed from cppagent `JsonFunctions.cs`).
- **`test-coverage-audit`**: `[TEST]` F-COV-C6-001 MEDIUM — cycle-5's IL walker only pinned the `newobj` for `ErrorResponseDocument`; a revert to `new ErrorResponseDocument()` (naked) would silently pass the pin while re-opening the exact LCG-emit-on-first-error class F-IMP-C5-001 closed. → **Fixed** @ `e19674ec` (adds `WarmReachableGraph_IL_contains_newobj_for_concrete_Error_envelope_fields` pin per fixture, asserting `newobj` producers for `MTConnectErrorHeader` + `Errors.Error` + `System.Version`; mutation-verified on bluefin).

### Cycle 6 — chase-fix for F-CR-C6-001 side-effect

- **All six agents**: NO cycle-7-eligible findings, one same-cycle fix landed:
  - `[TEST]` chase-fix @ `31668585` — the F-CR-C6-001 swap to `MTConnectVersions.Version25` eliminated the `newobj System.Version` in `WarmReachableGraph` (an `ldsfld` now loads the canonical constant), which would have false-positived the cycle-6 walker on `System.Version`. Widened the IL walker helper `AssertWarmReachableGraphNewsUp` in both fixtures to accept EITHER `newobj T::.ctor` OR `ldsfld <static-field-of-type-T>` — both producers are semantically equivalent for warm-up because STJ walks the runtime type of the value fed into `Serialize` regardless of source. `<summary>` blocks updated in both fixtures to name the widened contract and cross-reference F-CR-C6-001. Mutation-verified: deleting `Version = MTConnectVersions.Version25` fires the pin with the exact `System.Version` failure message; restoring returns to green.

### Cycle 7 — full-diff re-sweep at HEAD `31668585`

- **`code-review`**: NO FINDINGS. Verified: no circular init risk from `JsonFunctions.cctor` referencing `MTConnectVersions.Version25` (leaf static class, no MTConnect deps); widened walker's `ldsfld` branch endianness sound on every .NET-supported target; sibling singleton adopters follow the pattern with cross-referencing comments back to `JsonFunctions.cs`.
- **`security-audit`**: NO FINDINGS. Verified: `Module.ResolveField(token)` operates on the test project's own compiled assembly (no untrusted metadata); no secret exposure in walker error strings; no dependency-manifest change.
- **`simplification`**: NO FINDINGS. Verified: comment blocks on both `WarmReachableGraph` methods (~28 lines each) trace to distinct closed-finding rationales; the dual-opcode walker branch is clearer as-is than split into two helpers.
- **`improvement`**: NO FINDINGS. Verified: `MTConnectVersions.Version25` field-initializer chain has no cycle; widened walker adds zero production-side overhead; `using System;` correctly retained in plain-JSON (needed for `DateTime` / `TimeSpan` in `GetTimestamp`), correctly removed from cppagent (no unqualified `System.*` reference remains).
- **`documentation-audit`**: NO FINDINGS. Verified: no docs page references the removed magic `new Version(2, 5)` literal; both updated `<summary>` blocks accurately name the widened walker contract and cross-reference F-CR-C6-001; no AmE-token drift in the cycle-6/7 prose.
- **`test-coverage-audit`**: NO FINDINGS. Verified: mutation-tests confirm the widened walker catches every intended regression class (RED on delete of the Version producer, GREEN on restore); nested-field-of-same-type analysis returns no false-positive class.

_(Zero unfixed findings — Ready-eligible.)_

**Test results at HEAD `31668585`** (bluefin 2026-08-21, `dotnet test` per project):

| Project | Pass / Total |
| --- | --- |
| `MTConnect.NET-JSON-Tests` | 82 / 82 |
| `MTConnect.NET-JSON-cppagent-Tests` | 382 / 382 |
| `MTConnect.NET-Common-Tests` | 4085 / 4085 |
| `MTConnect.NET-AgentModule-MqttRelay-Tests` | 63 / 63 |

Total 4612 tests, zero failures. Net +11 pins over cycle 1 (Error warm-up IL walker + concrete-field pin + sibling singleton pins + MQTT singleton pin + widened walker `<summary>` updates). All 14 commits `upstream/master..HEAD` signed (`%G? = G`).

